### PR TITLE
Added support for unicode identifiers

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -10,6 +10,9 @@ delimiters.  Both of those are currently intentional to better leverage
 the editor ecosystem which typically cannot deal with these reconfigured
 Jinja templates.
 
+MiniJinja by default does not allow unicode identifiers.  These need to be
+turned on with the `unicode` feature to achieve parity with Jinja2.
+
 ## Runtime Differences
 
 The biggest differences between MiniJinja and Jinja2 stem from the different

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ doc:
 
 test:
 	@$(MAKE) run-tests FEATURES=$(TEST_FEATURES)
-	@$(MAKE) run-tests FEATURES=$(TEST_FEATURES),preserve_order,key_interning
+	@$(MAKE) run-tests FEATURES=$(TEST_FEATURES),preserve_order,key_interning,unicode
 	@echo "CARGO TEST ALL FEATURES"
 	@cd minijinja; cargo test --all-features
 

--- a/minijinja/Cargo.toml
+++ b/minijinja/Cargo.toml
@@ -24,6 +24,7 @@ preserve_order = ["indexmap"]
 deserialization = []
 debug = []
 source = ["self_cell", "memo-map"]
+unicode = ["unicode-ident"]
 
 # Speedups
 key_interning = []
@@ -50,6 +51,7 @@ serde_json = { version = "1.0.68", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
 indexmap = { version = "1.7.0", optional = true }
 memo-map = { version = "0.3.1", optional = true }
+unicode-ident = { version = "1.0.5", optional = true }
 
 [dev-dependencies]
 insta = { version = "1.19.0", features = ["glob", "serde"] }

--- a/minijinja/src/lib.rs
+++ b/minijinja/src/lib.rs
@@ -137,6 +137,8 @@
 //!   - `macros`: when removed the `{% macro %}` tag is not included.
 //!   - `multi-template`: when removed the templates related to imports and extends
 //!     are removed (`{% from %}`, `{% import %}`, `{% include %}`, and `{% extends %}`).
+//!   - `unicode`: when added unicode identifiers are supported.  Without this features
+//!     only ASCII identifiers can be used for variable names and attributes.
 //!
 //! - **Rust Functionality:**
 //!


### PR DESCRIPTION
This adds support for unicode identifiers which are also supported by Jinja2. As it pulls in an extra dependency, the `unicode` feature needs to be enabled.