### PR TITLE
Allow optional borrowing of State

### DIFF
--- a/benchmarks/inputs/all_elements.html
+++ b/benchmarks/inputs/all_elements.html
@@ -10,7 +10,7 @@
     <nav>
       <ul class="nav">
         {% for item in site.nav %}
-          <li><a href="{{ item.url }}"{% if item.is_active %} class="active"{% endif %}>{{ item.title }}</a>
+          <li><a href="{{ item.url }}"{% if item.is_active %} class="active"{% endif %}>{{ item.title|upper }}</a>
         {% endfor %}
       </ul>
     </nav>
@@ -19,7 +19,7 @@
     {% block body %}
       <ul>
       {% for item in items %}
-        <li>{{ loop.index }}: {{ item }}</li>
+        <li>{{ loop.index }}: {{ item|upper }}</li>
       {% endfor %}
       </ul>
     {% endblock %}

--- a/examples/filters/src/main.rs
+++ b/examples/filters/src/main.rs
@@ -1,7 +1,7 @@
 use minijinja::value::Value;
-use minijinja::{context, Environment, State};
+use minijinja::{context, Environment};
 
-fn slugify(_state: &State, value: String) -> String {
+fn slugify(value: String) -> String {
     value
         .to_lowercase()
         .split_whitespace()
@@ -9,7 +9,7 @@ fn slugify(_state: &State, value: String) -> String {
         .join("-")
 }
 
-fn get_nav(_state: &State) -> Value {
+fn get_nav() -> Value {
     vec![
         context! { href => "/", title => "Index" },
         context! { href => "/downloads", title => "Downloads" },
@@ -21,6 +21,7 @@ fn get_nav(_state: &State) -> Value {
 fn main() {
     let mut env = Environment::new();
     env.add_filter("slugify", slugify);
+    env.add_filter("repeat", str::repeat);
     env.add_function("get_nav", get_nav);
     env.add_template("template.html", include_str!("template.html"))
         .unwrap();

--- a/examples/filters/src/template.html
+++ b/examples/filters/src/template.html
@@ -6,6 +6,9 @@
   <li><a href="{{ item.href }}">{{ item.title|upper }}</a></li>
 {%- endfor %}
 </ul>
+<pre>
+  {{ "-*- "|repeat(10) }}
+</pre>
 <footer>
   &copy; Copyright {{ year }}
 </footer>

--- a/minijinja/src/defaults.rs
+++ b/minijinja/src/defaults.rs
@@ -32,7 +32,7 @@ pub fn default_auto_escape_callback(name: &str) -> AutoEscape {
 /// The default formatter.
 ///
 /// This formatter takes a value and directly writes it into the output format
-/// while honoring the requested auto escape format of the output.  If the
+/// while honoring the requested auto escape format of the state.  If the
 /// value is already marked as safe, it's handled as if no auto escaping
 /// was requested.
 ///

--- a/minijinja/src/defaults.rs
+++ b/minijinja/src/defaults.rs
@@ -1,25 +1,12 @@
 use std::collections::BTreeMap;
-use std::fmt;
 
-use crate::error::{Error, ErrorKind};
+use crate::error::Error;
 use crate::filters::{self, BoxedFilter};
 use crate::output::Output;
 use crate::tests::BoxedTest;
-use crate::utils::{AutoEscape, HtmlEscape};
-use crate::value::{Value, ValueKind};
-
-fn write_with_html_escaping(out: &mut Output, value: &Value) -> fmt::Result {
-    if matches!(
-        value.kind(),
-        ValueKind::Undefined | ValueKind::None | ValueKind::Bool | ValueKind::Number
-    ) {
-        write!(out, "{}", value)
-    } else if let Some(s) = value.as_str() {
-        write!(out, "{}", HtmlEscape(s))
-    } else {
-        write!(out, "{}", HtmlEscape(&value.to_string()))
-    }
-}
+use crate::utils::{write_escaped, AutoEscape};
+use crate::value::Value;
+use crate::vm::State;
 
 pub(crate) fn no_auto_escape(_: &str) -> AutoEscape {
     AutoEscape::None
@@ -56,29 +43,8 @@ pub fn default_auto_escape_callback(name: &str) -> AutoEscape {
 )]
 /// * [`None`](AutoEscape::None): no escaping
 /// * [`Custom(..)`](AutoEscape::Custom): results in an error
-pub fn escape_formatter(out: &mut Output, value: &Value) -> Result<(), Error> {
-    match (value.is_safe(), out.auto_escape()) {
-        // safe values do not get escaped
-        (true, _) | (_, AutoEscape::None) => write!(out, "{}", value)?,
-        (false, AutoEscape::Html) => write_with_html_escaping(out, value)?,
-        #[cfg(feature = "json")]
-        (false, AutoEscape::Json) => {
-            let value = serde_json::to_string(&value).map_err(|err| {
-                Error::new(ErrorKind::BadSerialization, "unable to format to JSON").with_source(err)
-            })?;
-            write!(out, "{}", value)?
-        }
-        (false, AutoEscape::Custom(name)) => {
-            return Err(Error::new(
-                ErrorKind::ImpossibleOperation,
-                format!(
-                    "Default formatter does not know how to format to custom format '{}'",
-                    name
-                ),
-            ));
-        }
-    }
-    Ok(())
+pub fn escape_formatter(out: &mut Output, state: &State, value: &Value) -> Result<(), Error> {
+    write_escaped(out, state.auto_escape(), value)
 }
 
 pub(crate) fn get_builtin_filters() -> BTreeMap<&'static str, filters::BoxedFilter> {

--- a/minijinja/src/expression.rs
+++ b/minijinja/src/expression.rs
@@ -67,6 +67,7 @@ impl<'env, 'source> Expression<'env, 'source> {
                 root,
                 &BTreeMap::new(),
                 &mut Output::null(),
+                crate::AutoEscape::None,
             )?
             .expect("expression evaluation did not leave value on stack"))
     }

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -78,7 +78,7 @@ use crate::error::Error;
 use crate::utils::{write_escaped, SealedMarker};
 use crate::value::{FunctionArgs, FunctionResult, Value};
 use crate::vm::State;
-use crate::AutoEscape;
+use crate::{AutoEscape, Output};
 
 type FilterFunc = dyn Fn(&State, &[Value]) -> Result<Value, Error> + Sync + Send + 'static;
 
@@ -188,6 +188,7 @@ tuple_impls! { A }
 tuple_impls! { A B }
 tuple_impls! { A B C }
 tuple_impls! { A B C D }
+tuple_impls! { A B C D E }
 
 impl BoxedFilter {
     /// Creates a new boxed filter.
@@ -212,7 +213,7 @@ impl BoxedFilter {
 /// Marks a value as safe.  This converts it into a string.
 ///
 /// When a value is marked as safe, no further auto escaping will take place.
-pub fn safe(_state: &State, v: String) -> Value {
+pub fn safe(v: String) -> Value {
     Value::from_safe_string(v)
 }
 
@@ -237,9 +238,10 @@ pub fn escape(state: &State, v: Value) -> Result<Value, Error> {
         },
         other => other,
     };
-    let mut out = String::new();
+    let mut rv = String::new();
+    let mut out = Output::with_string(&mut rv);
     write_escaped(&mut out, auto_escape, &v)?;
-    Ok(Value::from_safe_string(out))
+    Ok(Value::from_safe_string(rv))
 }
 
 #[cfg(feature = "builtins")]
@@ -261,7 +263,7 @@ mod builtins {
     /// <h1>{{ chapter.title|upper }}</h1>
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn upper(_state: &State, v: Cow<'_, str>) -> String {
+    pub fn upper(v: Cow<'_, str>) -> String {
         v.to_uppercase()
     }
 
@@ -271,7 +273,7 @@ mod builtins {
     /// <h1>{{ chapter.title|lower }}</h1>
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn lower(_state: &State, v: Cow<'_, str>) -> String {
+    pub fn lower(v: Cow<'_, str>) -> String {
         v.to_lowercase()
     }
 
@@ -281,7 +283,7 @@ mod builtins {
     /// <h1>{{ chapter.title|title }}</h1>
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn title(_state: &State, v: Cow<'_, str>) -> String {
+    pub fn title(v: Cow<'_, str>) -> String {
         let mut rv = String::new();
         let mut capitalize = true;
         for c in v.chars() {
@@ -324,7 +326,7 @@ mod builtins {
     /// <p>Search results: {{ results|length }}
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn length(_state: &State, v: Value) -> Result<usize, Error> {
+    pub fn length(v: Value) -> Result<usize, Error> {
         v.len().ok_or_else(|| {
             Error::new(
                 ErrorKind::ImpossibleOperation,
@@ -337,7 +339,7 @@ mod builtins {
     ///
     /// This filter works like `|items` but sorts the pairs by key first.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn dictsort(_state: &State, v: Value) -> Result<Value, Error> {
+    pub fn dictsort(v: Value) -> Result<Value, Error> {
         let mut pairs = match v.0 {
             ValueRepr::Map(ref v) => v.iter().collect::<Vec<_>>(),
             _ => {
@@ -374,7 +376,7 @@ mod builtins {
     /// </dl>
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn items(_state: &State, v: Value) -> Result<Value, Error> {
+    pub fn items(v: Value) -> Result<Value, Error> {
         Ok(Value::from(
             match v.0 {
                 ValueRepr::Map(ref v) => v.iter(),
@@ -398,7 +400,7 @@ mod builtins {
     /// {% endfor %}
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn reverse(_state: &State, v: Value) -> Result<Value, Error> {
+    pub fn reverse(v: Value) -> Result<Value, Error> {
         if let Some(s) = v.as_str() {
             Ok(Value::from(s.chars().rev().collect::<String>()))
         } else if matches!(v.kind(), ValueKind::Seq) {
@@ -415,7 +417,7 @@ mod builtins {
 
     /// Trims a value
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn trim(_state: &State, s: Cow<'_, str>, chars: Option<Cow<'_, str>>) -> String {
+    pub fn trim(s: Cow<'_, str>, chars: Option<Cow<'_, str>>) -> String {
         match chars {
             Some(chars) => {
                 let chars = chars.chars().collect::<Vec<_>>();
@@ -427,7 +429,7 @@ mod builtins {
 
     /// Joins a sequence by a character
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn join(_state: &State, val: Value, joiner: Option<Cow<'_, str>>) -> Result<String, Error> {
+    pub fn join(val: Value, joiner: Option<Cow<'_, str>>) -> Result<String, Error> {
         if val.is_undefined() || val.is_none() {
             return Ok(String::new());
         }
@@ -471,7 +473,7 @@ mod builtins {
     /// <p>{{ my_variable|default("my_variable was not defined") }}</p>
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn default(_: &State, value: Value, other: Option<Value>) -> Value {
+    pub fn default(value: Value, other: Option<Value>) -> Value {
         if value.is_undefined() {
             other.unwrap_or_else(|| Value::from(""))
         } else {
@@ -486,7 +488,7 @@ mod builtins {
     ///   -> |2 - 4| = 2
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn abs(_: &State, value: Value) -> Result<Value, Error> {
+    pub fn abs(value: Value) -> Result<Value, Error> {
         match value.0 {
             ValueRepr::I64(x) => Ok(Value::from(x.abs())),
             ValueRepr::I128(x) => Ok(Value::from(x.abs())),
@@ -508,7 +510,7 @@ mod builtins {
     ///   -> 43.0
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn round(_: &State, value: Value, precision: Option<i32>) -> Result<Value, Error> {
+    pub fn round(value: Value, precision: Option<i32>) -> Result<Value, Error> {
         match value.0 {
             ValueRepr::I64(_) | ValueRepr::I128(_) => Ok(value),
             ValueRepr::F64(val) => {
@@ -533,7 +535,7 @@ mod builtins {
     /// </dl>
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn first(_: &State, value: Value) -> Result<Value, Error> {
+    pub fn first(value: Value) -> Result<Value, Error> {
         match value.0 {
             ValueRepr::String(s) | ValueRepr::SafeString(s) => {
                 Ok(s.chars().next().map_or(Value::UNDEFINED, Value::from))
@@ -562,7 +564,7 @@ mod builtins {
     /// {% endwith %}
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn last(_: &State, value: Value) -> Result<Value, Error> {
+    pub fn last(value: Value) -> Result<Value, Error> {
         match value.0 {
             ValueRepr::String(s) | ValueRepr::SafeString(s) => {
                 Ok(s.chars().rev().next().map_or(Value::UNDEFINED, Value::from))
@@ -582,7 +584,7 @@ mod builtins {
     /// string this returns the characters.  If the value is undefined
     /// an empty list is returned.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn list(_: &State, value: Value) -> Result<Value, Error> {
+    pub fn list(value: Value) -> Result<Value, Error> {
         match &value.0 {
             ValueRepr::Undefined => Ok(Value::from(Vec::<Value>::new())),
             ValueRepr::String(ref s) | ValueRepr::SafeString(ref s) => {
@@ -606,7 +608,7 @@ mod builtins {
     /// This behaves the same as the if statement does with regards to
     /// handling of boolean values.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn bool(_: &State, value: Value) -> bool {
+    pub fn bool(value: Value) -> bool {
         value.is_true()
     }
 
@@ -631,12 +633,7 @@ mod builtins {
     /// If you pass it a second argument it’s used to fill missing values on the
     /// last iteration.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn slice(
-        _: &State,
-        value: Value,
-        count: usize,
-        fill_with: Option<Value>,
-    ) -> Result<Value, Error> {
+    pub fn slice(value: Value, count: usize, fill_with: Option<Value>) -> Result<Value, Error> {
         let items = value.try_iter()?.collect::<Vec<_>>();
         let len = items.len();
         let items_per_slice = len / count;
@@ -685,12 +682,7 @@ mod builtins {
     /// </table>
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn batch(
-        _: &State,
-        value: Value,
-        count: usize,
-        fill_with: Option<Value>,
-    ) -> Result<Value, Error> {
+    pub fn batch(value: Value, count: usize, fill_with: Option<Value>) -> Result<Value, Error> {
         let mut rv = Vec::new();
         let mut tmp = Vec::with_capacity(count);
 
@@ -733,7 +725,7 @@ mod builtins {
     /// ```
     #[cfg_attr(docsrs, doc(cfg(all(feature = "builtins", feature = "json"))))]
     #[cfg(feature = "json")]
-    pub fn tojson(_: &State, value: Value, pretty: Option<bool>) -> Result<Value, Error> {
+    pub fn tojson(value: Value, pretty: Option<bool>) -> Result<Value, Error> {
         if pretty.unwrap_or(false) {
             serde_json::to_string_pretty(&value)
         } else {
@@ -769,7 +761,7 @@ mod builtins {
     /// ```
     #[cfg_attr(docsrs, doc(cfg(all(feature = "builtins", feature = "urlencode"))))]
     #[cfg(feature = "urlencode")]
-    pub fn urlencode(_: &State, value: Value) -> Result<String, Error> {
+    pub fn urlencode(value: Value) -> Result<String, Error> {
         const SET: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
             .remove(b'/')
             .remove(b'.')
@@ -804,7 +796,7 @@ mod builtins {
 
     #[test]
     fn test_basics() {
-        fn test(_: &State, a: u32, b: u32) -> Result<u32, Error> {
+        fn test(a: u32, b: u32) -> Result<u32, Error> {
             Ok(a + b)
         }
 
@@ -821,7 +813,7 @@ mod builtins {
 
     #[test]
     fn test_rest_args() {
-        fn sum(_: &State, val: u32, rest: crate::value::Rest<u32>) -> u32 {
+        fn sum(val: u32, rest: crate::value::Rest<u32>) -> u32 {
             rest.iter().fold(val, |a, b| a + b)
         }
 
@@ -846,7 +838,7 @@ mod builtins {
 
     #[test]
     fn test_optional_args() {
-        fn add(_: &State, val: u32, a: u32, b: Option<u32>) -> Result<u32, Error> {
+        fn add(val: u32, a: u32, b: Option<u32>) -> Result<u32, Error> {
             // ensure we really get our value as first argument
             assert_eq!(val, 23);
             let mut sum = val + a;

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -57,10 +57,8 @@
 //! might change from one MiniJinja version to another.
 use std::sync::Arc;
 
-use crate::defaults::escape_formatter;
 use crate::error::Error;
-use crate::output::Output;
-use crate::utils::SealedMarker;
+use crate::utils::{write_escaped, SealedMarker};
 use crate::value::{FunctionArgs, FunctionResult, Value};
 use crate::vm::State;
 use crate::AutoEscape;
@@ -226,8 +224,7 @@ pub fn escape(state: &State, v: Value) -> Result<Value, Error> {
         other => other,
     };
     let mut out = String::new();
-    let mut formatter = Output::with_string(&mut out, auto_escape);
-    escape_formatter(&mut formatter, &v)?;
+    write_escaped(&mut out, auto_escape, &v)?;
     Ok(Value::from_safe_string(out))
 }
 

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -148,6 +148,7 @@ tuple_impls! { A }
 tuple_impls! { A B }
 tuple_impls! { A B C }
 tuple_impls! { A B C D }
+tuple_impls! { A B C D E }
 
 impl BoxedFunction {
     /// Creates a new boxed filter.
@@ -227,7 +228,7 @@ mod builtins {
     /// </ul>
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn range(_state: &State, lower: u32, upper: Option<u32>, step: Option<u32>) -> Vec<u32> {
+    pub fn range(lower: u32, upper: Option<u32>, step: Option<u32>) -> Vec<u32> {
         let rng = match upper {
             Some(upper) => lower..upper,
             None => 0..lower,
@@ -251,7 +252,7 @@ mod builtins {
     /// )|tojson }};</script>
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn dict(_state: &State, value: Value) -> Result<Value, Error> {
+    pub fn dict(value: Value) -> Result<Value, Error> {
         if value.is_undefined() {
             Ok(Value::from(BTreeMap::<bool, Value>::new()))
         } else if value.kind() != ValueKind::Map {

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -18,8 +18,7 @@
 //!
 //! # Custom Functions
 //!
-//! A custom global function is just a simple rust function which accepts the
-//! [`&State`](crate::State) as first argument, optionally some additional
+//! A custom global function is just a simple rust function which accepts optional
 //! arguments and then returns a result.  Global functions are typically used to
 //! perform a data loading operation.  For instance these functions can be used
 //! to expose data to the template that hasn't been provided by the individual
@@ -28,9 +27,9 @@
 //! ```rust
 //! # use minijinja::Environment;
 //! # let mut env = Environment::new();
-//! use minijinja::{State, Error, ErrorKind};
+//! use minijinja::{Error, ErrorKind};
 //!
-//! fn include_file(_state: &State, name: String) -> Result<String, Error> {
+//! fn include_file(name: String) -> Result<String, Error> {
 //!     std::fs::read_to_string(&name)
 //!         .map_err(|e| Error::new(
 //!             ErrorKind::ImpossibleOperation,
@@ -88,9 +87,9 @@ pub(crate) struct BoxedFunction(Arc<FuncFunc>, &'static str);
 /// ```rust
 /// # use minijinja::Environment;
 /// # let mut env = Environment::new();
-/// use minijinja::{State, Error, ErrorKind};
+/// use minijinja::{Error, ErrorKind};
 ///
-/// fn include_file(_state: &State, name: String) -> Result<String, Error> {
+/// fn include_file(name: String) -> Result<String, Error> {
 ///     std::fs::read_to_string(&name)
 ///         .map_err(|e| Error::new(
 ///             ErrorKind::ImpossibleOperation,
@@ -110,10 +109,9 @@ pub(crate) struct BoxedFunction(Arc<FuncFunc>, &'static str);
 /// ```
 /// # use minijinja::Environment;
 /// # let mut env = Environment::new();
-/// use minijinja::State;
 /// use minijinja::value::Rest;
 ///
-/// fn sum(_state: &State, values: Rest<i64>) -> i64 {
+/// fn sum(values: Rest<i64>) -> i64 {
 ///     values.iter().sum()
 /// }
 ///
@@ -126,20 +124,20 @@ pub(crate) struct BoxedFunction(Arc<FuncFunc>, &'static str);
 pub trait Function<Rv, Args>: Send + Sync + 'static {
     /// Calls a function with the given arguments.
     #[doc(hidden)]
-    fn invoke(&self, env: &State, args: Args, _: SealedMarker) -> Rv;
+    fn invoke(&self, args: Args, _: SealedMarker) -> Rv;
 }
 
 macro_rules! tuple_impls {
     ( $( $name:ident )* ) => {
         impl<Func, Rv, $($name),*> Function<Rv, ($($name,)*)> for Func
         where
-            Func: Fn(&State, $($name),*) -> Rv + Send + Sync + 'static,
+            Func: Fn($($name),*) -> Rv + Send + Sync + 'static,
             Rv: FunctionResult,
         {
-            fn invoke(&self, state: &State, args: ($($name,)*), _: SealedMarker) -> Rv {
+            fn invoke(&self, args: ($($name,)*), _: SealedMarker) -> Rv {
                 #[allow(non_snake_case)]
                 let ($($name,)*) = args;
-                (self)(state, $($name,)*)
+                (self)($($name,)*)
             }
         }
     };
@@ -161,7 +159,7 @@ impl BoxedFunction {
     {
         BoxedFunction(
             Arc::new(move |state, args| -> Result<Value, Error> {
-                f.invoke(state, Args::from_values(args)?, SealedMarker)
+                f.invoke(Args::from_values(Some(state), args)?, SealedMarker)
                     .into_result()
             }),
             std::any::type_name::<F>(),

--- a/minijinja/src/lib.rs
+++ b/minijinja/src/lib.rs
@@ -177,9 +177,9 @@ pub mod machinery {
     pub use crate::compiler::tokens::{Span, Token};
     pub use crate::vm::Vm;
 
-    use crate::{AutoEscape, Output};
+    use crate::Output;
 
-    pub fn make_string_output(s: &mut String, auto_escape: AutoEscape) -> Output<'_> {
-        Output::with_string(s, auto_escape)
+    pub fn make_string_output(s: &mut String) -> Output<'_> {
+        Output::with_string(s)
     }
 }

--- a/minijinja/src/lib.rs
+++ b/minijinja/src/lib.rs
@@ -72,6 +72,22 @@
 //! This becomes particularly powerful when [dynamic objects](crate::value::Object) are
 //! exposed to templates.
 //!
+//! # Custom Filters
+//!
+//! ```
+//! use minijinja::{Environment, context};
+//!
+//! let mut env = Environment::new();
+//! env.add_filter("repeat", str::repeat);
+//! env.add_template("hello", "{{ 'Na '|repeat(3) }} {{ name }}!").unwrap();
+//! let tmpl = env.get_template("hello").unwrap();
+//! println!("{}", tmpl.render(context!(name => "Batman")).unwrap());
+//! ```
+//!
+//! ```plain
+//! Na Na Na Batman!
+//! ```
+//!
 //! # Learn more
 //!
 //! - [`Environment`]: the main API entry point.  Teaches you how to configure the environment.

--- a/minijinja/src/output.rs
+++ b/minijinja/src/output.rs
@@ -8,11 +8,6 @@ use crate::value::Value;
 /// This is a utility type used in the engine which can be written into like one
 /// can write into an [`std::fmt::Write`] value.  It's primarily used internally
 /// in the engine but it's also passed to the custom formatter function.
-///
-/// Additionally it keeps track of the requested auto escape format of the
-/// template so that the formatter can customize it's behavior based on the auto
-/// escaping request.  The output itself however does not have functionality to
-/// escape by itself.
 pub struct Output<'a> {
     // Note on type design: this type partially exists so that in the future non
     // string outputs can be implemented.  Right now only the null writer exists
@@ -21,24 +16,21 @@ pub struct Output<'a> {
     // fmt::Error has no support for carrying actual IO errors.
     w: &'a mut (dyn fmt::Write + 'a),
     capture_stack: Vec<String>,
-    pub(crate) auto_escape: AutoEscape,
 }
 
 impl<'a> Output<'a> {
     /// Creates an output writing to a string.
-    pub(crate) fn with_string(buf: &'a mut String, auto_escape: AutoEscape) -> Self {
+    pub(crate) fn with_string(buf: &'a mut String) -> Self {
         Self {
             w: buf,
             capture_stack: Vec::new(),
-            auto_escape,
         }
     }
 
-    pub(crate) fn with_write(w: &'a mut (dyn fmt::Write + 'a), auto_escape: AutoEscape) -> Self {
+    pub(crate) fn with_write(w: &'a mut (dyn fmt::Write + 'a)) -> Self {
         Self {
             w,
             capture_stack: Vec::new(),
-            auto_escape,
         }
     }
 
@@ -49,7 +41,6 @@ impl<'a> Output<'a> {
             // SAFETY: this is safe as the null writer is a ZST
             w: unsafe { &mut NULL_WRITER },
             capture_stack: Vec::new(),
-            auto_escape: AutoEscape::None,
         }
     }
 
@@ -59,9 +50,9 @@ impl<'a> Output<'a> {
     }
 
     /// Ends capturing and returns the captured string as value.
-    pub(crate) fn end_capture(&mut self) -> Value {
+    pub(crate) fn end_capture(&mut self, auto_escape: AutoEscape) -> Value {
         let captured = self.capture_stack.pop().unwrap();
-        if !matches!(self.auto_escape, AutoEscape::None) {
+        if !matches!(auto_escape, AutoEscape::None) {
             Value::from_safe_string(captured)
         } else {
             Value::from(captured)
@@ -73,12 +64,6 @@ impl<'a> Output<'a> {
             Some(stream) => stream as _,
             None => self.w,
         }
-    }
-
-    /// Returns the current auto escape setting.
-    #[inline]
-    pub fn auto_escape(&self) -> AutoEscape {
-        self.auto_escape
     }
 
     /// Writes some data to the underlying buffer contained within this output.

--- a/minijinja/src/output.rs
+++ b/minijinja/src/output.rs
@@ -9,11 +9,6 @@ use crate::value::Value;
 /// can write into an [`std::fmt::Write`] value.  It's primarily used internally
 /// in the engine but it's also passed to the custom formatter function.
 pub struct Output<'a> {
-    // Note on type design: this type partially exists so that in the future non
-    // string outputs can be implemented.  Right now only the null writer exists
-    // as alternative which is also infallible.  If writing to io::Write should
-    // be added, then errors would need to be collected out of bounds as
-    // fmt::Error has no support for carrying actual IO errors.
     w: &'a mut (dyn fmt::Write + 'a),
     capture_stack: Vec<String>,
 }
@@ -59,6 +54,7 @@ impl<'a> Output<'a> {
         }
     }
 
+    #[inline(always)]
     fn target(&mut self) -> &mut dyn fmt::Write {
         match self.capture_stack.last_mut() {
             Some(stream) => stream as _,

--- a/minijinja/src/template.rs
+++ b/minijinja/src/template.rs
@@ -86,11 +86,8 @@ impl<'env> Template<'env> {
 
     fn _render(&self, root: Value) -> Result<String, Error> {
         let mut rv = String::new();
-        self._eval(
-            root,
-            &mut Output::with_string(&mut rv, self.initial_auto_escape),
-        )
-        .map(|_| rv)
+        self._eval(root, &mut Output::with_string(&mut rv))
+            .map(|_| rv)
     }
 
     /// Renders the template into a [`io::Write`].
@@ -111,7 +108,7 @@ impl<'env> Template<'env> {
         let mut wrapper = WriteWrapper { w, err: None };
         self._eval(
             Value::from_serializable(&ctx),
-            &mut Output::with_write(&mut wrapper, self.initial_auto_escape),
+            &mut Output::with_write(&mut wrapper),
         )
         .map_err(|err| {
             wrapper
@@ -132,6 +129,7 @@ impl<'env> Template<'env> {
                 root,
                 &self.compiled.blocks,
                 out,
+                self.initial_auto_escape,
             )
             .map(|_| ())
     }

--- a/minijinja/src/tests.rs
+++ b/minijinja/src/tests.rs
@@ -119,7 +119,7 @@ impl TestResult for bool {
 /// # let mut env = Environment::new();
 /// use minijinja::State;
 ///
-/// fn is_lowercase(_state: &State, value: String) -> bool {
+/// fn is_lowercase(value: String) -> bool {
 ///     value.chars().all(|x| x.is_lowercase())
 /// }
 ///
@@ -137,7 +137,7 @@ impl TestResult for bool {
 /// # let mut env = Environment::new();
 /// use minijinja::State;
 ///
-/// fn is_containing(_state: &State, value: String, other: String) -> bool {
+/// fn is_containing(value: String, other: String) -> bool {
 ///     value.contains(&other)
 /// }
 ///
@@ -175,6 +175,7 @@ tuple_impls! { A }
 tuple_impls! { A B }
 tuple_impls! { A B C }
 tuple_impls! { A B C D }
+tuple_impls! { A B C D E }
 
 impl BoxedTest {
     /// Creates a new boxed filter.
@@ -207,61 +208,61 @@ mod builtins {
 
     /// Checks if a value is odd.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_odd(_state: &State, v: Value) -> bool {
+    pub fn is_odd(v: Value) -> bool {
         i128::try_from(v).ok().map_or(false, |x| x % 2 != 0)
     }
 
     /// Checks if a value is even.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_even(_state: &State, v: Value) -> bool {
+    pub fn is_even(v: Value) -> bool {
         i128::try_from(v).ok().map_or(false, |x| x % 2 == 0)
     }
 
     /// Checks if a value is undefined.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_undefined(_state: &State, v: Value) -> bool {
+    pub fn is_undefined(v: Value) -> bool {
         v.is_undefined()
     }
 
     /// Checks if a value is defined.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_defined(_state: &State, v: Value) -> bool {
+    pub fn is_defined(v: Value) -> bool {
         !v.is_undefined()
     }
 
     /// Checks if this value is a number.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_number(_state: &State, v: Value) -> bool {
+    pub fn is_number(v: Value) -> bool {
         matches!(v.kind(), ValueKind::Number)
     }
 
     /// Checks if this value is a string.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_string(_state: &State, v: Value) -> bool {
+    pub fn is_string(v: Value) -> bool {
         matches!(v.kind(), ValueKind::String)
     }
 
     /// Checks if this value is a sequence
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_sequence(_state: &State, v: Value) -> bool {
+    pub fn is_sequence(v: Value) -> bool {
         matches!(v.kind(), ValueKind::Seq)
     }
 
     /// Checks if this value is a mapping
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_mapping(_state: &State, v: Value) -> bool {
+    pub fn is_mapping(v: Value) -> bool {
         matches!(v.kind(), ValueKind::Map)
     }
 
     /// Checks if the value is starting with a string.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_startingwith(_state: &State, v: Cow<'_, str>, other: Cow<'_, str>) -> bool {
+    pub fn is_startingwith(v: Cow<'_, str>, other: Cow<'_, str>) -> bool {
         v.starts_with(&other as &str)
     }
 
     /// Checks if the value is ending with a string.
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_endingwith(_state: &State, v: Cow<'_, str>, other: Cow<'_, str>) -> bool {
+    pub fn is_endingwith(v: Cow<'_, str>, other: Cow<'_, str>) -> bool {
         v.ends_with(&other as &str)
     }
 

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -5,6 +5,7 @@ use std::iter::{once, repeat};
 use std::str::Chars;
 
 use crate::error::{Error, ErrorKind};
+use crate::value::{Value, ValueKind};
 
 #[cfg(test)]
 use similar_asserts::assert_eq;
@@ -20,6 +21,48 @@ pub fn memstr(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack
         .windows(needle.len())
         .position(|window| window == needle)
+}
+
+fn write_with_html_escaping(out: &mut dyn fmt::Write, value: &Value) -> fmt::Result {
+    if matches!(
+        value.kind(),
+        ValueKind::Undefined | ValueKind::None | ValueKind::Bool | ValueKind::Number
+    ) {
+        write!(out, "{}", value)
+    } else if let Some(s) = value.as_str() {
+        write!(out, "{}", HtmlEscape(s))
+    } else {
+        write!(out, "{}", HtmlEscape(&value.to_string()))
+    }
+}
+
+pub fn write_escaped(
+    out: &mut dyn fmt::Write,
+    auto_escape: AutoEscape,
+    value: &Value,
+) -> Result<(), Error> {
+    match (value.is_safe(), auto_escape) {
+        // safe values do not get escaped
+        (true, _) | (_, AutoEscape::None) => write!(out, "{}", value)?,
+        (false, AutoEscape::Html) => write_with_html_escaping(out, value)?,
+        #[cfg(feature = "json")]
+        (false, AutoEscape::Json) => {
+            let value = serde_json::to_string(&value).map_err(|err| {
+                Error::new(ErrorKind::BadSerialization, "unable to format to JSON").with_source(err)
+            })?;
+            write!(out, "{}", value)?
+        }
+        (false, AutoEscape::Custom(name)) => {
+            return Err(Error::new(
+                ErrorKind::ImpossibleOperation,
+                format!(
+                    "Default formatter does not know how to format to custom format '{}'",
+                    name
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Controls the autoescaping behavior.

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -6,6 +6,7 @@ use std::str::Chars;
 
 use crate::error::{Error, ErrorKind};
 use crate::value::{Value, ValueKind};
+use crate::Output;
 
 #[cfg(test)]
 use similar_asserts::assert_eq;
@@ -23,7 +24,7 @@ pub fn memstr(haystack: &[u8], needle: &[u8]) -> Option<usize> {
         .position(|window| window == needle)
 }
 
-fn write_with_html_escaping(out: &mut dyn fmt::Write, value: &Value) -> fmt::Result {
+fn write_with_html_escaping(out: &mut Output, value: &Value) -> fmt::Result {
     if matches!(
         value.kind(),
         ValueKind::Undefined | ValueKind::None | ValueKind::Bool | ValueKind::Number
@@ -36,8 +37,9 @@ fn write_with_html_escaping(out: &mut dyn fmt::Write, value: &Value) -> fmt::Res
     }
 }
 
+#[inline(always)]
 pub fn write_escaped(
-    out: &mut dyn fmt::Write,
+    out: &mut Output,
     auto_escape: AutoEscape,
     value: &Value,
 ) -> Result<(), Error> {

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -126,7 +126,7 @@ impl<'env> Vm<'env> {
                 Instruction::EmitRaw(val) => {
                     // this only produces a format error, no need to attach
                     // location information.
-                    write!(out, "{}", val)?;
+                    out.write_str(val)?;
                 }
                 Instruction::Emit => {
                     try_ctx!(self.env.format(&stack.pop(), state, out));

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -39,6 +39,7 @@ impl<'env> Vm<'env> {
         root: Value,
         blocks: &BTreeMap<&'env str, Instructions<'env>>,
         out: &mut Output,
+        auto_escape: AutoEscape,
     ) -> Result<Option<Value>, Error> {
         let mut ctx = Context::default();
         ctx.push_frame(Frame::new(FrameBase::Value(root)));
@@ -47,20 +48,27 @@ impl<'env> Vm<'env> {
             referenced_blocks.insert(name, vec![instr]);
         }
         value::with_value_optimization(|| {
-            self.eval_state(&mut State {
-                env: self.env,
-                ctx,
-                current_block: None,
-                instructions,
+            self.eval_state(
+                &mut State {
+                    env: self.env,
+                    ctx,
+                    current_block: None,
+                    instructions,
+                    auto_escape,
+                    blocks: referenced_blocks,
+                },
                 out,
-                blocks: referenced_blocks,
-            })
+            )
         })
     }
 
     /// This is the actual evaluation loop that works with a specific context.
-    fn eval_state(&self, state: &mut State<'_, 'env, '_, '_>) -> Result<Option<Value>, Error> {
-        let initial_auto_escape = state.out.auto_escape;
+    fn eval_state(
+        &self,
+        state: &mut State<'_, 'env>,
+        out: &mut Output,
+    ) -> Result<Option<Value>, Error> {
+        let initial_auto_escape = state.auto_escape;
         let mut stack = Stack::default();
         let mut auto_escape_stack = vec![];
         let mut next_loop_recursion_jump = None;
@@ -106,7 +114,7 @@ impl<'env> Vm<'env> {
                 // to.
                 next_loop_recursion_jump = Some((pc + 1, $capture));
                 if $capture {
-                    state.out.begin_capture();
+                    out.begin_capture();
                 }
                 pc = jump_target;
                 continue;
@@ -118,10 +126,10 @@ impl<'env> Vm<'env> {
                 Instruction::EmitRaw(val) => {
                     // this only produces a format error, no need to attach
                     // location information.
-                    write!(state.out, "{}", val)?;
+                    write!(out, "{}", val)?;
                 }
                 Instruction::Emit => {
-                    try_ctx!(self.env.format(&stack.pop(), state.out));
+                    try_ctx!(self.env.format(&stack.pop(), state, out));
                 }
                 Instruction::StoreLocal(name) => {
                     state.ctx.store(name, stack.pop());
@@ -213,7 +221,7 @@ impl<'env> Vm<'env> {
                         {
                             pc = target;
                             if end_capture {
-                                stack.push(state.out.end_capture());
+                                stack.push(out.end_capture(state.auto_escape));
                             }
                             continue;
                         }
@@ -272,7 +280,7 @@ impl<'env> Vm<'env> {
                     state.current_block = Some(name);
                     if let Some(layers) = state.blocks.get(name) {
                         let instructions = layers.first().unwrap();
-                        try_ctx!(self.sub_eval(state, instructions, state.blocks.clone()));
+                        try_ctx!(self.sub_eval(state, out, instructions, state.blocks.clone()));
                     } else {
                         bail!(Error::new(
                             ErrorKind::ImpossibleOperation,
@@ -294,22 +302,22 @@ impl<'env> Vm<'env> {
                 }
                 Instruction::Include(ignore_missing) => {
                     let name = stack.pop();
-                    try_ctx!(self.perform_include(name, state, *ignore_missing));
+                    try_ctx!(self.perform_include(name, state, out, *ignore_missing));
                 }
                 Instruction::PushAutoEscape => {
                     let value = stack.pop();
-                    auto_escape_stack.push(state.out.auto_escape);
-                    state.out.auto_escape =
+                    auto_escape_stack.push(state.auto_escape);
+                    state.auto_escape =
                         try_ctx!(self.derive_auto_escape(value, initial_auto_escape));
                 }
                 Instruction::PopAutoEscape => {
-                    state.out.auto_escape = auto_escape_stack.pop().unwrap();
+                    state.auto_escape = auto_escape_stack.pop().unwrap();
                 }
                 Instruction::BeginCapture => {
-                    state.out.begin_capture();
+                    out.begin_capture();
                 }
                 Instruction::EndCapture => {
-                    stack.push(state.out.end_capture());
+                    stack.push(out.end_capture(state.auto_escape));
                 }
                 Instruction::ApplyFilter(name) => {
                     let top = stack.pop();
@@ -332,7 +340,7 @@ impl<'env> Vm<'env> {
                                 "super() takes no arguments",
                             ));
                         }
-                        stack.push(try_ctx!(self.perform_super(state, true)));
+                        stack.push(try_ctx!(self.perform_super(state, out, true)));
                     // loop is a special name which when called recurses the current loop.
                     } else if *function_name == "loop" {
                         if args.len() != 1 {
@@ -371,7 +379,7 @@ impl<'env> Vm<'env> {
                     stack.pop();
                 }
                 Instruction::FastSuper => {
-                    try_ctx!(self.perform_super(state, false));
+                    try_ctx!(self.perform_super(state, out, false));
                 }
                 Instruction::FastRecurse => {
                     recurse_loop!(false);
@@ -386,7 +394,8 @@ impl<'env> Vm<'env> {
     fn perform_include(
         &self,
         name: Value,
-        state: &mut State<'_, 'env, '_, '_>,
+        state: &mut State<'_, 'env>,
+        out: &mut Output,
         ignore_missing: bool,
     ) -> Result<(), Error> {
         let choices = if let ValueRepr::Seq(ref choices) = name.0 {
@@ -418,10 +427,10 @@ impl<'env> Vm<'env> {
             for (&name, instr) in tmpl.blocks().iter() {
                 referenced_blocks.insert(name, vec![instr]);
             }
-            let original_escape = state.out.auto_escape;
-            state.out.auto_escape = tmpl.initial_auto_escape();
-            self.sub_eval(state, instructions, referenced_blocks)?;
-            state.out.auto_escape = original_escape;
+            let original_escape = state.auto_escape;
+            state.auto_escape = tmpl.initial_auto_escape();
+            self.sub_eval(state, out, instructions, referenced_blocks)?;
+            state.auto_escape = original_escape;
             return Ok(());
         }
         if !templates_tried.is_empty() && !ignore_missing {
@@ -446,7 +455,8 @@ impl<'env> Vm<'env> {
 
     fn perform_super(
         &self,
-        state: &mut State<'_, 'env, '_, '_>,
+        state: &mut State<'_, 'env>,
+        out: &mut Output,
         capture: bool,
     ) -> Result<Value, Error> {
         let mut inner_blocks = state.blocks.clone();
@@ -464,11 +474,11 @@ impl<'env> Vm<'env> {
             layers.remove(0);
             let instructions = layers.first().unwrap();
             if capture {
-                state.out.begin_capture();
+                out.begin_capture();
             }
-            self.sub_eval(state, instructions, state.blocks.clone())?;
+            self.sub_eval(state, out, instructions, state.blocks.clone())?;
             if capture {
-                Ok(state.out.end_capture())
+                Ok(out.end_capture(state.auto_escape))
             } else {
                 Ok(Value::UNDEFINED)
             }
@@ -495,7 +505,7 @@ impl<'env> Vm<'env> {
         }
     }
 
-    fn load_blocks(&self, name: Value, state: &mut State<'_, 'env, '_, '_>) -> Result<(), Error> {
+    fn load_blocks(&self, name: Value, state: &mut State<'_, 'env>) -> Result<(), Error> {
         let tmpl = name
             .as_str()
             .ok_or_else(|| {
@@ -540,7 +550,7 @@ impl<'env> Vm<'env> {
 
     fn push_loop(
         &self,
-        state: &mut State<'_, 'env, '_, '_>,
+        state: &mut State<'_, 'env>,
         iterable: Value,
         flags: u8,
         pc: usize,
@@ -599,20 +609,24 @@ impl<'env> Vm<'env> {
 
     fn sub_eval(
         &self,
-        state: &mut State<'_, 'env, '_, '_>,
+        state: &mut State<'_, 'env>,
+        out: &mut Output,
         instructions: &Instructions<'env>,
         blocks: BTreeMap<&'env str, Vec<&'_ Instructions<'env>>>,
     ) -> Result<(), Error> {
         let mut sub_context = Context::default();
         sub_context.push_frame(Frame::new(FrameBase::Context(&state.ctx)));
-        self.eval_state(&mut State {
-            env: self.env,
-            ctx: sub_context,
-            current_block: state.current_block,
-            out: state.out,
-            instructions,
-            blocks,
-        })?;
+        self.eval_state(
+            &mut State {
+                env: self.env,
+                ctx: sub_context,
+                current_block: state.current_block,
+                auto_escape: state.auto_escape,
+                instructions,
+                blocks,
+            },
+            out,
+        )?;
         Ok(())
     }
 }

--- a/minijinja/src/vm/state.rs
+++ b/minijinja/src/vm/state.rs
@@ -126,13 +126,16 @@ impl<'a> ArgType<'a> for &State<'_, '_> {
         ))
     }
 
-    fn from_state(state: Option<&'a State>) -> Result<Option<Self::Output>, Error> {
+    fn from_state_and_value(
+        state: Option<&'a State>,
+        _value: Option<&'a Value>,
+    ) -> Result<(Self::Output, usize), Error> {
         match state {
             None => Err(Error::new(
                 ErrorKind::ImpossibleOperation,
                 "state unavailable",
             )),
-            Some(state) => Ok(Some(state)),
+            Some(state) => Ok((state, 0)),
         }
     }
 }

--- a/minijinja/src/vm/state.rs
+++ b/minijinja/src/vm/state.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use crate::compiler::instructions::Instructions;
 use crate::environment::Environment;
 use crate::error::{Error, ErrorKind};
-use crate::value::Value;
+use crate::value::{ArgType, Value};
 use crate::vm::context::Context;
 use crate::AutoEscape;
 
@@ -112,6 +112,27 @@ impl<'vm, 'env> State<'vm, 'env> {
             template_source: Some(instructions.source().to_string()),
             context: Some(Value::from(self.ctx.freeze(self.env))),
             referenced_names: Some(referenced_names.iter().map(|x| x.to_string()).collect()),
+        }
+    }
+}
+
+impl<'a> ArgType<'a> for &State<'_, '_> {
+    type Output = &'a State<'a, 'a>;
+
+    fn from_value(_value: Option<&'a Value>) -> Result<Self::Output, Error> {
+        Err(Error::new(
+            ErrorKind::ImpossibleOperation,
+            "cannot use state type in this position",
+        ))
+    }
+
+    fn from_state(state: Option<&'a State>) -> Result<Option<Self::Output>, Error> {
+        match state {
+            None => Err(Error::new(
+                ErrorKind::ImpossibleOperation,
+                "state unavailable",
+            )),
+            Some(state) => Ok(Some(state)),
         }
     }
 }

--- a/minijinja/tests/test_vm.rs
+++ b/minijinja/tests/test_vm.rs
@@ -16,8 +16,14 @@ pub fn simple_eval<S: serde::Serialize>(
     let vm = Vm::new(&env);
     let root = Value::from_serializable(&ctx);
     let mut rv = String::new();
-    let mut output = make_string_output(&mut rv, AutoEscape::None);
-    vm.eval(instructions, root, &empty_blocks, &mut output)?;
+    let mut output = make_string_output(&mut rv);
+    vm.eval(
+        instructions,
+        root,
+        &empty_blocks,
+        &mut output,
+        AutoEscape::None,
+    )?;
     Ok(rv)
 }
 


### PR DESCRIPTION
This makes the state argument to filters, tests and global functions optional.

Fixes #108