### PR TITLE
Remove vendored matches macro

### DIFF
--- a/minijinja/src/compiler.rs
+++ b/minijinja/src/compiler.rs
@@ -6,7 +6,6 @@ use crate::instructions::{
     Instruction, Instructions, LOOP_FLAG_RECURSIVE, LOOP_FLAG_WITH_LOOP_VAR,
 };
 use crate::tokens::Span;
-use crate::utils::matches;
 use crate::value::Value;
 
 #[cfg(test)]

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -190,7 +190,6 @@ mod builtins {
     use super::*;
 
     use crate::error::ErrorKind;
-    use crate::utils::matches;
     use crate::value::{ValueKind, ValueRepr};
     use std::borrow::Cow;
     use std::fmt::Write;

--- a/minijinja/src/lexer.rs
+++ b/minijinja/src/lexer.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use crate::error::{Error, ErrorKind};
 use crate::tokens::{Span, Token};
-use crate::utils::{matches, memchr, memstr, unescape};
+use crate::utils::{memchr, memstr, unescape};
 
 #[cfg(test)]
 use similar_asserts::assert_eq;

--- a/minijinja/src/parser.rs
+++ b/minijinja/src/parser.rs
@@ -2,7 +2,6 @@ use crate::ast::{self, Spanned};
 use crate::error::{Error, ErrorKind};
 use crate::lexer::tokenize;
 use crate::tokens::{Span, Token};
-use crate::utils::matches;
 use crate::value::Value;
 
 const RESERVED_NAMES: [&str; 8] = [

--- a/minijinja/src/tests.rs
+++ b/minijinja/src/tests.rs
@@ -134,7 +134,6 @@ mod builtins {
 
     use std::convert::TryFrom;
 
-    use crate::utils::matches;
     use crate::value::ValueKind;
 
     /// Checks if a value is odd.

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -9,17 +9,6 @@ use crate::error::{Error, ErrorKind};
 #[cfg(test)]
 use similar_asserts::assert_eq;
 
-// we target Rust 1.41 and that does not have this macro yet
-macro_rules! _matches {
-    ($expression:expr, $( $pattern:pat )|+ $( if $guard: expr )? $(,)?) => {
-        match $expression {
-            $( $pattern )|+ $( if $guard )? => true,
-            _ => false
-        }
-    }
-}
-pub(crate) use _matches as matches;
-
 pub fn memchr(haystack: &[u8], needle: u8) -> Option<usize> {
     haystack.iter().position(|&x| x == needle)
 }

--- a/minijinja/src/value.rs
+++ b/minijinja/src/value.rs
@@ -78,7 +78,7 @@ use serde::ser::{self, Serialize, Serializer};
 
 use crate::error::{Error, ErrorKind};
 use crate::key::{Key, KeySerializer};
-use crate::utils::{matches, OnDrop};
+use crate::utils::OnDrop;
 use crate::vm::State;
 
 #[cfg(test)]

--- a/minijinja/src/vm.rs
+++ b/minijinja/src/vm.rs
@@ -10,7 +10,6 @@ use crate::instructions::{
     Instruction, Instructions, LOOP_FLAG_RECURSIVE, LOOP_FLAG_WITH_LOOP_VAR,
 };
 use crate::key::Key;
-use crate::utils::matches;
 use crate::value::{self, Object, RcType, Value, ValueIterator, ValueRepr};
 use crate::AutoEscape;
 


### PR DESCRIPTION
This is not needed any longer as our minimal rust version ships it.