### PR TITLE
Added support for ignore missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to MiniJinja are documented here.
 
 - Added `bool` filter.
 - Added `meta` API. (#55)
+- Added support for `ignore missing` in include tags. (#56)
 
 # 0.13.0
 

--- a/minijinja/src/ast.rs
+++ b/minijinja/src/ast.rs
@@ -168,6 +168,7 @@ pub struct Extends<'a> {
 #[cfg_attr(feature = "internal_debug", derive(Debug))]
 pub struct Include<'a> {
     pub name: Expr<'a>,
+    pub ignore_missing: bool,
 }
 
 /// An auto escape control block.

--- a/minijinja/src/compiler.rs
+++ b/minijinja/src/compiler.rs
@@ -284,7 +284,7 @@ impl<'source> Compiler<'source> {
             ast::Stmt::Include(include) => {
                 self.set_location_from_span(include.span());
                 self.compile_expr(&include.name)?;
-                self.add(Instruction::Include);
+                self.add(Instruction::Include(include.ignore_missing));
             }
             ast::Stmt::AutoEscape(auto_escape) => {
                 self.set_location_from_span(auto_escape.span());

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -437,7 +437,7 @@ impl<'source> Environment<'source> {
         .ok_or_else(|| {
             Error::new(
                 ErrorKind::TemplateNotFound,
-                format!("template name {:?}", name),
+                format!("template {:?} does not exist", name),
             )
         })
     }

--- a/minijinja/src/instructions.rs
+++ b/minijinja/src/instructions.rs
@@ -142,7 +142,7 @@ pub enum Instruction<'source> {
     LoadBlocks,
 
     /// Includes another template.
-    Include,
+    Include(bool),
 
     /// Sets the auto escape flag to the current value.
     PushAutoEscape,
@@ -238,7 +238,7 @@ impl<'source> fmt::Debug for Instruction<'source> {
             Instruction::JumpIfTrueOrPop(t) => write!(f, "JUMP_IF_TRUE_OR_POP (to {:>05x})", t),
             Instruction::CallBlock(n) => write!(f, "CALL_BLOCK (name {:?})", n),
             Instruction::LoadBlocks => write!(f, "LOAD_BLOCKS"),
-            Instruction::Include => write!(f, "INCLUDE"),
+            Instruction::Include(b) => write!(f, "INCLUDE (ignore missing {:?})", b),
             Instruction::PushAutoEscape => write!(f, "PUSH_AUTO_ESCAPE"),
             Instruction::PopAutoEscape => write!(f, "POP_AUTO_ESCAPE"),
             Instruction::BeginCapture => write!(f, "BEGIN_CAPTURE"),

--- a/minijinja/src/parser.rs
+++ b/minijinja/src/parser.rs
@@ -741,7 +741,18 @@ impl<'a> Parser<'a> {
 
     fn parse_include(&mut self) -> Result<ast::Include<'a>, Error> {
         let name = self.parse_expr()?;
-        Ok(ast::Include { name })
+        let ignore_missing = if matches!(self.stream.current()?, Some((Token::Ident("ignore"), _)))
+        {
+            self.stream.next()?;
+            expect_token!(self, Token::Ident("missing"), "missing keyword")?;
+            true
+        } else {
+            false
+        };
+        Ok(ast::Include {
+            name,
+            ignore_missing,
+        })
     }
 
     fn parse_auto_escape(&mut self) -> Result<ast::AutoEscape<'a>, Error> {

--- a/minijinja/src/syntax.rs
+++ b/minijinja/src/syntax.rs
@@ -364,6 +364,13 @@
 //!   Body
 //! {% include 'footer.html' %}
 //! ```
+//!
+//! Optionally `ignore missing` can be added in which case non existing templates
+//! are silently ignored.
+//!
+//! ```jinja
+//! {% include 'customization.html' ignore missing %}
+//! ```
 //!  
 //! Included templates have access to the variables of the active context.
 //!

--- a/minijinja/tests/snapshots/test_parser__parser@include.txt.snap
+++ b/minijinja/tests/snapshots/test_parser__parser@include.txt.snap
@@ -1,5 +1,6 @@
 ---
 source: minijinja/tests/test_parser.rs
+assertion_line: 10
 expression: "&ast"
 input_file: minijinja/tests/parser-inputs/include.txt
 
@@ -11,6 +12,7 @@ Ok(
                 name: Const {
                     value: "foo.txt",
                 } @ 1:11-1:20,
+                ignore_missing: false,
             } @ 1:3-1:20,
         ],
     } @ 0:0-1:23,


### PR DESCRIPTION
This adds support for the `include missing` flag on include blocks to make include blocks fail silently if templates are missing.