### PR TITLE
Make get_item_opt accept &str keys

### DIFF
--- a/minijinja/src/value.rs
+++ b/minijinja/src/value.rs
@@ -1031,6 +1031,8 @@ impl Value {
                 Shared::Dynamic(ref dy) => {
                     if let Key::String(ref key) = key {
                         return dy.get_attr(key);
+                    } else if let Key::Str(key) = key {
+                        return dy.get_attr(key);
                     }
                 }
                 _ => {}


### PR DESCRIPTION
I was running into an issue (possibly because of #28?) where an access into an `Object` like this:
```{{ x['key'] }}```
would return an empty string (because it couldn't look up the key). The reason was, that my key was appereantly parsed as a Key::Str instead of a Key::String.