### PR TITLE
Remove remove_template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to MiniJinja are documented here.
 
+# 0.15.0
+
+- Removed the functionality to unload templates from an environment. (#60)
+
 # 0.14.1
 
 - Fixed `or` expressions not working properly.

--- a/minijinja/src/source.rs
+++ b/minijinja/src/source.rs
@@ -85,11 +85,6 @@ impl Source {
         Ok(())
     }
 
-    /// Removes an already loaded template from the source.
-    pub fn remove_template(&mut self, name: &str) {
-        self.templates.remove(name);
-    }
-
     /// Loads templates from a path.
     ///
     /// This function takes two arguments: `path` which is the path to where the templates are
@@ -159,12 +154,9 @@ impl Source {
     }
 
     /// Gets a compiled template from the source.
-    pub(crate) fn get_compiled_template(
-        &self,
-        name: &str,
-    ) -> Option<(&str, &CompiledTemplate<'_>)> {
+    pub(crate) fn get_compiled_template(&self, name: &str) -> Option<&CompiledTemplate<'_>> {
         self.templates
-            .get_key_value(name)
-            .map(|(key, value)| (key.as_str(), value.borrow_dependent()))
+            .get(name)
+            .map(|value| value.borrow_dependent())
     }
 }

--- a/minijinja/tests/test_source.rs
+++ b/minijinja/tests/test_source.rs
@@ -17,10 +17,3 @@ fn test_basic() {
     let t = env.get_template("hello").unwrap();
     assert_eq!(t.render(&()).unwrap(), "Hello World!");
 }
-
-#[test]
-fn test_removal() {
-    let mut env = create_env();
-    env.remove_template("hello");
-    assert!(env.get_template("hello").is_err());
-}


### PR DESCRIPTION
If support for #59 should come it will more convenient to remove the functionality to unload templates. This quite an edge case to support and removing it should be save.

This also removes an unnecessary internal reference where we store the name twice now.