### PR TITLE
Simplier value implementation without unsafe

### DIFF
--- a/minijinja/src/instructions.rs
+++ b/minijinja/src/instructions.rs
@@ -344,5 +344,5 @@ impl<'source> fmt::Debug for Instructions<'source> {
 #[test]
 #[cfg(target_pointer_width = "64")]
 fn test_sizes() {
-    assert_eq!(std::mem::size_of::<Instruction>(), 24);
+    assert_eq!(std::mem::size_of::<Instruction>(), 32);
 }

--- a/minijinja/src/key.rs
+++ b/minijinja/src/key.rs
@@ -89,28 +89,7 @@ impl TryFrom<Value> for Key<'static> {
     type Error = Error;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        match value
-            .as_primitive()
-            .ok_or_else(|| Error::from(ErrorKind::NonKey))?
-        {
-            Primitive::Bool(v) => Ok(Key::Bool(v)),
-            Primitive::U64(v) => TryFrom::try_from(v)
-                .map(Key::I64)
-                .map_err(|_| ErrorKind::NonKey.into()),
-            Primitive::U128(v) => TryFrom::try_from(v)
-                .map(Key::I64)
-                .map_err(|_| ErrorKind::NonKey.into()),
-            Primitive::I64(v) => Ok(Key::I64(v)),
-            Primitive::I128(v) => TryFrom::try_from(v)
-                .map(Key::I64)
-                .map_err(|_| ErrorKind::NonKey.into()),
-            Primitive::F64(_) => Err(ErrorKind::NonKey.into()),
-            Primitive::Char(c) => Ok(Key::Char(c)),
-            Primitive::Str(s) => Ok(Key::String(RcType::new(s.to_string()))),
-            Primitive::Bytes(_) | Primitive::None | Primitive::Undefined => {
-                Err(ErrorKind::NonKey.into())
-            }
-        }
+        value.try_into_key()
     }
 }
 

--- a/minijinja/src/value.rs
+++ b/minijinja/src/value.rs
@@ -202,7 +202,15 @@ enum Repr {
     F64(f64),
     Char(char),
     None,
-    Shared(RcType<Shared>),
+    U128(RcType<u128>),
+    I128(RcType<i128>),
+    String(RcType<String>),
+    SafeString(RcType<String>),
+    Bytes(RcType<Vec<u8>>),
+    Seq(RcType<Vec<Value>>),
+    Map(RcType<BTreeMap<Key<'static>, Value>>),
+    Struct(RcType<BTreeMap<&'static str, Value>>),
+    Dynamic(RcType<dyn Object>),
 }
 
 impl fmt::Debug for Repr {
@@ -215,49 +223,21 @@ impl fmt::Debug for Repr {
             Repr::F64(val) => fmt::Debug::fmt(val, f),
             Repr::Char(val) => fmt::Debug::fmt(val, f),
             Repr::None => write!(f, "None"),
-            Repr::Shared(val) => fmt::Debug::fmt(val, f),
-        }
-    }
-}
-
-#[derive(Clone)]
-enum Shared {
-    U128(u128),
-    I128(i128),
-    String(String),
-    SafeString(String),
-    Bytes(Vec<u8>),
-    Seq(Vec<Value>),
-    Map(BTreeMap<Key<'static>, Value>),
-    Struct(BTreeMap<&'static str, Value>),
-    // this annoyingly has basically two refcounts.  One we inherit from
-    // shared, the second we have to use because the outside user of this
-    // dynamic type also wants to hold on to it without having to inspect
-    // into a value object.  It would be nice to be able to store this
-    // adjacent to `Shared` but unfortunately a `dyn Trait` needs two
-    // pointers and that increases the size of the value type for all
-    // uses.
-    Dynamic(RcType<dyn Object>),
-}
-
-impl fmt::Debug for Shared {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Shared::U128(val) => fmt::Debug::fmt(val, f),
-            Shared::I128(val) => fmt::Debug::fmt(val, f),
-            Shared::String(val) => fmt::Debug::fmt(val, f),
-            Shared::SafeString(val) => fmt::Debug::fmt(val, f),
-            Shared::Bytes(val) => fmt::Debug::fmt(val, f),
-            Shared::Seq(val) => fmt::Debug::fmt(val, f),
-            Shared::Map(val) => fmt::Debug::fmt(val, f),
-            Shared::Struct(val) => {
+            Repr::U128(val) => fmt::Debug::fmt(val, f),
+            Repr::I128(val) => fmt::Debug::fmt(val, f),
+            Repr::String(val) => fmt::Debug::fmt(val, f),
+            Repr::SafeString(val) => fmt::Debug::fmt(val, f),
+            Repr::Bytes(val) => fmt::Debug::fmt(val, f),
+            Repr::Seq(val) => fmt::Debug::fmt(val, f),
+            Repr::Map(val) => fmt::Debug::fmt(val, f),
+            Repr::Struct(val) => {
                 let mut s = f.debug_struct("Struct");
                 for (k, v) in val.iter() {
                     s.field(k, v);
                 }
                 s.finish()
             }
-            Shared::Dynamic(val) => fmt::Debug::fmt(val, f),
+            Repr::Dynamic(val) => fmt::Debug::fmt(val, f),
         }
     }
 }
@@ -313,31 +293,24 @@ impl From<Repr> for Value {
     }
 }
 
-impl From<Shared> for Value {
-    #[inline(always)]
-    fn from(val: Shared) -> Value {
-        Value(Repr::Shared(RcType::new(val)))
-    }
-}
-
 impl<'a> From<&'a [u8]> for Value {
     #[inline(always)]
     fn from(val: &'a [u8]) -> Self {
-        Shared::Bytes(val.into()).into()
+        Repr::Bytes(RcType::new(val.into())).into()
     }
 }
 
 impl<'a> From<&'a str> for Value {
     #[inline(always)]
     fn from(val: &'a str) -> Self {
-        Shared::String(val.into()).into()
+        Repr::String(RcType::new(val.into())).into()
     }
 }
 
 impl From<String> for Value {
     #[inline(always)]
     fn from(val: String) -> Self {
-        Shared::String(val).into()
+        Repr::String(RcType::new(val)).into()
     }
 }
 
@@ -361,14 +334,14 @@ impl From<()> for Value {
 impl From<i128> for Value {
     #[inline(always)]
     fn from(val: i128) -> Self {
-        Shared::I128(val).into()
+        Repr::I128(RcType::new(val)).into()
     }
 }
 
 impl From<u128> for Value {
     #[inline(always)]
     fn from(val: u128) -> Self {
-        Shared::U128(val).into()
+        Repr::U128(RcType::new(val)).into()
     }
 }
 
@@ -386,13 +359,16 @@ impl<'a> From<Key<'a>> for Value {
 
 impl<K: Into<Key<'static>>, V: Into<Value>> From<BTreeMap<K, V>> for Value {
     fn from(val: BTreeMap<K, V>) -> Self {
-        Shared::Map(val.into_iter().map(|(k, v)| (k.into(), v.into())).collect()).into()
+        Repr::Map(RcType::new(
+            val.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
+        ))
+        .into()
     }
 }
 
 impl<T: Into<Value>> From<Vec<T>> for Value {
     fn from(val: Vec<T>) -> Self {
-        Shared::Seq(val.into_iter().map(|x| x.into()).collect()).into()
+        Repr::Seq(RcType::new(val.into_iter().map(|x| x.into()).collect())).into()
     }
 }
 
@@ -502,30 +478,6 @@ fn coerce<'a>(a: Primitive<'a>, b: Primitive<'a>) -> Option<CoerceResult> {
     }
 }
 
-impl fmt::Display for Shared {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Shared::I128(val) => write!(f, "{}", val),
-            Shared::String(val) => write!(f, "{}", val),
-            Shared::SafeString(val) => write!(f, "{}", val),
-            Shared::Bytes(val) => write!(f, "{}", String::from_utf8_lossy(val)),
-            Shared::Seq(values) => format_seqish(f, values.iter()),
-            Shared::Map(val) => format_seqish(f, val.iter().map(|x| x.0)),
-            Shared::Struct(val) => {
-                for (idx, (key, _)) in val.iter().enumerate() {
-                    if idx > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{}", key)?;
-                }
-                Ok(())
-            }
-            Shared::U128(val) => write!(f, "{}", val),
-            Shared::Dynamic(x) => write!(f, "{}", x),
-        }
-    }
-}
-
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
@@ -536,7 +488,23 @@ impl fmt::Display for Value {
             Repr::F64(val) => write!(f, "{}", val),
             Repr::Char(val) => write!(f, "{}", val),
             Repr::None => write!(f, "none"),
-            Repr::Shared(cplx) => write!(f, "{}", cplx),
+            Repr::I128(val) => write!(f, "{}", val),
+            Repr::String(val) => write!(f, "{}", val),
+            Repr::SafeString(val) => write!(f, "{}", val),
+            Repr::Bytes(val) => write!(f, "{}", String::from_utf8_lossy(val)),
+            Repr::Seq(values) => format_seqish(f, values.iter()),
+            Repr::Map(val) => format_seqish(f, val.iter().map(|x| x.0)),
+            Repr::Struct(val) => {
+                for (idx, (key, _)) in val.iter().enumerate() {
+                    if idx > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", key)?;
+                }
+                Ok(())
+            }
+            Repr::U128(val) => write!(f, "{}", val),
+            Repr::Dynamic(x) => write!(f, "{}", x),
         }
     }
 }
@@ -615,18 +583,13 @@ pub(crate) fn neg(val: &Value) -> Result<Value, Error> {
 }
 
 /// Attempts a string concatenation.
-pub(crate) fn string_concat(left: Value, right: &Value) -> Value {
+pub(crate) fn string_concat(mut left: Value, right: &Value) -> Value {
     match left.0 {
         // if we're a string and we have a single reference to it, we can
         // directly append into ourselves and reconstruct the value
-        Repr::Shared(mut cplx) if matches!(*cplx, Shared::String(_)) => {
-            let shared = RcType::make_mut(&mut cplx);
-            if let Shared::String(s) = shared {
-                write!(s, "{}", right).ok();
-                Value(Repr::Shared(cplx))
-            } else {
-                unreachable!();
-            }
+        Repr::String(ref mut s) => {
+            write!(RcType::make_mut(s), "{}", right).ok();
+            left
         }
         // otherwise we use format! to concat the two values
         _ => Value::from(format!("{}{}", left, right)),
@@ -635,30 +598,27 @@ pub(crate) fn string_concat(left: Value, right: &Value) -> Value {
 
 /// Implements a containment operation on values.
 pub(crate) fn contains(container: &Value, value: &Value) -> Result<Value, Error> {
-    if let Value(Repr::Shared(ref cplx)) = container {
-        match **cplx {
-            Shared::Seq(ref values) => return Ok(Value::from(values.contains(value))),
-            Shared::Map(ref map) => {
-                let key = match Key::try_from(value.clone()) {
-                    Ok(key) => key,
-                    Err(_) => return Ok(Value::from(false)),
-                };
-                return Ok(Value::from(map.get(&key).is_some()));
-            }
-            Shared::String(ref s) | Shared::SafeString(ref s) => {
-                return Ok(Value::from(if let Some(s2) = value.as_str() {
-                    s.contains(&s2)
-                } else {
-                    s.contains(&value.to_string())
-                }));
-            }
-            _ => {}
+    match container.0 {
+        Repr::Seq(ref values) => Ok(Value::from(values.contains(value))),
+        Repr::Map(ref map) => {
+            let key = match Key::try_from(value.clone()) {
+                Ok(key) => key,
+                Err(_) => return Ok(Value::from(false)),
+            };
+            return Ok(Value::from(map.get(&key).is_some()));
         }
+        Repr::String(ref s) | Repr::SafeString(ref s) => {
+            return Ok(Value::from(if let Some(s2) = value.as_str() {
+                s.contains(&s2)
+            } else {
+                s.contains(&value.to_string())
+            }));
+        }
+        _ => Err(Error::new(
+            ErrorKind::ImpossibleOperation,
+            "cannot perform a containment check on this value",
+        )),
     }
-    Err(Error::new(
-        ErrorKind::ImpossibleOperation,
-        "cannot perform a containment check on this value",
-    ))
 }
 
 macro_rules! primitive_try_from {
@@ -815,12 +775,12 @@ impl Value {
 
     /// Creates a value from a safe string.
     pub fn from_safe_string(value: String) -> Value {
-        Repr::Shared(RcType::new(Shared::SafeString(value))).into()
+        Repr::SafeString(RcType::new(value)).into()
     }
 
     /// Creates a value from a reference counted dynamic object.
     pub(crate) fn from_rc_object<T: Object + 'static>(value: RcType<T>) -> Value {
-        Repr::Shared(RcType::new(Shared::Dynamic(value as RcType<dyn Object>))).into()
+        Repr::Dynamic(value as RcType<dyn Object>).into()
     }
 
     /// Creates a value from a dynamic object.
@@ -856,20 +816,18 @@ impl Value {
     /// assert_eq!(thing.id, 42);
     /// ```
     pub fn downcast_object_ref<T: Object>(&self) -> Option<&T> {
-        if let Repr::Shared(ref cplx) = self.0 {
-            if let Shared::Dynamic(ref obj) = **cplx {
-                if (**obj).type_id() == TypeId::of::<T>() {
-                    unsafe {
-                        // newer versions of Furst have RcType::as_ptr but we support
-                        // rust versions down to 1.41.0 so we need to use a workaround here.
-                        let count = RcType::strong_count(obj);
-                        let clone = obj.clone();
-                        let raw: *const (dyn Object) = RcType::into_raw(clone);
-                        let rv = (raw as *const u8 as *const T).as_ref();
-                        RcType::from_raw(raw);
-                        debug_assert_eq!(count, RcType::strong_count(obj));
-                        return rv;
-                    }
+        if let Repr::Dynamic(ref obj) = self.0 {
+            if (**obj).type_id() == TypeId::of::<T>() {
+                unsafe {
+                    // newer versions of Furst have RcType::as_ptr but we support
+                    // rust versions down to 1.41.0 so we need to use a workaround here.
+                    let count = RcType::strong_count(obj);
+                    let clone = obj.clone();
+                    let raw: *const (dyn Object) = RcType::into_raw(clone);
+                    let rv = (raw as *const u8 as *const T).as_ref();
+                    RcType::from_raw(raw);
+                    debug_assert_eq!(count, RcType::strong_count(obj));
+                    return rv;
                 }
             }
         }
@@ -884,15 +842,13 @@ impl Value {
             Repr::U64(_) | Repr::I64(_) | Repr::F64(_) => ValueKind::Number,
             Repr::Char(_) => ValueKind::Char,
             Repr::None => ValueKind::None,
-            Repr::Shared(ref cplx) => match **cplx {
-                Shared::I128(_) => ValueKind::Number,
-                Shared::String(_) | Shared::SafeString(_) => ValueKind::String,
-                Shared::Bytes(_) => ValueKind::Bytes,
-                Shared::U128(_) => ValueKind::Number,
-                Shared::Seq(_) => ValueKind::Seq,
-                Shared::Map(_) => ValueKind::Map,
-                Shared::Struct(_) | Shared::Dynamic(_) => ValueKind::Struct,
-            },
+            Repr::I128(_) => ValueKind::Number,
+            Repr::String(_) | Repr::SafeString(_) => ValueKind::String,
+            Repr::Bytes(_) => ValueKind::Bytes,
+            Repr::U128(_) => ValueKind::Number,
+            Repr::Seq(_) => ValueKind::Seq,
+            Repr::Map(_) => ValueKind::Map,
+            Repr::Struct(_) | Repr::Dynamic(_) => ValueKind::Struct,
         }
     }
 
@@ -906,14 +862,12 @@ impl Value {
             Repr::F64(val) => Some(Primitive::F64(val)),
             Repr::Char(val) => Some(Primitive::Char(val)),
             Repr::None => Some(Primitive::None),
-            Repr::Shared(ref cplx) => match **cplx {
-                Shared::I128(val) => Some(Primitive::I128(val)),
-                Shared::String(ref val) => Some(Primitive::Str(val.as_str())),
-                Shared::SafeString(ref val) => Some(Primitive::Str(val.as_str())),
-                Shared::Bytes(ref val) => Some(Primitive::Bytes(&val[..])),
-                Shared::U128(val) => Some(Primitive::U128(val)),
-                _ => None,
-            },
+            Repr::I128(ref val) => Some(Primitive::I128(**val)),
+            Repr::String(ref val) => Some(Primitive::Str(val.as_str())),
+            Repr::SafeString(ref val) => Some(Primitive::Str(val.as_str())),
+            Repr::Bytes(ref val) => Some(Primitive::Bytes(&val[..])),
+            Repr::U128(ref val) => Some(Primitive::U128(**val)),
+            _ => None,
         }
     }
 
@@ -944,7 +898,7 @@ impl Value {
 
     /// Returns `true` if this value is safe.
     pub fn is_safe(&self) -> bool {
-        matches!(&self.0, Repr::Shared(cplx) if matches!(**cplx, Shared::SafeString(_)))
+        matches!(&self.0, Repr::SafeString(_))
     }
 
     /// Returns `true` if this value is undefined.
@@ -959,32 +913,25 @@ impl Value {
 
     /// Returns the length of the contained value.
     pub fn len(&self) -> Option<usize> {
-        if let Repr::Shared(ref cplx) = self.0 {
-            match **cplx {
-                Shared::String(ref s) | Shared::SafeString(ref s) => Some(s.chars().count()),
-                Shared::Map(ref items) => Some(items.len()),
-                Shared::Struct(ref items) => Some(items.len()),
-                Shared::Seq(ref items) => Some(items.len()),
-                Shared::Dynamic(ref dy) => Some(dy.attributes().len()),
-                _ => None,
-            }
-        } else {
-            None
+        match self.0 {
+            Repr::String(ref s) | Repr::SafeString(ref s) => Some(s.chars().count()),
+            Repr::Map(ref items) => Some(items.len()),
+            Repr::Struct(ref items) => Some(items.len()),
+            Repr::Seq(ref items) => Some(items.len()),
+            Repr::Dynamic(ref dy) => Some(dy.attributes().len()),
+            _ => None,
         }
     }
 
     /// Looks up an attribute by attribute name.
     pub fn get_attr(&self, key: &str) -> Result<Value, Error> {
         let value = match self.0 {
-            Repr::Shared(ref cplx) => match **cplx {
-                Shared::Map(ref items) => {
-                    let lookup_key = Key::Str(key);
-                    items.get(&lookup_key).cloned()
-                }
-                Shared::Struct(ref items) => items.get(key).cloned(),
-                Shared::Dynamic(ref dy) => dy.get_attr(key),
-                _ => None,
-            },
+            Repr::Map(ref items) => {
+                let lookup_key = Key::Str(key);
+                items.get(&lookup_key).cloned()
+            }
+            Repr::Struct(ref items) => items.get(key).cloned(),
+            Repr::Dynamic(ref dy) => dy.get_attr(key),
             Repr::Undefined => {
                 return Err(Error::from(ErrorKind::UndefinedError));
             }
@@ -1009,42 +956,38 @@ impl Value {
     fn get_item_opt(&self, key: &Value) -> Option<Value> {
         let key = Key::from_borrowed_value(key).ok()?;
 
-        if let Repr::Shared(ref cplx) = self.0 {
-            match **cplx {
-                Shared::Map(ref items) => return items.get(&key).cloned(),
-                Shared::Struct(ref items) => {
-                    if let Key::String(ref key) = key {
-                        return items.get(key.as_str()).cloned();
-                    }
+        match self.0 {
+            Repr::Map(ref items) => return items.get(&key).cloned(),
+            Repr::Struct(ref items) => {
+                if let Key::String(ref key) = key {
+                    return items.get(key.as_str()).cloned();
                 }
-                Shared::Seq(ref items) => {
-                    if let Key::I64(idx) = key {
-                        let idx = isize::try_from(idx).ok()?;
-                        let idx = if idx < 0 {
-                            items.len() - (-idx as usize)
-                        } else {
-                            idx as usize
-                        };
-                        return items.get(idx).cloned();
-                    }
-                }
-                Shared::Dynamic(ref dy) => match key {
-                    Key::String(ref key) => return dy.get_attr(key),
-                    Key::Str(ref key) => return dy.get_attr(key),
-                    _ => {}
-                },
-                _ => {}
             }
+            Repr::Seq(ref items) => {
+                if let Key::I64(idx) = key {
+                    let idx = isize::try_from(idx).ok()?;
+                    let idx = if idx < 0 {
+                        items.len() - (-idx as usize)
+                    } else {
+                        idx as usize
+                    };
+                    return items.get(idx).cloned();
+                }
+            }
+            Repr::Dynamic(ref dy) => match key {
+                Key::String(ref key) => return dy.get_attr(key),
+                Key::Str(key) => return dy.get_attr(key),
+                _ => {}
+            },
+            _ => {}
         }
         None
     }
 
     /// Calls the value directly.
     pub(crate) fn call(&self, state: &State, args: Vec<Value>) -> Result<Value, Error> {
-        if let Repr::Shared(ref cplx) = self.0 {
-            if let Shared::Dynamic(ref dy) = **cplx {
-                return dy.call(state, args);
-            }
+        if let Repr::Dynamic(ref dy) = self.0 {
+            return dy.call(state, args);
         }
         Err(Error::new(
             ErrorKind::ImpossibleOperation,
@@ -1059,79 +1002,59 @@ impl Value {
         name: &str,
         args: Vec<Value>,
     ) -> Result<Value, Error> {
-        if let Repr::Shared(ref cplx) = self.0 {
-            if let Shared::Dynamic(ref dy) = **cplx {
-                return dy.call_method(state, name, args);
-            }
+        if let Repr::Dynamic(ref dy) = self.0 {
+            dy.call_method(state, name, args)
+        } else {
+            Err(Error::new(
+                ErrorKind::ImpossibleOperation,
+                format!("object has no method named {}", name),
+            ))
         }
-        Err(Error::new(
-            ErrorKind::ImpossibleOperation,
-            format!("object has no method named {}", name),
-        ))
     }
 
     pub(crate) fn try_into_vec(self) -> Result<Vec<Value>, Error> {
-        if let Repr::Shared(arc) = self.0 {
-            match RcType::try_unwrap(arc) {
-                Ok(Shared::Seq(v)) => return Ok(v),
-                Ok(_) => {}
-                Err(arc) => {
-                    if let Shared::Seq(v) = &*arc {
-                        return Ok(v.to_vec());
-                    }
-                }
-            }
+        match self.0 {
+            Repr::Seq(v) => Ok(match RcType::try_unwrap(v) {
+                Ok(v) => v,
+                Err(rc) => (*rc).clone(),
+            }),
+            _ => Err(Error::new(
+                ErrorKind::ImpossibleOperation,
+                "cannot convert value into list",
+            )),
         }
-        Err(Error::new(
-            ErrorKind::ImpossibleOperation,
-            "cannot convert value into list",
-        ))
     }
 
     #[cfg(feature = "builtin_filters")]
     pub(crate) fn try_into_pairs(self) -> Result<Vec<Value>, Error> {
-        if let Repr::Shared(arc) = self.0 {
-            match RcType::try_unwrap(arc) {
-                Ok(Shared::Map(v)) => {
-                    return Ok(v
-                        .into_iter()
-                        .map(|(k, v)| Value::from(vec![Value::from(k), v]))
-                        .collect())
-                }
-                Ok(_) => {}
-                Err(arc) => {
-                    if let Shared::Map(v) = &*arc {
-                        return Ok(v
-                            .iter()
-                            .map(|(k, v)| Value::from(vec![Value::from(k.clone()), v.clone()]))
-                            .collect());
-                    }
-                }
+        match self.0 {
+            Repr::Map(v) => Ok(match RcType::try_unwrap(v) {
+                Ok(v) => v,
+                Err(rc) => (*rc).clone(),
             }
+            .into_iter()
+            .map(|(k, v)| Value::from(vec![Value::from(k), v]))
+            .collect()),
+            _ => Err(Error::new(
+                ErrorKind::ImpossibleOperation,
+                "cannot convert value into pair list",
+            )),
         }
-        Err(Error::new(
-            ErrorKind::ImpossibleOperation,
-            "cannot convert value into pair list",
-        ))
     }
 
     /// Iterates over the value.
     pub(crate) fn iter(&self) -> ValueIterator {
         let value = self.clone();
-        let clone = value.clone();
-        let (iter_state, len) = match &clone.0 {
-            Repr::Shared(cplx) => match **cplx {
-                Shared::Seq(ref seq) => (ValueIteratorState::Seq(0), seq.len()),
-                Shared::Map(ref items) => (
-                    ValueIteratorState::Map(items.iter().next().map(|x| x.0.clone())),
-                    items.len(),
-                ),
-                Shared::Struct(ref fields) => (
-                    ValueIteratorState::Struct(fields.iter().next().map(|x| *x.0)),
-                    fields.len(),
-                ),
-                _ => (ValueIteratorState::Empty, 0),
-            },
+        let (iter_state, len) = match self.0 {
+            Repr::Seq(ref seq) => (ValueIteratorState::Seq(0), seq.len()),
+            Repr::Map(ref items) => (
+                ValueIteratorState::Map(items.iter().next().map(|x| x.0.clone())),
+                items.len(),
+            ),
+            Repr::Struct(ref fields) => (
+                ValueIteratorState::Struct(fields.iter().next().map(|x| *x.0)),
+                fields.len(),
+            ),
             _ => (ValueIteratorState::Empty, 0),
         };
         ValueIterator {
@@ -1165,40 +1088,38 @@ impl Serialize for Value {
             Repr::Char(c) => serializer.serialize_char(c),
             Repr::None => serializer.serialize_unit(),
             Repr::Undefined => serializer.serialize_unit(),
-            Repr::Shared(ref cplx) => match **cplx {
-                Shared::U128(u) => serializer.serialize_u128(u),
-                Shared::I128(i) => serializer.serialize_i128(i),
-                Shared::String(ref s) => serializer.serialize_str(s),
-                Shared::SafeString(ref val) => serializer.serialize_str(val),
-                Shared::Bytes(ref b) => serializer.serialize_bytes(b),
-                Shared::Seq(ref elements) => elements.serialize(serializer),
-                Shared::Map(ref entries) => {
-                    use serde::ser::SerializeMap;
-                    let mut map = serializer.serialize_map(Some(entries.len()))?;
-                    for (ref k, ref v) in entries.iter() {
-                        map.serialize_entry(k, v)?;
-                    }
-                    map.end()
+            Repr::U128(ref u) => serializer.serialize_u128(**u),
+            Repr::I128(ref i) => serializer.serialize_i128(**i),
+            Repr::String(ref s) => serializer.serialize_str(s),
+            Repr::SafeString(ref val) => serializer.serialize_str(val),
+            Repr::Bytes(ref b) => serializer.serialize_bytes(b),
+            Repr::Seq(ref elements) => elements.serialize(serializer),
+            Repr::Map(ref entries) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(entries.len()))?;
+                for (ref k, ref v) in entries.iter() {
+                    map.serialize_entry(k, v)?;
                 }
-                Shared::Struct(ref fields) => {
-                    use serde::ser::SerializeStruct;
-                    let mut s = serializer.serialize_struct("Struct", fields.len())?;
-                    for (k, ref v) in fields.iter() {
-                        s.serialize_field(k, v)?;
-                    }
-                    s.end()
+                map.end()
+            }
+            Repr::Struct(ref fields) => {
+                use serde::ser::SerializeStruct;
+                let mut s = serializer.serialize_struct("Struct", fields.len())?;
+                for (k, ref v) in fields.iter() {
+                    s.serialize_field(k, v)?;
                 }
-                Shared::Dynamic(ref n) => {
-                    use serde::ser::SerializeMap;
-                    let fields = n.attributes();
-                    let mut s = serializer.serialize_map(Some(fields.len()))?;
-                    for k in fields {
-                        let v = n.get_attr(k).unwrap_or(Value::UNDEFINED);
-                        s.serialize_entry(k, &v)?;
-                    }
-                    s.end()
+                s.end()
+            }
+            Repr::Dynamic(ref n) => {
+                use serde::ser::SerializeMap;
+                let fields = n.attributes();
+                let mut s = serializer.serialize_map(Some(fields.len()))?;
+                for k in fields {
+                    let v = n.get_attr(k).unwrap_or(Value::UNDEFINED);
+                    s.serialize_entry(k, &v)?;
                 }
-            },
+                s.end()
+            }
         }
     }
 }
@@ -1238,7 +1159,7 @@ impl Serializer for ValueSerializer {
     }
 
     fn serialize_i128(self, v: i128) -> Result<Value, Error> {
-        Ok(Shared::I128(v).into())
+        Ok(Repr::I128(RcType::new(v)).into())
     }
 
     fn serialize_u8(self, v: u8) -> Result<Value, Error> {
@@ -1258,7 +1179,7 @@ impl Serializer for ValueSerializer {
     }
 
     fn serialize_u128(self, v: u128) -> Result<Value, Error> {
-        Ok(Shared::U128(v).into())
+        Ok(Repr::U128(RcType::new(v)).into())
     }
 
     fn serialize_f32(self, v: f32) -> Result<Value, Error> {
@@ -1274,11 +1195,11 @@ impl Serializer for ValueSerializer {
     }
 
     fn serialize_str(self, value: &str) -> Result<Value, Error> {
-        Ok(Shared::String(value.to_owned()).into())
+        Ok(Repr::String(RcType::new(value.to_owned())).into())
     }
 
     fn serialize_bytes(self, value: &[u8]) -> Result<Value, Error> {
-        Ok(Shared::Bytes(value.to_owned()).into())
+        Ok(Repr::Bytes(RcType::new(value.to_owned())).into())
     }
 
     fn serialize_none(self) -> Result<Value, Error> {
@@ -1306,7 +1227,7 @@ impl Serializer for ValueSerializer {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<Value, Error> {
-        Ok(Shared::String(variant.to_string()).into())
+        Ok(Repr::String(RcType::new(variant.to_string())).into())
     }
 
     fn serialize_newtype_struct<T: ?Sized>(
@@ -1332,7 +1253,7 @@ impl Serializer for ValueSerializer {
     {
         let mut map = BTreeMap::new();
         map.insert(Key::from(variant), value.serialize(self)?);
-        Ok(Shared::Map(map).into())
+        Ok(Repr::Map(RcType::new(map)).into())
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
@@ -1420,7 +1341,7 @@ impl ser::SerializeSeq for SerializeSeq {
     }
 
     fn end(self) -> Result<Value, Error> {
-        Ok(Shared::Seq(self.elements).into())
+        Ok(Repr::Seq(RcType::new(self.elements)).into())
     }
 }
 
@@ -1442,7 +1363,7 @@ impl ser::SerializeTuple for SerializeTuple {
     }
 
     fn end(self) -> Result<Value, Error> {
-        Ok(Shared::Seq(self.elements).into())
+        Ok(Repr::Seq(RcType::new(self.elements)).into())
     }
 }
 
@@ -1464,7 +1385,7 @@ impl ser::SerializeTupleStruct for SerializeTupleStruct {
     }
 
     fn end(self) -> Result<Value, Error> {
-        Ok(Value(Repr::Shared(RcType::new(Shared::Seq(self.fields)))))
+        Ok(Value(Repr::Seq(RcType::new(self.fields))))
     }
 }
 
@@ -1525,7 +1446,7 @@ impl ser::SerializeMap for SerializeMap {
     }
 
     fn end(self) -> Result<Value, Error> {
-        Ok(Value(Repr::Shared(RcType::new(Shared::Map(self.entries)))))
+        Ok(Value(Repr::Map(RcType::new(self.entries))))
     }
 
     fn serialize_entry<K: ?Sized, V: ?Sized>(&mut self, key: &K, value: &V) -> Result<(), Error>
@@ -1572,7 +1493,7 @@ impl ser::SerializeStruct for SerializeStruct {
                         .expect("value handle not in registry")
                 }))
             }
-            _ => Ok(Shared::Struct(self.fields).into()),
+            _ => Ok(Repr::Struct(RcType::new(self.fields)).into()),
         }
     }
 }
@@ -1597,7 +1518,7 @@ impl ser::SerializeStructVariant for SerializeStructVariant {
 
     fn end(self) -> Result<Value, Error> {
         let mut rv = BTreeMap::new();
-        rv.insert(self.variant, Value::from(Shared::Map(self.map)));
+        rv.insert(self.variant, Value::from(Repr::Map(RcType::new(self.map))));
         Ok(rv.into())
     }
 }
@@ -1677,10 +1598,7 @@ impl ValueIteratorState {
         macro_rules! unpack_shared {
             ($ty:ident) => {
                 match &value.0 {
-                    Repr::Shared(cplx) => match **cplx {
-                        Shared::$ty(ref inner) => inner,
-                        _ => return None,
-                    },
+                    Repr::$ty(ref inner) => inner,
                     _ => return None,
                 }
             };
@@ -1912,4 +1830,13 @@ fn test_value_serialization() {
         serde_json::to_string(&Value::from_safe_string("foo".to_string())).unwrap(),
         "\"foo\""
     );
+}
+
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn test_sizes() {
+    assert_eq!(std::mem::size_of::<Value>(), 24);
+    assert_eq!(std::mem::size_of::<RcType<u128>>(), 8);
+    assert_eq!(std::mem::size_of::<RcType<i128>>(), 8);
+    assert_eq!(std::mem::size_of::<RcType<Box<dyn Object>>>(), 8);
 }

--- a/minijinja/src/value.rs
+++ b/minijinja/src/value.rs
@@ -819,7 +819,7 @@ impl Value {
         if let Repr::Dynamic(ref obj) = self.0 {
             if (**obj).type_id() == TypeId::of::<T>() {
                 unsafe {
-                    // newer versions of Furst have RcType::as_ptr but we support
+                    // newer versions of Rust have RcType::as_ptr but we support
                     // rust versions down to 1.41.0 so we need to use a workaround here.
                     let count = RcType::strong_count(obj);
                     let clone = obj.clone();
@@ -1840,7 +1840,4 @@ fn test_value_serialization() {
 #[cfg(target_pointer_width = "64")]
 fn test_sizes() {
     assert_eq!(std::mem::size_of::<Value>(), 24);
-    assert_eq!(std::mem::size_of::<RcType<u128>>(), 8);
-    assert_eq!(std::mem::size_of::<RcType<i128>>(), 8);
-    assert_eq!(std::mem::size_of::<RcType<Box<dyn Object>>>(), 8);
 }


### PR DESCRIPTION
This started out to fix #1 but also changes the value type to no longer have the shared reference. I think overall this is a much saner internal API in particular because you can move the same `Rc<T>` between different objects (eg: `Key` and `Value`) but it comes with the downsize of overall larger `Value`s. This is caused by `RcType<dyn Object>`.

The way the iteration works now for maps is a bit more wasteful but gets away without `unsafe` which makes me sleep better at night.

Fixes #1