### PR TITLE
Adds support for tuple unpacking in With blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to MiniJinja are documented here.
 
+# 0.16.0
+
+- Added support for unpacking in `with` blocks. (#65)
+
 # 0.15.0
 
 - Bumped minimum version requirement to 1.43.

--- a/minijinja/src/ast.rs
+++ b/minijinja/src/ast.rs
@@ -147,7 +147,7 @@ pub struct IfCond<'a> {
 /// A with block.
 #[cfg_attr(feature = "internal_debug", derive(Debug))]
 pub struct WithBlock<'a> {
-    pub assignments: Vec<(&'a str, Expr<'a>)>,
+    pub assignments: Vec<(Expr<'a>, Expr<'a>)>,
     pub body: Vec<Stmt<'a>>,
 }
 

--- a/minijinja/src/compiler.rs
+++ b/minijinja/src/compiler.rs
@@ -252,7 +252,7 @@ impl<'source> Compiler<'source> {
             ast::Stmt::WithBlock(with_block) => {
                 self.set_location_from_span(with_block.span());
                 for (target, expr) in &with_block.assignments {
-                    self.add(Instruction::LoadConst(Value::from(*target)));
+                    self.compile_unpack(target)?;
                     self.compile_expr(expr)?;
                 }
                 self.add(Instruction::BuildMap(with_block.assignments.len()));
@@ -321,6 +321,25 @@ impl<'source> Compiler<'source> {
                 self.add(Instruction::UnpackList(list.items.len()));
                 for expr in &list.items {
                     self.compile_assignment(expr)?;
+                }
+            }
+            _ => panic!("bad assignment target"),
+        }
+        Ok(())
+    }
+
+    /// Compiles an unpack expression.
+    pub fn compile_unpack(&mut self, expr: &ast::Expr<'source>) -> Result<(), Error> {
+        match expr {
+            ast::Expr::Var(var) => {
+                self.set_location_from_span(var.span());
+                self.add(Instruction::LoadConst(Value::from(var.id)));
+            }
+            ast::Expr::List(list) => {
+                self.set_location_from_span(list.span());
+                self.add(Instruction::UnpackList(list.items.len()));
+                for expr in &list.items {
+                    self.compile_unpack(expr)?;
                 }
             }
             _ => panic!("bad assignment target"),

--- a/minijinja/src/instructions.rs
+++ b/minijinja/src/instructions.rs
@@ -111,8 +111,8 @@ pub enum Instruction<'source> {
     /// The argument are loop flags.
     PushLoop(u8),
 
-    /// Pushes a value as context layer.
-    PushContext,
+    /// Starts a with block.
+    PushWith,
 
     /// Does a single loop iteration
     ///
@@ -229,7 +229,7 @@ impl<'source> fmt::Debug for Instruction<'source> {
                     loop_var, recursive
                 )
             }
-            Instruction::PushContext => write!(f, "PUSH_CONTEXT"),
+            Instruction::PushWith => write!(f, "PUSH_WITH"),
             Instruction::Iterate(t) => write!(f, "ITERATE (exit to {:>05x})", t),
             Instruction::PopFrame => write!(f, "POP_FRAME"),
             Instruction::Jump(t) => write!(f, "JUMP (to {:>05x})", t),
@@ -349,7 +349,7 @@ impl<'source> Instructions<'source> {
                 | Instruction::StoreLocal(name)
                 | Instruction::CallFunction(name) => *name,
                 Instruction::PushLoop(flags) if flags & LOOP_FLAG_WITH_LOOP_VAR != 0 => "loop",
-                Instruction::PushLoop(_) | Instruction::PushContext => break,
+                Instruction::PushLoop(_) | Instruction::PushWith => break,
                 _ => continue,
             };
             if !rv.contains(&name) {

--- a/minijinja/src/meta.rs
+++ b/minijinja/src/meta.rs
@@ -165,8 +165,8 @@ pub fn find_undeclared_variables(source: &str) -> Result<HashSet<String>, Error>
             }
             ast::Stmt::WithBlock(stmt) => {
                 state.push();
-                for (name, expr) in &stmt.assignments {
-                    state.assign(name);
+                for (target, expr) in &stmt.assignments {
+                    assign_nested(target, state);
                     visit_expr(expr, state);
                 }
                 stmt.body.iter().for_each(|x| walk(x, state));

--- a/minijinja/src/parser.rs
+++ b/minijinja/src/parser.rs
@@ -699,7 +699,14 @@ impl<'a> Parser<'a> {
             if !assignments.is_empty() {
                 expect_token!(self, Token::Comma, "comma")?;
             }
-            let target = self.parse_assign_name()?;
+            let target = if matches!(self.stream.current()?, Some((Token::ParenOpen, _))) {
+                self.stream.next()?;
+                let assign = self.parse_assignment()?;
+                expect_token!(self, Token::ParenClose, "`)`")?;
+                assign
+            } else {
+                self.parse_assign_name()?
+            };
             expect_token!(self, Token::Assign, "assignment operator")?;
             let expr = self.parse_expr()?;
             assignments.push((target, expr));

--- a/minijinja/src/parser.rs
+++ b/minijinja/src/parser.rs
@@ -699,10 +699,7 @@ impl<'a> Parser<'a> {
             if !assignments.is_empty() {
                 expect_token!(self, Token::Comma, "comma")?;
             }
-            let target = match self.parse_assign_name()? {
-                ast::Expr::Var(var) => var.id,
-                _ => panic!("unexpected node from assignment parse"),
-            };
+            let target = self.parse_assign_name()?;
             expect_token!(self, Token::Assign, "assignment operator")?;
             let expr = self.parse_expr()?;
             assignments.push((target, expr));

--- a/minijinja/src/syntax.rs
+++ b/minijinja/src/syntax.rs
@@ -396,6 +396,14 @@
 //! foo is not visible here any longer
 //! ```
 //!
+//! Multiple variables can be set at once and unpacking is supported:
+//!
+//! ```jinja
+//! {% with a = 1, (b, c) = [2, 3] %}
+//!   {{ a }}, {{ b }}, {{ c }}  (outputs 1, 2, 3)
+//! {% endwith %}
+//! ```
+//!
 //! ## `{% filter %}`
 //!
 //! Filter sections allow you to apply regular [filters](crate::filters) on a

--- a/minijinja/tests/inputs/with.txt
+++ b/minijinja/tests/inputs/with.txt
@@ -1,7 +1,17 @@
 foo: 42
 bar: 23
 other: 11
+tuple: [1, 2, [3]]
+tuple2: [[1], 2, 3]
 ---
 {% with a=foo, b=bar %}
   {{ a }}|{{ b }}|{{ other }}
+{% endwith %}
+
+{% with (a, b, (c,)) = tuple %}
+  {{ a }}|{{ b }}|{{ c }}
+{% endwith %}
+
+{% with ((a,), b, c) = tuple2 %}
+  {{ a }}|{{ b }}|{{ c }}
 {% endwith %}

--- a/minijinja/tests/snapshots/test_parser__parser@with.txt.snap
+++ b/minijinja/tests/snapshots/test_parser__parser@with.txt.snap
@@ -2,7 +2,6 @@
 source: minijinja/tests/test_parser.rs
 expression: "&ast"
 input_file: minijinja/tests/parser-inputs/with.txt
-
 ---
 Ok(
     Template {
@@ -10,13 +9,17 @@ Ok(
             WithBlock {
                 assignments: [
                     (
-                        "a",
+                        Var {
+                            id: "a",
+                        } @ 1:8-1:9,
                         Var {
                             id: "foo",
                         } @ 1:10-1:13,
                     ),
                     (
-                        "b",
+                        Var {
+                            id: "b",
+                        } @ 1:15-1:16,
                         Var {
                             id: "bar",
                         } @ 1:17-1:20,
@@ -50,7 +53,9 @@ Ok(
             WithBlock {
                 assignments: [
                     (
-                        "a",
+                        Var {
+                            id: "a",
+                        } @ 5:8-5:9,
                         Var {
                             id: "foo",
                         } @ 5:10-5:13,

--- a/minijinja/tests/snapshots/test_templates__vm@with.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@with.txt.snap
@@ -2,9 +2,16 @@
 source: minijinja/tests/test_templates.rs
 expression: "&rendered"
 input_file: minijinja/tests/inputs/with.txt
-
 ---
 
   42|23|11
+
+
+
+  1|2|3
+
+
+
+  1|2|3
 
 

--- a/minijinja/tests/test_templates.rs
+++ b/minijinja/tests/test_templates.rs
@@ -34,6 +34,7 @@ fn test_vm() {
 
         env.add_template(filename, iter.next().unwrap()).unwrap();
         let template = env.get_template(filename).unwrap();
+        dbg!(&template);
 
         let mut rendered = match template.render(ctx) {
             Ok(rendered) => rendered,


### PR DESCRIPTION
This adds support for tuple unpacking in with blocks. This also changes how with blocks are compiled to bytecode to better reuse the logic we already have for for loops.

Fixes #65