### PR TITLE
Bump to newer self_cell

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,4 +29,4 @@ jobs:
           profile: minimal
           override: true
       - name: Test
-        run: make test-142
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 DOC_FEATURES=source
 TEST_FEATURES=unstable_machinery,builtin_tests,builtin_filters,builtin_functions,source,json,urlencode
-TEST_142_FEATURES=unstable_machinery,builtin_tests,builtin_filters,builtin_functions,json,urlencode
 
 all: test
 
@@ -14,9 +13,6 @@ test:
 	@$(MAKE) run-tests FEATURES=$(TEST_FEATURES)
 	@echo "CARGO TEST ALL FEATURES"
 	@cd minijinja; cargo test --all-features
-
-test-142:
-	@$(MAKE) run-tests FEATURES=$(TEST_142_FEATURES)
 
 run-tests:
 	@rustup component add rustfmt 2> /dev/null

--- a/examples/inheritance/src/main.rs
+++ b/examples/inheritance/src/main.rs
@@ -1,4 +1,4 @@
-use minijinja::{Environment, context};
+use minijinja::{context, Environment};
 use serde::Serialize;
 
 #[derive(Serialize)]

--- a/minijinja/Cargo.toml
+++ b/minijinja/Cargo.toml
@@ -32,7 +32,7 @@ unstable_machinery = []
 serde = "1.0.130"
 memchr = { version = "2.4.1", optional = true }
 v_htmlescape = { version = "0.14.1", optional = true }
-self_cell = { version = "0.10.0", optional = true }
+self_cell = { version = "0.10.1", optional = true, features = ["old_rust"] }
 serde_json = { version = "1.0.68", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
 


### PR DESCRIPTION
This restores support for older rust versions when `source` is used. Refs https://github.com/Voultapher/self_cell/issues/30