### PR TITLE
Remove eroneous text from documentation

### DIFF
--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -384,8 +384,6 @@ mod builtins {
         }
     }
 
-    /// Checks if a string starts with another string.
-    ///
     /// If the value is undefined it will return the passed default value,
     /// otherwise the value of the variable:
     ///


### PR DESCRIPTION
This removes the first line of text from the `default` filter which was wrong.