### PR TITLE
Make the similar-asserts crate into a dev dependency

### DIFF
--- a/minijinja/Cargo.toml
+++ b/minijinja/Cargo.toml
@@ -41,11 +41,11 @@ serde_json = { version = "1.0.68", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
 indexmap = { version = "1.7.0", optional = true }
 memo-map = { version = "0.3.1", optional = true }
-similar-asserts = "1.4.2"
 
 [dev-dependencies]
 insta = { version = "1.19.0", features = ["glob"] }
 serde_json = "1.0.68"
+similar-asserts = "1.4.2"
 
 [[test]]
 name = "test_templates"


### PR DESCRIPTION
Updating to minijinja 0.18.0 added the following dependencies to our projects:

* bstr
* console
* encode_unicode
* similar
* similar-asserts
* terminal_size

Considering that similar-asserts only gets used for tests, adding those dependencies for everyone doesn't seem to make sense. This is also mentioned in their docs: https://docs.rs/similar-asserts/1.4.2/similar_asserts/#faster-builds