### PR TITLE
disable usage of unused serde features

### DIFF
--- a/minijinja/Cargo.toml
+++ b/minijinja/Cargo.toml
@@ -34,7 +34,7 @@ internal_debug = []
 unstable_machinery = ["internal_debug"]
 
 [dependencies]
-serde = "1.0.130"
+serde = { version = "1.0.130", default-features = false }
 v_htmlescape = { version = "0.14.1", optional = true }
 self_cell = { version = "0.10.1", optional = true, features = ["old_rust"] }
 serde_json = { version = "1.0.68", optional = true }


### PR DESCRIPTION
As can I see `minijinja` is not depend on any features of "serde",
but because of it is not use `default-features = false`,
crates that depend on this crate got all features enabled, and can not disable
any of them.

So why not disable unused features?