### PR TITLE
Added template inheritance example

### DIFF
--- a/examples/inheritance.rs
+++ b/examples/inheritance.rs
@@ -1,0 +1,43 @@
+use minijinja::Environment;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct Page {
+    title: String,
+    content: String,
+}
+
+#[derive(Serialize)]
+pub struct Context {
+    page: Page,
+}
+
+fn main() {
+    let mut env = Environment::new();
+    env.add_template(
+        "base.html",
+        r#"<html>
+    <head><title>{% block title %}some website{% endblock %}</title></head>
+    <body>{% block body %}{% endblock %}</body></html>"#,
+    )
+    .unwrap();
+    env.add_template(
+        "index.html",
+        r#"{% extends "base.html" %}
+{% block title %}{{ page.title | upper }} | {{ super() }}{% endblock %}
+{% block body %}{{ page.content }}{% endblock %}"#,
+    )
+    .unwrap();
+    let template = env.get_template("index.html").unwrap();
+    println!(
+        "{}",
+        template
+            .render(&Context {
+                page: Page {
+                    title: "Some title".into(),
+                    content: "Lorum Ipsum".into(),
+                },
+            })
+            .unwrap()
+    );
+}


### PR DESCRIPTION
(Thank you very much ! It’s a nice project, the code is short but it already has many features)

I am not sure what the direction for the project is exactly (how much of Jinja2 will be implemented here? All the filters, or a subset ? etc.). It was not crystal clear right away what the feature set was at this point. The example directory feels a bit empty, so I did not suspect so many things were tackled already − it’s only when I browsed the tests that I found… well, the work already done.

Anyway, I’m just adding an extra example with **template inheritance** (one of the killer features IMO of jinja) in order for others to jump right away. It has not much rust code compared to `hello.rs`, the difference is mostly in the Jinja example, so maybe a better direction would be a long example with all the supported Jinja features ?