### PR TITLE
Add borrow support for filter arguments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,32 +17,34 @@ jobs:
       - name: Test
         run: make test
 
-  build-old-stable:
-    name: Build on 1.45.0
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.45.0
-          profile: minimal
-          override: true
-      - name: Build
-        run: cargo build --features=unstable_machinery,builtins,source,json,urlencode,debug,internal_debug
-        working-directory: ./minijinja
-        env:
-          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-          CARGO_HTTP_MULTIPLEXING: "false"
+  ## Bugs in older Rust versions for some of our borrowing logic for filters
+  ## No longer makes supporting this Rust version possible
+  # build-old-stable:
+  #   name: Build on 1.45.0
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: 1.45.0
+  #         profile: minimal
+  #         override: true
+  #     - name: Build
+  #       run: cargo build --features=unstable_machinery,builtins,source,json,urlencode,debug,internal_debug
+  #       working-directory: ./minijinja
+  #       env:
+  #         CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  #         CARGO_HTTP_MULTIPLEXING: "false"
 
   test-stable:
-    name: Test on 1.56.1
+    name: Test on 1.61.0
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.56.1
+          toolchain: 1.61.0
           profile: minimal
           override: true
       - name: Test

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/mitsuhiko/minijinja/workflows/Tests/badge.svg?branch=main)](https://github.com/mitsuhiko/minijinja/actions?query=workflow%3ATests)
 [![License](https://img.shields.io/github/license/mitsuhiko/minijinja)](https://github.com/mitsuhiko/minijinja/blob/main/LICENSE)
 [![Crates.io](https://img.shields.io/crates/d/minijinja.svg)](https://crates.io/crates/minijinja)
-[![rustc 1.45.0](https://img.shields.io/badge/rust-1.45%2B-orange.svg)](https://img.shields.io/badge/rust-1.45%2B-orange.svg)
+[![rustc 1.61.0](https://img.shields.io/badge/rust-1.61%2B-orange.svg)](https://img.shields.io/badge/rust-1.61%2B-orange.svg)
 [![Documentation](https://docs.rs/minijinja/badge.svg)](https://docs.rs/minijinja)
 
 </div>
@@ -63,9 +63,12 @@ fn main() {
 
 ## Minimum Rust Version
 
-MiniJinja supports Rust versions down to 1.45 at the moment.  For the order
-preservation feature Rust 1.49 is required as it uses the indexmap dependency
-which no longer supports older Rust versions.
+MiniJinja's development version requires Rust 1.61 due to limitations with
+HRTBs in older Rust versions.
+
+MiniJinja 0.20 supports Rust versions down to 1.45.  It is possible to write
+code that is compatible with both 0.20 and newer versions of MiniJinja which
+should make it possible to defer the upgrade to later.
 
 ## Sponsor
 

--- a/examples/dynamic/src/main.rs
+++ b/examples/dynamic/src/main.rs
@@ -2,7 +2,7 @@
 use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use minijinja::value::{parse_args, Object, Value};
+use minijinja::value::{from_args, Object, Value};
 use minijinja::{Environment, Error, State};
 
 #[derive(Debug)]
@@ -20,7 +20,7 @@ impl fmt::Display for Cycler {
 impl Object for Cycler {
     fn call(&self, _state: &State, args: &[Value]) -> Result<Value, Error> {
         // we don't want any args
-        parse_args(args)?;
+        from_args(args)?;
         let idx = self.idx.fetch_add(1, Ordering::Relaxed);
         Ok(self.values[idx % self.values.len()].clone())
     }
@@ -46,7 +46,7 @@ impl Object for Magic {
     fn call_method(&self, _state: &State, name: &str, args: &[Value]) -> Result<Value, Error> {
         if name == "make_class" {
             // single string argument
-            let (tag,): (&str,) = parse_args(args)?;
+            let (tag,): (&str,) = from_args(args)?;
             Ok(Value::from(format!("magic-{}", tag)))
         } else {
             Err(Error::new(

--- a/examples/dynamic/src/main.rs
+++ b/examples/dynamic/src/main.rs
@@ -2,7 +2,7 @@
 use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use minijinja::value::{FunctionArgs, Object, Value};
+use minijinja::value::{parse_args, Object, Value};
 use minijinja::{Environment, Error, State};
 
 #[derive(Debug)]
@@ -19,7 +19,8 @@ impl fmt::Display for Cycler {
 
 impl Object for Cycler {
     fn call(&self, _state: &State, args: &[Value]) -> Result<Value, Error> {
-        let _: () = FunctionArgs::from_values(args)?;
+        // we don't want any args
+        parse_args::<()>(args)?;
         let idx = self.idx.fetch_add(1, Ordering::Relaxed);
         Ok(self.values[idx % self.values.len()].clone())
     }
@@ -44,7 +45,8 @@ impl fmt::Display for Magic {
 impl Object for Magic {
     fn call_method(&self, _state: &State, name: &str, args: &[Value]) -> Result<Value, Error> {
         if name == "make_class" {
-            let (tag,): (String,) = FunctionArgs::from_values(args)?;
+            // single string argument
+            let (tag,): (&str,) = parse_args(args)?;
             Ok(Value::from(format!("magic-{}", tag)))
         } else {
             Err(Error::new(

--- a/examples/dynamic/src/main.rs
+++ b/examples/dynamic/src/main.rs
@@ -20,7 +20,7 @@ impl fmt::Display for Cycler {
 impl Object for Cycler {
     fn call(&self, _state: &State, args: &[Value]) -> Result<Value, Error> {
         // we don't want any args
-        parse_args::<()>(args)?;
+        parse_args(args)?;
         let idx = self.idx.fetch_add(1, Ordering::Relaxed);
         Ok(self.values[idx % self.values.len()].clone())
     }

--- a/minijinja/src/compiler/codegen.rs
+++ b/minijinja/src/compiler/codegen.rs
@@ -412,7 +412,7 @@ impl<'source> CodeGenerator<'source> {
                 for arg in &f.args {
                     self.compile_expr(arg)?;
                 }
-                self.add(Instruction::BuildList(f.args.len()));
+                self.add(Instruction::BuildList(f.args.len() + 1));
                 self.add(Instruction::ApplyFilter(f.name));
             }
             ast::Expr::Test(f) => {

--- a/minijinja/src/defaults.rs
+++ b/minijinja/src/defaults.rs
@@ -118,6 +118,7 @@ pub(crate) fn get_builtin_filters() -> BTreeMap<&'static str, filters::BoxedFilt
             rv.insert("urlencode", BoxedFilter::new(filters::urlencode));
         }
     }
+
     rv
 }
 
@@ -151,5 +152,6 @@ pub(crate) fn get_globals() -> BTreeMap<&'static str, Value> {
         rv.insert("dict", BoxedFunction::new(functions::dict).to_value());
         rv.insert("debug", BoxedFunction::new(functions::debug).to_value());
     }
+
     rv
 }

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -363,7 +363,12 @@ impl<'source> Environment<'source> {
     /// [`Filter`](crate::filters::Filter).
     pub fn add_filter<F, V, Rv, Args>(&mut self, name: &'source str, f: F)
     where
-        F: filters::Filter<V, Rv, Args>,
+        F: filters::Filter<V, Rv, Args>
+            + for<'a> filters::Filter<
+                <V as ArgType<'a>>::Output,
+                Rv,
+                <Args as FunctionArgs<'a>>::Output,
+            > + 'static,
         V: for<'a> ArgType<'a>,
         Rv: FunctionResult,
         Args: for<'a> FunctionArgs<'a>,
@@ -383,9 +388,11 @@ impl<'source> Environment<'source> {
     /// have a look at [`Test`](crate::tests::Test).
     pub fn add_test<F, V, Rv, Args>(&mut self, name: &'source str, f: F)
     where
+        F: tests::Test<V, Rv, Args>
+            + for<'a> tests::Test<<V as ArgType<'a>>::Output, Rv, <Args as FunctionArgs<'a>>::Output>
+            + 'static,
         V: for<'a> ArgType<'a>,
         Rv: tests::TestResult,
-        F: tests::Test<V, Rv, Args>,
         Args: for<'a> FunctionArgs<'a>,
     {
         self.tests.insert(name, tests::BoxedTest::new(f));
@@ -402,8 +409,10 @@ impl<'source> Environment<'source> {
     /// functions and other global variables share the same namespace.
     pub fn add_function<F, Rv, Args>(&mut self, name: &'source str, f: F)
     where
+        F: functions::Function<Rv, Args>
+            + for<'a> functions::Function<Rv, <Args as FunctionArgs<'a>>::Output>
+            + 'static,
         Rv: FunctionResult,
-        F: functions::Function<Rv, Args>,
         Args: for<'a> FunctionArgs<'a>,
     {
         self.add_global(name, functions::BoxedFunction::new(f).to_value());

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -361,16 +361,11 @@ impl<'source> Environment<'source> {
     /// Filter functions are functions that can be applied to values in
     /// templates.  For details about filters have a look at
     /// [`Filter`](crate::filters::Filter).
-    pub fn add_filter<F, Rv, V, Args>(&mut self, name: &'source str, f: F)
+    pub fn add_filter<F, Rv, Args>(&mut self, name: &'source str, f: F)
     where
         // the crazy bounds here exist to enable borrowing in closures
-        F: filters::Filter<Rv, V, Args>
-            + for<'a> filters::Filter<
-                Rv,
-                <V as ArgType<'a>>::Output,
-                <Args as FunctionArgs<'a>>::Output,
-            >,
-        V: for<'a> ArgType<'a>,
+        F: filters::Filter<Rv, Args>
+            + for<'a> filters::Filter<Rv, <Args as FunctionArgs<'a>>::Output>,
         Rv: FunctionResult,
         Args: for<'a> FunctionArgs<'a>,
     {

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -368,7 +368,7 @@ impl<'source> Environment<'source> {
                 <V as ArgType<'a>>::Output,
                 Rv,
                 <Args as FunctionArgs<'a>>::Output,
-            > + 'static,
+            >,
         V: for<'a> ArgType<'a>,
         Rv: FunctionResult,
         Args: for<'a> FunctionArgs<'a>,
@@ -389,8 +389,7 @@ impl<'source> Environment<'source> {
     pub fn add_test<F, V, Rv, Args>(&mut self, name: &'source str, f: F)
     where
         F: tests::Test<V, Rv, Args>
-            + for<'a> tests::Test<<V as ArgType<'a>>::Output, Rv, <Args as FunctionArgs<'a>>::Output>
-            + 'static,
+            + for<'a> tests::Test<<V as ArgType<'a>>::Output, Rv, <Args as FunctionArgs<'a>>::Output>,
         V: for<'a> ArgType<'a>,
         Rv: tests::TestResult,
         Args: for<'a> FunctionArgs<'a>,
@@ -410,8 +409,7 @@ impl<'source> Environment<'source> {
     pub fn add_function<F, Rv, Args>(&mut self, name: &'source str, f: F)
     where
         F: functions::Function<Rv, Args>
-            + for<'a> functions::Function<Rv, <Args as FunctionArgs<'a>>::Output>
-            + 'static,
+            + for<'a> functions::Function<Rv, <Args as FunctionArgs<'a>>::Output>,
         Rv: FunctionResult,
         Args: for<'a> FunctionArgs<'a>,
     {

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -181,8 +181,7 @@ impl BoxedFilter {
     pub fn new<F, V, Rv, Args>(f: F) -> BoxedFilter
     where
         F: Filter<V, Rv, Args>
-            + for<'a> Filter<<V as ArgType<'a>>::Output, Rv, <Args as FunctionArgs<'a>>::Output>
-            + 'static,
+            + for<'a> Filter<<V as ArgType<'a>>::Output, Rv, <Args as FunctionArgs<'a>>::Output>,
         V: for<'a> ArgType<'a>,
         Rv: FunctionResult,
         Args: for<'a> FunctionArgs<'a>,

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -155,7 +155,7 @@ impl BoxedFunction {
     /// Creates a new boxed filter.
     pub fn new<F, Rv, Args>(f: F) -> BoxedFunction
     where
-        F: Function<Rv, Args> + for<'a> Function<Rv, <Args as FunctionArgs<'a>>::Output> + 'static,
+        F: Function<Rv, Args> + for<'a> Function<Rv, <Args as FunctionArgs<'a>>::Output>,
         Rv: FunctionResult,
         Args: for<'a> FunctionArgs<'a>,
     {

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -78,8 +78,8 @@ pub(crate) struct BoxedFunction(Arc<FuncFunc>, &'static str);
 ///
 /// The parameters can be marked optional by using `Option<T>`.  The last
 /// argument can also use [`Rest<T>`](crate::value::Rest) to capture the
-/// remaining arguments.  All types are supported for which [`ArgType`] is
-/// implemented.
+/// remaining arguments.  All types are supported for which
+/// [`ArgType`](crate::value::ArgType) is implemented.
 ///
 /// For a list of built-in functions see [`functions`](crate::functions).
 ///

--- a/minijinja/src/tests.rs
+++ b/minijinja/src/tests.rs
@@ -183,7 +183,9 @@ impl BoxedTest {
     /// Creates a new boxed filter.
     pub fn new<F, V, Rv, Args>(f: F) -> BoxedTest
     where
-        F: Test<V, Rv, Args>,
+        F: Test<V, Rv, Args>
+            + for<'a> Test<<V as ArgType<'a>>::Output, Rv, <Args as FunctionArgs<'a>>::Output>
+            + 'static,
         V: for<'a> ArgType<'a>,
         Rv: TestResult,
         Args: for<'a> FunctionArgs<'a>,
@@ -192,8 +194,8 @@ impl BoxedTest {
             let value = Some(value);
             f.perform(
                 state,
-                ArgType::from_value(value)?,
-                FunctionArgs::from_values(args)?,
+                V::from_value(value)?,
+                Args::from_values(args)?,
                 SealedMarker,
             )
             .into_result()

--- a/minijinja/src/tests.rs
+++ b/minijinja/src/tests.rs
@@ -184,8 +184,7 @@ impl BoxedTest {
     pub fn new<F, V, Rv, Args>(f: F) -> BoxedTest
     where
         F: Test<V, Rv, Args>
-            + for<'a> Test<<V as ArgType<'a>>::Output, Rv, <Args as FunctionArgs<'a>>::Output>
-            + 'static,
+            + for<'a> Test<<V as ArgType<'a>>::Output, Rv, <Args as FunctionArgs<'a>>::Output>,
         V: for<'a> ArgType<'a>,
         Rv: TestResult,
         Args: for<'a> FunctionArgs<'a>,

--- a/minijinja/src/tests.rs
+++ b/minijinja/src/tests.rs
@@ -212,6 +212,7 @@ impl BoxedTest {
 mod builtins {
     use super::*;
 
+    use std::borrow::Cow;
     use std::convert::TryFrom;
 
     use crate::value::ValueKind;
@@ -266,14 +267,14 @@ mod builtins {
 
     /// Checks if the value is starting with a string.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_startingwith(_state: &State, v: String, other: String) -> bool {
-        v.starts_with(&other)
+    pub fn is_startingwith(_state: &State, v: Cow<'_, str>, other: Cow<'_, str>) -> bool {
+        v.starts_with(&other as &str)
     }
 
     /// Checks if the value is ending with a string.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_endingwith(_state: &State, v: String, other: String) -> bool {
-        v.ends_with(&other)
+    pub fn is_endingwith(_state: &State, v: Cow<'_, str>, other: Cow<'_, str>) -> bool {
+        v.ends_with(&other as &str)
     }
 
     #[test]

--- a/minijinja/src/value/argtypes.rs
+++ b/minijinja/src/value/argtypes.rs
@@ -40,7 +40,8 @@ impl<I: Into<Value>> FunctionResult for I {
 /// arity of 4 parameters.
 ///
 /// For each argument the conversion is performed via the [`ArgType`]
-/// trait which is implemented for many common types.
+/// trait which is implemented for many common types.  For manual
+/// conversions the [`from_args`] utility should be used.
 pub trait FunctionArgs<'a> {
     type Output;
 
@@ -56,17 +57,17 @@ pub trait FunctionArgs<'a> {
 /// implementing [`Object::call_method`](crate::value::Object::call_method).
 ///
 /// ```
-/// use minijinja::value::parse_args;
+/// use minijinja::value::from_args;
 /// # use minijinja::value::Value;
 /// # fn foo() -> Result<(), minijinja::Error> {
 /// # let args = vec![Value::from("foo"), Value::from(42i64)]; let args = &args[..];
 ///
 /// // args is &[Value]
-/// let (string, num): (&str, i64) = parse_args(args)?;
+/// let (string, num): (&str, i64) = from_args(args)?;
 /// # Ok(()) } fn main() { foo().unwrap(); }
 /// ```
 #[inline(always)]
-pub fn parse_args<'a, Args>(values: &'a [Value]) -> Result<Args, Error>
+pub fn from_args<'a, Args>(values: &'a [Value]) -> Result<Args, Error>
 where
     Args: FunctionArgs<'a, Output = Args>,
 {
@@ -81,9 +82,9 @@ where
 ///
 /// * unsigned integers: [`u8`], [`u16`], [`u32`], [`u64`], [`u128`], [`usize`]
 /// * signed integers: [`i8`], [`i16`], [`i32`], [`i64`], [`i128`]
-/// * floats: [`f64`]
+/// * floats: [`f32`], [`f64`]
 /// * bool: [`bool`]
-/// * string: [`String`], [`&str`], `Cow<'_, str>`
+/// * string: [`String`], [`&str`], `Cow<'_, str>` ([`char`])
 /// * values: [`Value`], `&Value`
 /// * vectors: [`Vec<T>`], `&[Value]`
 ///
@@ -333,7 +334,12 @@ primitive_int_try_from!(usize);
 primitive_try_from!(bool, {
     ValueRepr::Bool(val) => val,
 });
-
+primitive_try_from!(char, {
+    ValueRepr::Char(val) => val,
+});
+primitive_try_from!(f32, {
+    ValueRepr::F64(val) => val as f32,
+});
 primitive_try_from!(f64, {
     ValueRepr::F64(val) => val,
 });

--- a/minijinja/src/value/argtypes.rs
+++ b/minijinja/src/value/argtypes.rs
@@ -446,10 +446,12 @@ impl<T> DerefMut for Rest<T> {
 impl<'a, T: ArgType<'a, Output = T>> ArgType<'a> for Rest<T> {
     type Output = Self;
 
-    fn from_value(_value: Option<&'a Value>) -> Result<Self, Error> {
-        Err(Error::new(
-            ErrorKind::ImpossibleOperation,
-            "cannot collect remaining arguments in this argument position",
+    fn from_value(value: Option<&'a Value>) -> Result<Self, Error> {
+        Ok(Rest(
+            value
+                .iter()
+                .map(|v| T::from_value(Some(v)))
+                .collect::<Result<_, _>>()?,
         ))
     }
 

--- a/minijinja/src/value/argtypes.rs
+++ b/minijinja/src/value/argtypes.rs
@@ -42,7 +42,6 @@ impl<I: Into<Value>> FunctionResult for I {
 /// For each argument the conversion is performed via the [`ArgType`]
 /// trait which is implemented for many common types.
 pub trait FunctionArgs<'a> {
-    #[doc(hidden)]
     type Output;
 
     /// Converts to function arguments from a slice of values.
@@ -61,6 +60,8 @@ pub trait FunctionArgs<'a> {
 /// # use minijinja::value::Value;
 /// # fn foo() -> Result<(), minijinja::Error> {
 /// # let args = vec![Value::from("foo"), Value::from(42i64)]; let args = &args[..];
+///
+/// // args is &[Value]
 /// let (string, num): (&str, i64) = parse_args(args)?;
 /// # Ok(()) } fn main() { foo().unwrap(); }
 /// ```
@@ -97,7 +98,6 @@ where
 /// it's implemented for [`Rest<T>`] which is used to encode the remaining arguments
 /// of a function call.
 pub trait ArgType<'a> {
-    #[doc(hidden)]
     type Output;
 
     #[doc(hidden)]

--- a/minijinja/src/value/argtypes.rs
+++ b/minijinja/src/value/argtypes.rs
@@ -42,10 +42,34 @@ impl<I: Into<Value>> FunctionResult for I {
 /// For each argument the conversion is performed via the [`ArgType`]
 /// trait which is implemented for many common types.
 pub trait FunctionArgs<'a> {
+    #[doc(hidden)]
     type Output;
 
     /// Converts to function arguments from a slice of values.
+    #[doc(hidden)]
     fn from_values(values: &'a [Value]) -> Result<Self::Output, Error>;
+}
+
+/// Utility function to convert a slice of values into arguments.
+///
+/// This performs the same conversion that [`Function`](crate::functions::Function)
+/// performs.  It exists so that you one can leverage the same functionality when
+/// implementing [`Object::call_method`](crate::value::Object::call_method).
+///
+/// ```
+/// use minijinja::value::parse_args;
+/// # use minijinja::value::Value;
+/// # fn foo() -> Result<(), minijinja::Error> {
+/// # let args = vec![Value::from("foo"), Value::from(42i64)]; let args = &args[..];
+/// let (string, num): (&str, i64) = parse_args(args)?;
+/// # Ok(()) } fn main() { foo().unwrap(); }
+/// ```
+#[inline(always)]
+pub fn parse_args<'a, Args>(values: &'a [Value]) -> Result<Args, Error>
+where
+    Args: FunctionArgs<'a, Output = Args>,
+{
+    Args::from_values(values)
 }
 
 /// A trait implemented by all filter/test argument types.
@@ -73,6 +97,7 @@ pub trait FunctionArgs<'a> {
 /// it's implemented for [`Rest<T>`] which is used to encode the remaining arguments
 /// of a function call.
 pub trait ArgType<'a> {
+    #[doc(hidden)]
     type Output;
 
     #[doc(hidden)]

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -83,7 +83,7 @@ use crate::utils::OnDrop;
 use crate::value::serialize::ValueSerializer;
 use crate::vm::State;
 
-pub use crate::value::argtypes::{parse_args, ArgType, FunctionArgs, FunctionResult, Rest};
+pub use crate::value::argtypes::{from_args, ArgType, FunctionArgs, FunctionResult, Rest};
 pub use crate::value::object::Object;
 
 mod argtypes;

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -83,7 +83,7 @@ use crate::utils::OnDrop;
 use crate::value::serialize::ValueSerializer;
 use crate::vm::State;
 
-pub use crate::value::argtypes::{ArgType, FunctionArgs, FunctionResult, Rest};
+pub use crate::value::argtypes::{parse_args, ArgType, FunctionArgs, FunctionResult, Rest};
 pub use crate::value::object::Object;
 
 mod argtypes;

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -50,7 +50,7 @@ pub trait Object: fmt::Display + fmt::Debug + Any + Sync + Send {
     /// error is generated if an invalid method is invoked.
     ///
     /// To convert the arguments into arguments use the
-    /// [`parse_args`](crate::value::parse_args) function.
+    /// [`from_args`](crate::value::from_args) function.
     fn call_method(&self, state: &State, name: &str, args: &[Value]) -> Result<Value, Error> {
         let _state = state;
         let _args = args;
@@ -66,7 +66,7 @@ pub trait Object: fmt::Display + fmt::Debug + Any + Sync + Send {
     /// cannot be invoked.
     ///
     /// To convert the arguments into arguments use the
-    /// [`parse_args`](crate::value::parse_args) function.
+    /// [`from_args`](crate::value::from_args) function.
     fn call(&self, state: &State, args: &[Value]) -> Result<Value, Error> {
         let _state = state;
         let _args = args;

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -48,6 +48,9 @@ pub trait Object: fmt::Display + fmt::Debug + Any + Sync + Send {
     ///
     /// It's the responsibility of the implementer to ensure that an
     /// error is generated if an invalid method is invoked.
+    ///
+    /// To convert the arguments into arguments use the
+    /// [`parse_args`](crate::value::parse_args) function.
     fn call_method(&self, state: &State, name: &str, args: &[Value]) -> Result<Value, Error> {
         let _state = state;
         let _args = args;
@@ -61,6 +64,9 @@ pub trait Object: fmt::Display + fmt::Debug + Any + Sync + Send {
     ///
     /// The default implementation just generates an error that the object
     /// cannot be invoked.
+    ///
+    /// To convert the arguments into arguments use the
+    /// [`parse_args`](crate::value::parse_args) function.
     fn call(&self, state: &State, args: &[Value]) -> Result<Value, Error> {
         let _state = state;
         let _args = args;

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -314,8 +314,7 @@ impl<'env> Vm<'env> {
                 Instruction::ApplyFilter(name) => {
                     let top = stack.pop();
                     let args = try_ctx!(top.as_slice());
-                    let value = stack.pop();
-                    stack.push(try_ctx!(state.apply_filter(name, &value, args)));
+                    stack.push(try_ctx!(state.apply_filter(name, args)));
                 }
                 Instruction::PerformTest(name) => {
                     let top = stack.pop();

--- a/minijinja/src/vm/state.rs
+++ b/minijinja/src/vm/state.rs
@@ -80,14 +80,9 @@ impl<'vm, 'env, 'out, 'buf> State<'vm, 'env, 'out, 'buf> {
         })
     }
 
-    pub(crate) fn apply_filter(
-        &self,
-        name: &str,
-        value: &Value,
-        args: &[Value],
-    ) -> Result<Value, Error> {
+    pub(crate) fn apply_filter(&self, name: &str, args: &[Value]) -> Result<Value, Error> {
         if let Some(filter) = self.env.get_filter(name) {
-            filter.apply_to(self, value, args)
+            filter.apply_to(self, args)
         } else {
             Err(Error::new(
                 ErrorKind::UnknownFilter,


### PR DESCRIPTION
This allows borrowing for `&str` and `&Value`. It's a backwards incompatible change because `FunctionArgs::from_values` no longer works. I have hidden these implementations now and added a `from_args` utility as replacement.

This appears to currently require Rust 1.61.0

Fixes #97