### PR TITLE
Change the Object::attributes method to return an iterator

### DIFF
--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -36,12 +36,12 @@ pub trait Object: fmt::Display + fmt::Debug + Any + Sync + Send {
 
     /// An enumeration of attributes that are known to exist on this object.
     ///
-    /// The default implementation returns an empty slice.  If it's not possible
+    /// The default implementation returns an empty iterator.  If it's not possible
     /// to implement this, it's fine for the implementation to be omitted.  The
     /// enumeration here is used by the `for` loop to iterate over the attributes
     /// on the value.
-    fn attributes(&self) -> &[&str] {
-        &[][..]
+    fn attributes(&self) -> Box<dyn Iterator<Item = &str> + '_> {
+        Box::new(None.into_iter())
     }
 
     /// Called when the engine tries to call a method on the object.

--- a/minijinja/src/vm/loop_object.rs
+++ b/minijinja/src/vm/loop_object.rs
@@ -24,18 +24,21 @@ impl fmt::Debug for Loop {
 }
 
 impl Object for Loop {
-    fn attributes(&self) -> &[&str] {
-        &[
-            "index0",
-            "index",
-            "length",
-            "revindex",
-            "revindex0",
-            "first",
-            "last",
-            "depth",
-            "depth0",
-        ][..]
+    fn attributes(&self) -> Box<dyn Iterator<Item = &str> + '_> {
+        Box::new(
+            [
+                "index0",
+                "index",
+                "length",
+                "revindex",
+                "revindex0",
+                "first",
+                "last",
+                "depth",
+                "depth0",
+            ]
+            .into_iter(),
+        )
     }
 
     fn get_attr(&self, name: &str) -> Option<Value> {

--- a/minijinja/src/vm/macro_object.rs
+++ b/minijinja/src/vm/macro_object.rs
@@ -41,8 +41,8 @@ impl fmt::Display for Macro {
 }
 
 impl Object for Macro {
-    fn attributes(&self) -> &[&str] {
-        &["name", "arguments"][..]
+    fn attributes(&self) -> Box<dyn Iterator<Item = &str> + '_> {
+        Box::new(["name", "arguments"].into_iter())
     }
 
     fn get_attr(&self, name: &str) -> Option<Value> {


### PR DESCRIPTION
This changes the method to return an iterator. This iterator here is over `&str` which I wonder if that is generic enough. It at least feels like it should be somewhat easy to fulfill but obviously there might be corner cases where this is non trivial. However changing the item to a `Cow<'_, str>` is not quite as easy without making some more changes throughout the system.

Fixes #137