### PR TITLE
Added opcode for direct super and loop recursion

### DIFF
--- a/minijinja/src/instructions.rs
+++ b/minijinja/src/instructions.rs
@@ -171,6 +171,12 @@ pub enum Instruction<'source> {
     /// Discards the top item
     DiscardTop,
 
+    /// A fast super instruction without intermediate capturing.
+    FastSuper,
+
+    /// A fast loop recurse instruction without intermediate capturing.
+    FastRecurse,
+
     /// A nop
     #[allow(unused)]
     Nop,
@@ -242,6 +248,8 @@ impl<'source> fmt::Debug for Instruction<'source> {
             Instruction::CallObject => write!(f, "CALL_OBJECT"),
             Instruction::DupTop => write!(f, "DUP_TOP"),
             Instruction::DiscardTop => write!(f, "DISCARD_TOP"),
+            Instruction::FastSuper => write!(f, "FAST_SUPER"),
+            Instruction::FastRecurse => write!(f, "FAST_RECURSE"),
             Instruction::Nop => write!(f, "NOP"),
         }
     }

--- a/minijinja/src/vm.rs
+++ b/minijinja/src/vm.rs
@@ -99,7 +99,10 @@ pub struct Loop<'env> {
     locals: BTreeMap<&'env str, Value>,
     with_loop_var: bool,
     recurse_jump_target: Option<usize>,
-    current_recursion_jump: Option<usize>,
+    // if we're popping the frame, do we want to jump somewhere?  The
+    // first item is the target jump instruction, the second argument
+    // tells us if we need to end capturing.
+    current_recursion_jump: Option<(usize, bool)>,
     iterator: ValueIterator,
     controller: RcType<LoopState>,
 }
@@ -521,6 +524,63 @@ impl<'env> Vm<'env> {
             }};
         }
 
+        macro_rules! super_block {
+            ($capture:expr) => {
+                let mut inner_blocks = blocks.clone();
+                let name = match state.current_block {
+                    Some(name) => name,
+                    None => {
+                        bail!(Error::new(
+                            ErrorKind::ImpossibleOperation,
+                            "cannot super outside of block",
+                        ));
+                    }
+                };
+                if let Some(layers) = inner_blocks.get_mut(name) {
+                    layers.remove(0);
+                    let instructions = layers.first().unwrap();
+                    if $capture {
+                        begin_capture!();
+                    }
+                    sub_eval!(instructions);
+                    if $capture {
+                        end_capture!();
+                    }
+                } else {
+                    panic!("attempted to super unreferenced block");
+                }
+            };
+        }
+
+        macro_rules! recurse_loop {
+            ($capture:expr) => {
+                if let Some(loop_ctx) = state.ctx.current_loop() {
+                    if let Some(recurse_jump_target) = loop_ctx.recurse_jump_target {
+                        // the way this works is that we remember the next instruction
+                        // as loop exit jump target.  Whenever a loop is pushed, it
+                        // memorizes the value in `next_loop_iteration_jump` to jump
+                        // to.
+                        next_loop_recursion_jump = Some((pc + 1, $capture));
+                        if $capture {
+                            begin_capture!();
+                        }
+                        pc = recurse_jump_target;
+                        continue;
+                    } else {
+                        bail!(Error::new(
+                            ErrorKind::ImpossibleOperation,
+                            "cannot recurse outside of recursive loop"
+                        ));
+                    }
+                } else {
+                    bail!(Error::new(
+                        ErrorKind::ImpossibleOperation,
+                        "cannot recurse outside of loop"
+                    ));
+                }
+            };
+        }
+
         while let Some(instr) = instructions.get(pc) {
             match instr {
                 Instruction::EmitRaw(val) => {
@@ -629,9 +689,12 @@ impl<'env> Vm<'env> {
                 }
                 Instruction::PopFrame => {
                     if let Frame::Loop(mut loop_ctx) = state.ctx.pop_frame() {
-                        if let Some(target) = loop_ctx.current_recursion_jump.take() {
+                        if let Some((target, end_capture)) = loop_ctx.current_recursion_jump.take()
+                        {
                             pc = target;
-                            end_capture!();
+                            if end_capture {
+                                end_capture!();
+                            }
                             continue;
                         }
                     }
@@ -809,56 +872,17 @@ impl<'env> Vm<'env> {
                                 "super() takes no arguments",
                             ));
                         }
-                        let mut inner_blocks = blocks.clone();
-                        let name = match state.current_block {
-                            Some(name) => name,
-                            None => {
-                                bail!(Error::new(
-                                    ErrorKind::ImpossibleOperation,
-                                    "cannot super outside of block",
-                                ));
-                            }
-                        };
-                        if let Some(layers) = inner_blocks.get_mut(name) {
-                            layers.remove(0);
-                            let instructions = layers.first().unwrap();
-                            begin_capture!();
-                            sub_eval!(instructions);
-                            end_capture!();
-                        } else {
-                            panic!("attempted to super unreferenced block");
-                        }
+                        super_block!(true);
                     // loop is a special name which when called recurses the current loop.
                     } else if *function_name == "loop" {
-                        if let Some(loop_ctx) = state.ctx.current_loop() {
-                            if args.len() != 1 {
-                                bail!(Error::new(
-                                    ErrorKind::ImpossibleOperation,
-                                    format!("loop() takes one argument, got {}", args.len())
-                                ));
-                            }
-                            if let Some(recurse_jump_target) = loop_ctx.recurse_jump_target {
-                                // the way this works is that we remember the next instruction
-                                // as loop exit jump target.  Whenever a loop is pushed, it
-                                // memorizes the value in `next_loop_iteration_jump` to jump
-                                // to and also end the current capture.
-                                next_loop_recursion_jump = Some(pc + 1);
-                                stack.push(args.into_iter().next().unwrap());
-                                pc = recurse_jump_target;
-                                begin_capture!();
-                                continue;
-                            } else {
-                                bail!(Error::new(
-                                    ErrorKind::ImpossibleOperation,
-                                    "cannot recurse outside of recursive loop"
-                                ));
-                            }
-                        } else {
+                        if args.len() != 1 {
                             bail!(Error::new(
                                 ErrorKind::ImpossibleOperation,
-                                "tried to recurse outside of loop"
+                                format!("loop() takes one argument, got {}", args.len())
                             ));
                         }
+                        stack.push(args.into_iter().next().unwrap());
+                        recurse_loop!(true);
                     } else if let Some(func) = state.ctx.load(self.env, function_name) {
                         stack.push(try_ctx!(func.call(state, args)));
                     } else {
@@ -883,6 +907,12 @@ impl<'env> Vm<'env> {
                 }
                 Instruction::DiscardTop => {
                     stack.pop();
+                }
+                Instruction::FastSuper => {
+                    super_block!(false);
+                }
+                Instruction::FastRecurse => {
+                    recurse_loop!(false);
                 }
                 Instruction::Nop => {}
             }

--- a/minijinja/tests/inputs/block_super.html
+++ b/minijinja/tests/inputs/block_super.html
@@ -4,4 +4,5 @@ var: foo
 {% block body %}
   <p>New Content</p>
   {{ super() }}
+  {{ super()|upper }}
 {% endblock %}

--- a/minijinja/tests/inputs/loop_recursive.txt
+++ b/minijinja/tests/inputs/loop_recursive.txt
@@ -15,3 +15,10 @@ nav:
     if item.children %}<ul>{{ loop(item.children) }}</ul>{% endif %}</li>
 {% endfor %}
 </ul>
+
+<ul class="nav">
+{% for item in nav recursive %}
+  <li><a href={{ item.link }}">{{ item.title }}</a>{%
+    if item.children %}<ul>{{ loop(item.children)|upper }}</ul>{% endif %}</li>
+{% endfor %}
+</ul>

--- a/minijinja/tests/snapshots/test_templates__vm@block_super.html.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@block_super.html.snap
@@ -1,5 +1,6 @@
 ---
 source: minijinja/tests/test_templates.rs
+assertion_line: 44
 expression: "&rendered"
 input_file: minijinja/tests/inputs/block_super.html
 
@@ -8,6 +9,9 @@ input_file: minijinja/tests/inputs/block_super.html
   <p>New Content</p>
   
   <p>Default Content</p>
+
+  
+  &lt;P&gt;DEFAULT CONTENT&lt;&#x2f;P&gt;
 
 
 

--- a/minijinja/tests/snapshots/test_templates__vm@loop_recursive.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@loop_recursive.txt.snap
@@ -1,5 +1,6 @@
 ---
 source: minijinja/tests/test_templates.rs
+assertion_line: 44
 expression: "&rendered"
 input_file: minijinja/tests/inputs/loop_recursive.txt
 
@@ -12,6 +13,18 @@ input_file: minijinja/tests/inputs/loop_recursive.txt
   <li><a href=/docs/installation">Installation</a></li>
 
   <li><a href=/docs/faq">FAQ</a></li>
+</ul></li>
+
+</ul>
+
+<ul class="nav">
+
+  <li><a href=/">Index</a></li>
+
+  <li><a href=/docs">Docs</a><ul>
+  <LI><A HREF=/DOCS/INSTALLATION">INSTALLATION</A></LI>
+
+  <LI><A HREF=/DOCS/FAQ">FAQ</A></LI>
 </ul></li>
 
 </ul>


### PR DESCRIPTION
This changes the engine so that a direct calls to super and loop
are detected.  This avoids unnecessary double buffering if
necessary.

Refs #45