### PR TITLE
Add `.`, `-`, and `_` to set of unescaped characters in `urlencode`

### DIFF
--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -688,8 +688,12 @@ mod builtins {
     #[cfg_attr(docsrs, doc(cfg(all(feature = "builtins", feature = "urlencode"))))]
     #[cfg(feature = "urlencode")]
     pub fn urlencode(_: &State, value: Value) -> Result<String, Error> {
-        const SET: &percent_encoding::AsciiSet =
-            &percent_encoding::NON_ALPHANUMERIC.remove(b'/').remove(b'.').add(b' ');
+        const SET: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+            .remove(b'/')
+            .remove(b'.')
+            .remove(b'-')
+            .remove(b'_')
+            .add(b' ');
         match &value.0 {
             ValueRepr::None | ValueRepr::Undefined => Ok("".into()),
             ValueRepr::Bytes(b) => Ok(percent_encoding::percent_encode(b, SET).to_string()),

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -689,7 +689,7 @@ mod builtins {
     #[cfg(feature = "urlencode")]
     pub fn urlencode(_: &State, value: Value) -> Result<String, Error> {
         const SET: &percent_encoding::AsciiSet =
-            &percent_encoding::NON_ALPHANUMERIC.remove(b'/').add(b' ');
+            &percent_encoding::NON_ALPHANUMERIC.remove(b'/').remove(b'.').add(b' ');
         match &value.0 {
             ValueRepr::None | ValueRepr::Undefined => Ok("".into()),
             ValueRepr::Bytes(b) => Ok(percent_encoding::percent_encode(b, SET).to_string()),

--- a/minijinja/tests/inputs/filters.txt
+++ b/minijinja/tests/inputs/filters.txt
@@ -47,7 +47,7 @@ d: {{ undefined|d == "" }}
 json: {{ map|tojson }}
 json-pretty: {{ map|tojson(true) }}
 json-scary-html: {{ scary_html|tojson }}
-urlencode: {{ "hello world/baz.txt"|urlencode }}
+urlencode: {{ "hello world/foo-bar_baz.txt"|urlencode }}
 urlencode-kv: {{ dict(a="x y", b=2, c=3)|urlencode }}
 batch: {{ range(10)|batch(3) }}
 batch-fill: {{ range(10)|batch(3, '-') }}

--- a/minijinja/tests/inputs/filters.txt
+++ b/minijinja/tests/inputs/filters.txt
@@ -47,7 +47,7 @@ d: {{ undefined|d == "" }}
 json: {{ map|tojson }}
 json-pretty: {{ map|tojson(true) }}
 json-scary-html: {{ scary_html|tojson }}
-urlencode: {{ "hello world/baz"|urlencode }}
+urlencode: {{ "hello world/baz.txt"|urlencode }}
 urlencode-kv: {{ dict(a="x y", b=2, c=3)|urlencode }}
 batch: {{ range(10)|batch(3) }}
 batch-fill: {{ range(10)|batch(3, '-') }}

--- a/minijinja/tests/snapshots/test_templates__vm@filters.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@filters.txt.snap
@@ -1,9 +1,7 @@
 ---
 source: minijinja/tests/test_templates.rs
-assertion_line: 44
 expression: "&rendered"
 input_file: minijinja/tests/inputs/filters.txt
-
 ---
 lower: bird
 upper: BIRD
@@ -49,7 +47,7 @@ json-pretty: {
   "c": "d"
 }
 json-scary-html: "\u003c\u003e\u0026\u0027"
-urlencode: hello%20world/baz
+urlencode: hello%20world/baz.txt
 urlencode-kv: a=x%20y&b=2&c=3
 batch: [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]
 batch-fill: [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, "-", "-"]]

--- a/minijinja/tests/snapshots/test_templates__vm@filters.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@filters.txt.snap
@@ -47,7 +47,7 @@ json-pretty: {
   "c": "d"
 }
 json-scary-html: "\u003c\u003e\u0026\u0027"
-urlencode: hello%20world/baz.txt
+urlencode: hello%20world/foo-bar_baz.txt
 urlencode-kv: a=x%20y&b=2&c=3
 batch: [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]
 batch-fill: [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, "-", "-"]]


### PR DESCRIPTION
I ran `make test` and then `cargo insta review` to verify the changes. I'm not sure if there's anything else that's required. (See below for a note on a line that changed and I'm unsure why.)