### PR TITLE
New Function Traits

### DIFF
--- a/examples/dynamic/src/main.rs
+++ b/examples/dynamic/src/main.rs
@@ -18,7 +18,7 @@ impl fmt::Display for Cycler {
 }
 
 impl Object for Cycler {
-    fn call(&self, _state: &State, args: Vec<Value>) -> Result<Value, Error> {
+    fn call(&self, _state: &State, args: &[Value]) -> Result<Value, Error> {
         let _: () = FunctionArgs::from_values(args)?;
         let idx = self.idx.fetch_add(1, Ordering::Relaxed);
         Ok(self.values[idx % self.values.len()].clone())
@@ -42,7 +42,7 @@ impl fmt::Display for Magic {
 }
 
 impl Object for Magic {
-    fn call_method(&self, _state: &State, name: &str, args: Vec<Value>) -> Result<Value, Error> {
+    fn call_method(&self, _state: &State, name: &str, args: &[Value]) -> Result<Value, Error> {
         if name == "make_class" {
             let (tag,): (String,) = FunctionArgs::from_values(args)?;
             Ok(Value::from(format!("magic-{}", tag)))

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -526,10 +526,10 @@ impl<'source> Environment<'source> {
     /// For details about filters have a look at [`filters`].
     pub fn add_filter<F, V, Rv, Args>(&mut self, name: &'source str, f: F)
     where
-        V: ArgType,
+        V: for<'a> ArgType<'a>,
         Rv: Into<Value>,
         F: filters::Filter<V, Rv, Args>,
-        Args: FunctionArgs,
+        Args: for<'a> FunctionArgs<'a>,
     {
         self.filters.insert(name, filters::BoxedFilter::new(f));
     }
@@ -544,9 +544,9 @@ impl<'source> Environment<'source> {
     /// For details about tests have a look at [`tests`].
     pub fn add_test<F, V, Args>(&mut self, name: &'source str, f: F)
     where
-        V: ArgType,
+        V: for<'a> ArgType<'a>,
         F: tests::Test<V, Args>,
-        Args: FunctionArgs,
+        Args: for<'a> FunctionArgs<'a>,
     {
         self.tests.insert(name, tests::BoxedTest::new(f));
     }
@@ -564,7 +564,7 @@ impl<'source> Environment<'source> {
     where
         Rv: Into<Value>,
         F: functions::Function<Rv, Args>,
-        Args: FunctionArgs,
+        Args: for<'a> FunctionArgs<'a>,
     {
         self.add_global(name, functions::BoxedFunction::new(f).to_value());
     }

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -51,7 +51,7 @@ use crate::value::{ArgType, FunctionArgs, RcType, Value};
 use crate::vm::State;
 use crate::AutoEscape;
 
-type FilterFunc = dyn Fn(&State, Value, Vec<Value>) -> Result<Value, Error> + Sync + Send + 'static;
+type FilterFunc = dyn Fn(&State, Value, &[Value]) -> Result<Value, Error> + Sync + Send + 'static;
 
 #[derive(Clone)]
 pub(crate) struct BoxedFilter(RcType<FilterFunc>);
@@ -105,7 +105,7 @@ impl BoxedFilter {
     }
 
     /// Applies the filter to a value and argument.
-    pub fn apply_to(&self, state: &State, value: Value, args: Vec<Value>) -> Result<Value, Error> {
+    pub fn apply_to(&self, state: &State, value: Value, args: &[Value]) -> Result<Value, Error> {
         (self.0)(state, value, args)
     }
 }
@@ -758,7 +758,7 @@ mod builtins {
         };
         let bx = BoxedFilter::new(test);
         assert_eq!(
-            bx.apply_to(&state, Value::from(23), vec![Value::from(42)])
+            bx.apply_to(&state, Value::from(23), &[Value::from(42)][..])
                 .unwrap(),
             Value::from(65)
         );
@@ -784,7 +784,7 @@ mod builtins {
         };
         let bx = BoxedFilter::new(add);
         assert_eq!(
-            bx.apply_to(&state, Value::from(23), vec![Value::from(42)])
+            bx.apply_to(&state, Value::from(23), &[Value::from(42)][..])
                 .unwrap(),
             Value::from(65)
         );
@@ -792,7 +792,7 @@ mod builtins {
             bx.apply_to(
                 &state,
                 Value::from(23),
-                vec![Value::from(42), Value::UNDEFINED]
+                &[Value::from(42), Value::UNDEFINED][..]
             )
             .unwrap(),
             Value::from(65)
@@ -801,7 +801,7 @@ mod builtins {
             bx.apply_to(
                 &state,
                 Value::from(23),
-                vec![Value::from(42), Value::from(1)]
+                &[Value::from(42), Value::from(1)][..]
             )
             .unwrap(),
             Value::from(66)

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -51,7 +51,7 @@ use crate::value::{ArgType, FunctionArgs, RcType, Value};
 use crate::vm::State;
 use crate::AutoEscape;
 
-type FilterFunc = dyn Fn(&State, Value, &[Value]) -> Result<Value, Error> + Sync + Send + 'static;
+type FilterFunc = dyn Fn(&State, &Value, &[Value]) -> Result<Value, Error> + Sync + Send + 'static;
 
 #[derive(Clone)]
 pub(crate) struct BoxedFilter(RcType<FilterFunc>);
@@ -88,16 +88,16 @@ impl BoxedFilter {
     pub fn new<F, V, Rv, Args>(f: F) -> BoxedFilter
     where
         F: Filter<V, Rv, Args>,
-        V: ArgType,
+        V: for<'a> ArgType<'a>,
         Rv: Into<Value>,
-        Args: FunctionArgs,
+        Args: for<'a> FunctionArgs<'a>,
     {
         BoxedFilter(RcType::new(
             move |state, value, args| -> Result<Value, Error> {
                 f.apply_to(
                     state,
-                    ArgType::from_value(Some(value))?,
-                    FunctionArgs::from_values(args)?,
+                    ArgType::from_value(Some(unsafe { std::mem::transmute::<_, _>(value) }))?,
+                    FunctionArgs::from_values(unsafe { std::mem::transmute::<_, _>(args) })?,
                 )
                 .map(Into::into)
             },
@@ -105,7 +105,7 @@ impl BoxedFilter {
     }
 
     /// Applies the filter to a value and argument.
-    pub fn apply_to(&self, state: &State, value: Value, args: &[Value]) -> Result<Value, Error> {
+    pub fn apply_to(&self, state: &State, value: &Value, args: &[Value]) -> Result<Value, Error> {
         (self.0)(state, value, args)
     }
 }
@@ -758,7 +758,7 @@ mod builtins {
         };
         let bx = BoxedFilter::new(test);
         assert_eq!(
-            bx.apply_to(&state, Value::from(23), &[Value::from(42)][..])
+            bx.apply_to(&state, &Value::from(23), &[Value::from(42)][..])
                 .unwrap(),
             Value::from(65)
         );
@@ -784,14 +784,14 @@ mod builtins {
         };
         let bx = BoxedFilter::new(add);
         assert_eq!(
-            bx.apply_to(&state, Value::from(23), &[Value::from(42)][..])
+            bx.apply_to(&state, &Value::from(23), &[Value::from(42)][..])
                 .unwrap(),
             Value::from(65)
         );
         assert_eq!(
             bx.apply_to(
                 &state,
-                Value::from(23),
+                &Value::from(23),
                 &[Value::from(42), Value::UNDEFINED][..]
             )
             .unwrap(),
@@ -800,7 +800,7 @@ mod builtins {
         assert_eq!(
             bx.apply_to(
                 &state,
-                Value::from(23),
+                &Value::from(23),
                 &[Value::from(42), Value::from(1)][..]
             )
             .unwrap(),

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -96,8 +96,8 @@ impl BoxedFilter {
             move |state, value, args| -> Result<Value, Error> {
                 f.apply_to(
                     state,
-                    ArgType::from_value(Some(unsafe { std::mem::transmute::<_, _>(value) }))?,
-                    FunctionArgs::from_values(unsafe { std::mem::transmute::<_, _>(args) })?,
+                    ArgType::from_value(Some(value))?,
+                    FunctionArgs::from_values(args)?,
                 )
                 .map(Into::into)
             },

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -85,7 +85,7 @@ impl BoxedFunction {
     where
         F: Function<Rv, Args>,
         Rv: Into<Value>,
-        Args: FunctionArgs,
+        Args: for<'a> FunctionArgs<'a>,
     {
         BoxedFunction(
             Arc::new(move |env, args| -> Result<Value, Error> {

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -46,7 +46,7 @@ use crate::error::Error;
 use crate::value::{FunctionArgs, Object, Value};
 use crate::vm::State;
 
-type FuncFunc = dyn Fn(&State, Vec<Value>) -> Result<Value, Error> + Sync + Send + 'static;
+type FuncFunc = dyn Fn(&State, &[Value]) -> Result<Value, Error> + Sync + Send + 'static;
 
 /// A boxed function.
 #[derive(Clone)]
@@ -97,7 +97,7 @@ impl BoxedFunction {
     }
 
     /// Invokes the function.
-    pub fn invoke(&self, state: &State, args: Vec<Value>) -> Result<Value, Error> {
+    pub fn invoke(&self, state: &State, args: &[Value]) -> Result<Value, Error> {
         (self.0)(state, args)
     }
 
@@ -128,7 +128,7 @@ impl fmt::Display for BoxedFunction {
 }
 
 impl Object for BoxedFunction {
-    fn call(&self, state: &State, args: Vec<Value>) -> Result<Value, Error> {
+    fn call(&self, state: &State, args: &[Value]) -> Result<Value, Error> {
         self.invoke(state, args)
     }
 }

--- a/minijinja/src/tests.rs
+++ b/minijinja/src/tests.rs
@@ -51,7 +51,7 @@ use crate::error::Error;
 use crate::value::{ArgType, FunctionArgs, RcType, Value};
 use crate::vm::State;
 
-type TestFunc = dyn Fn(&State, Value, &[Value]) -> Result<bool, Error> + Sync + Send + 'static;
+type TestFunc = dyn Fn(&State, &Value, &[Value]) -> Result<bool, Error> + Sync + Send + 'static;
 
 #[derive(Clone)]
 pub(crate) struct BoxedTest(RcType<TestFunc>);
@@ -88,14 +88,15 @@ impl BoxedTest {
     pub fn new<F, V, Args>(f: F) -> BoxedTest
     where
         F: Test<V, Args>,
-        V: ArgType,
-        Args: FunctionArgs,
+        V: for<'a> ArgType<'a>,
+        Args: for<'a> FunctionArgs<'a>,
     {
         BoxedTest(RcType::new(
             move |state, value, args| -> Result<bool, Error> {
+                let value = Some(value);
                 f.perform(
                     state,
-                    ArgType::from_value(Some(value))?,
+                    ArgType::from_value(value)?,
                     FunctionArgs::from_values(args)?,
                 )
             },
@@ -103,7 +104,7 @@ impl BoxedTest {
     }
 
     /// Applies the filter to a value and argument.
-    pub fn perform(&self, state: &State, value: Value, args: &[Value]) -> Result<bool, Error> {
+    pub fn perform(&self, state: &State, value: &Value, args: &[Value]) -> Result<bool, Error> {
         (self.0)(state, value, args)
     }
 }
@@ -212,7 +213,7 @@ mod builtins {
         };
         let bx = BoxedTest::new(test);
         assert!(bx
-            .perform(&state, Value::from(23), &[Value::from(23)][..])
+            .perform(&state, &Value::from(23), &[Value::from(23)][..])
             .unwrap());
     }
 }

--- a/minijinja/src/tests.rs
+++ b/minijinja/src/tests.rs
@@ -51,7 +51,7 @@ use crate::error::Error;
 use crate::value::{ArgType, FunctionArgs, RcType, Value};
 use crate::vm::State;
 
-type TestFunc = dyn Fn(&State, Value, Vec<Value>) -> Result<bool, Error> + Sync + Send + 'static;
+type TestFunc = dyn Fn(&State, Value, &[Value]) -> Result<bool, Error> + Sync + Send + 'static;
 
 #[derive(Clone)]
 pub(crate) struct BoxedTest(RcType<TestFunc>);
@@ -103,7 +103,7 @@ impl BoxedTest {
     }
 
     /// Applies the filter to a value and argument.
-    pub fn perform(&self, state: &State, value: Value, args: Vec<Value>) -> Result<bool, Error> {
+    pub fn perform(&self, state: &State, value: Value, args: &[Value]) -> Result<bool, Error> {
         (self.0)(state, value, args)
     }
 }
@@ -212,7 +212,7 @@ mod builtins {
         };
         let bx = BoxedTest::new(test);
         assert!(bx
-            .perform(&state, Value::from(23), vec![Value::from(23)])
+            .perform(&state, Value::from(23), &[Value::from(23)][..])
             .unwrap());
     }
 }

--- a/minijinja/src/value.rs
+++ b/minijinja/src/value.rs
@@ -765,39 +765,59 @@ primitive_try_from!(f64, {
     ValueRepr::F64(val) => val,
 });
 
-macro_rules! infallible_conversion {
-    ($ty:ty) => {
-        impl<'a> ArgType<'a> for $ty {
-            fn from_value(value: Option<&'a Value>) -> Result<Self, Error> {
-                match value {
-                    Some(value) => Ok(value.into()),
-                    None => Err(Error::new(
-                        ErrorKind::UndefinedError,
-                        concat!("missing argument"),
-                    )),
-                }
-            }
+impl<'a> ArgType<'a> for Value {
+    fn from_value(value: Option<&'a Value>) -> Result<Self, Error> {
+        match value {
+            Some(value) => Ok(value.clone()),
+            None => Err(Error::new(
+                ErrorKind::UndefinedError,
+                concat!("missing argument"),
+            )),
         }
-
-        impl<'a> ArgType<'a> for Option<$ty> {
-            fn from_value(value: Option<&'a Value>) -> Result<Self, Error> {
-                match value {
-                    Some(value) => {
-                        if value.is_undefined() || value.is_none() {
-                            Ok(None)
-                        } else {
-                            Ok(Some(value.clone().into()))
-                        }
-                    }
-                    None => Ok(None),
-                }
-            }
-        }
-    };
+    }
 }
 
-infallible_conversion!(String);
-infallible_conversion!(Value);
+impl<'a> ArgType<'a> for Option<Value> {
+    fn from_value(value: Option<&'a Value>) -> Result<Self, Error> {
+        match value {
+            Some(value) => {
+                if value.is_undefined() || value.is_none() {
+                    Ok(None)
+                } else {
+                    Ok(Some(value.clone()))
+                }
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+impl<'a> ArgType<'a> for String {
+    fn from_value(value: Option<&'a Value>) -> Result<Self, Error> {
+        match value {
+            Some(value) => Ok(value.to_string()),
+            None => Err(Error::new(
+                ErrorKind::UndefinedError,
+                concat!("missing argument"),
+            )),
+        }
+    }
+}
+
+impl<'a> ArgType<'a> for Option<String> {
+    fn from_value(value: Option<&'a Value>) -> Result<Self, Error> {
+        match value {
+            Some(value) => {
+                if value.is_undefined() || value.is_none() {
+                    Ok(None)
+                } else {
+                    Ok(Some(value.to_string()))
+                }
+            }
+            None => Ok(None),
+        }
+    }
+}
 
 impl From<Value> for String {
     fn from(val: Value) -> Self {

--- a/minijinja/src/vm.rs
+++ b/minijinja/src/vm.rs
@@ -404,7 +404,7 @@ impl<'vm, 'env> State<'vm, 'env> {
     pub(crate) fn apply_filter(
         &self,
         name: &str,
-        value: Value,
+        value: &Value,
         args: &[Value],
     ) -> Result<Value, Error> {
         if let Some(filter) = self.env().get_filter(name) {
@@ -420,7 +420,7 @@ impl<'vm, 'env> State<'vm, 'env> {
     pub(crate) fn perform_test(
         &self,
         name: &str,
-        value: Value,
+        value: &Value,
         args: &[Value],
     ) -> Result<bool, Error> {
         if let Some(test) = self.env().get_test(name) {
@@ -976,13 +976,15 @@ impl<'env> Vm<'env> {
                     let top = stack.pop();
                     let args = try_ctx!(top.as_slice());
                     let value = stack.pop();
-                    stack.push(try_ctx!(state.apply_filter(name, value, args)));
+                    stack.push(try_ctx!(state.apply_filter(name, &value, args)));
                 }
                 Instruction::PerformTest(name) => {
                     let top = stack.pop();
                     let args = try_ctx!(top.as_slice());
                     let value = stack.pop();
-                    stack.push(Value::from(try_ctx!(state.perform_test(name, value, args))));
+                    stack.push(Value::from(
+                        try_ctx!(state.perform_test(name, &value, args)),
+                    ));
                 }
                 Instruction::CallFunction(function_name) => {
                     let top = stack.pop();

--- a/minijinja/src/vm.rs
+++ b/minijinja/src/vm.rs
@@ -684,12 +684,12 @@ impl<'env> Vm<'env> {
                     stack.push(Value::from(map));
                 }
                 Instruction::BuildList(count) => {
-                    let mut v = Vec::new();
+                    let mut v = Vec::with_capacity(*count);
                     for _ in 0..*count {
                         v.push(stack.pop());
                     }
                     v.reverse();
-                    stack.push(v.into());
+                    stack.push(Value(ValueRepr::Seq(RcType::new(v))));
                 }
                 Instruction::UnpackList(count) => {
                     let top = stack.pop();

--- a/minijinja/src/vm.rs
+++ b/minijinja/src/vm.rs
@@ -64,21 +64,22 @@ impl Object for LoopState {
         }
     }
 
-    fn call(&self, _state: &State, _args: Vec<Value>) -> Result<Value, Error> {
+    fn call(&self, _state: &State, _args: &[Value]) -> Result<Value, Error> {
         Err(Error::new(
             ErrorKind::ImpossibleOperation,
             "loop cannot be called if reassigned to different variable",
         ))
     }
 
-    fn call_method(&self, _state: &State, name: &str, args: Vec<Value>) -> Result<Value, Error> {
+    fn call_method(&self, _state: &State, name: &str, args: &[Value]) -> Result<Value, Error> {
         #[cfg(feature = "sync")]
         {
             if name == "changed" {
                 let mut last_changed_value = self.last_changed_value.lock().unwrap();
-                let changed = last_changed_value.as_ref() != Some(&args);
+                let value = args.to_owned();
+                let changed = last_changed_value.as_ref() != Some(&value);
                 if changed {
-                    *last_changed_value = Some(args);
+                    *last_changed_value = Some(value);
                     return Ok(Value::from(true));
                 }
                 return Ok(Value::from(false));
@@ -404,7 +405,7 @@ impl<'vm, 'env> State<'vm, 'env> {
         &self,
         name: &str,
         value: Value,
-        args: Vec<Value>,
+        args: &[Value],
     ) -> Result<Value, Error> {
         if let Some(filter) = self.env().get_filter(name) {
             filter.apply_to(self, value, args)
@@ -420,7 +421,7 @@ impl<'vm, 'env> State<'vm, 'env> {
         &self,
         name: &str,
         value: Value,
-        args: Vec<Value>,
+        args: &[Value],
     ) -> Result<bool, Error> {
         if let Some(test) = self.env().get_test(name) {
             test.perform(self, value, args)
@@ -972,17 +973,20 @@ impl<'env> Vm<'env> {
                     end_capture!();
                 }
                 Instruction::ApplyFilter(name) => {
-                    let args = try_ctx!(stack.pop().try_into_vec());
+                    let top = stack.pop();
+                    let args = try_ctx!(top.as_slice());
                     let value = stack.pop();
                     stack.push(try_ctx!(state.apply_filter(name, value, args)));
                 }
                 Instruction::PerformTest(name) => {
-                    let args = try_ctx!(stack.pop().try_into_vec());
+                    let top = stack.pop();
+                    let args = try_ctx!(top.as_slice());
                     let value = stack.pop();
                     stack.push(Value::from(try_ctx!(state.perform_test(name, value, args))));
                 }
                 Instruction::CallFunction(function_name) => {
-                    let args = try_ctx!(stack.pop().try_into_vec());
+                    let top = stack.pop();
+                    let args = try_ctx!(top.as_slice());
                     // super is a special function reserved for super-ing into blocks.
                     if *function_name == "super" {
                         if !args.is_empty() {
@@ -1000,7 +1004,7 @@ impl<'env> Vm<'env> {
                                 format!("loop() takes one argument, got {}", args.len())
                             ));
                         }
-                        stack.push(args.into_iter().next().unwrap());
+                        stack.push(args[0].clone());
                         recurse_loop!(true);
                     } else if let Some(func) = state.ctx.load(self.env, function_name) {
                         stack.push(try_ctx!(func.call(state, args)));
@@ -1012,12 +1016,14 @@ impl<'env> Vm<'env> {
                     }
                 }
                 Instruction::CallMethod(name) => {
-                    let args = try_ctx!(stack.pop().try_into_vec());
+                    let top = stack.pop();
+                    let args = try_ctx!(top.as_slice());
                     let obj = stack.pop();
                     stack.push(try_ctx!(obj.call_method(state, name, args)));
                 }
                 Instruction::CallObject => {
-                    let args = try_ctx!(stack.pop().try_into_vec());
+                    let top = stack.pop();
+                    let args = try_ctx!(top.as_slice());
                     let obj = stack.pop();
                     stack.push(try_ctx!(obj.call(state, args)));
                 }


### PR DESCRIPTION
This is a change to MiniJinja which changes the traits for filters, functions and tests to take values by reference. This in theory should allow borrowing out of the value (#97) but the lack of GATs in Rust does not actually make this possible yet.

This is a breaking change because some of this functionality is exposed to user code (eg: via `Object`).