### PR TITLE
with_fs_watcher fn should be behind watch-fs feature

### DIFF
--- a/minijinja-autoreload/src/lib.rs
+++ b/minijinja-autoreload/src/lib.rs
@@ -242,6 +242,7 @@ impl Notifier {
         inner.should_reload || inner.should_reload_callback.as_ref().map_or(false, |x| x())
     }
 
+    #[cfg(feature = "watch-fs")]
     fn with_fs_watcher<F: FnOnce(&mut notify::RecommendedWatcher)>(&self, f: F) {
         use notify::event::{EventKind, ModifyKind};
 


### PR DESCRIPTION
The `with_fs_watcher` function in `minijinja-autoreload` was not behind the `watch-fs` feature, causing `cargo check --no-default-features` (in the `minijinja-autoreload` crate directory) to fail. This also prevented users of `minijinja-autoreload` from using the auto-reload functionality without bringing in the filesystem-based watching functionality.