### PR TITLE
Align extends semantics with Jinja2

### DIFF
--- a/minijinja/src/compiler/instructions.rs
+++ b/minijinja/src/compiler/instructions.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use similar_asserts::assert_eq;
 
 use crate::compiler::tokens::Span;
+use crate::output::CaptureMode;
 use crate::value::Value;
 
 /// This loop has the loop var.
@@ -152,17 +153,14 @@ pub enum Instruction<'source> {
     /// Jump if the stack top evaluates to true or pops the value
     JumpIfTrueOrPop(usize),
 
-    /// Call into a block.
-    CallBlock(&'source str),
-
     /// Sets the auto escape flag to the current value.
     PushAutoEscape,
 
     /// Resets the auto escape flag to the previous value.
     PopAutoEscape,
 
-    /// Begins capturing of output.
-    BeginCapture,
+    /// Begins capturing of output (false) or discard (true).
+    BeginCapture(CaptureMode),
 
     /// Ends capturing of output.
     EndCapture,
@@ -188,9 +186,17 @@ pub enum Instruction<'source> {
     /// A fast loop recurse instruction without intermediate capturing.
     FastRecurse,
 
+    /// Call into a block.
+    #[cfg(feature = "multi-template")]
+    CallBlock(&'source str),
+
     /// Loads block from a template with name on stack ("extends")
     #[cfg(feature = "multi-template")]
     LoadBlocks,
+
+    /// Renders the parent template
+    #[cfg(feature = "multi-template")]
+    RenderParent,
 
     /// Includes another template.
     #[cfg(feature = "multi-template")]

--- a/minijinja/src/compiler/meta.rs
+++ b/minijinja/src/compiler/meta.rs
@@ -133,12 +133,6 @@ pub fn find_macro_closure<'a>(m: &ast::Macro<'a>) -> HashSet<&'a str> {
                 assign_nested(&stmt.target, state);
                 visit_expr(&stmt.expr, state);
             }
-            ast::Stmt::Block(stmt) => {
-                state.push();
-                state.assign("super");
-                stmt.body.iter().for_each(|x| walk(x, state));
-                state.pop();
-            }
             ast::Stmt::AutoEscape(stmt) => {
                 state.push();
                 stmt.body.iter().for_each(|x| walk(x, state));
@@ -152,6 +146,13 @@ pub fn find_macro_closure<'a>(m: &ast::Macro<'a>) -> HashSet<&'a str> {
             ast::Stmt::SetBlock(stmt) => {
                 assign_nested(&stmt.target, state);
                 state.push();
+                stmt.body.iter().for_each(|x| walk(x, state));
+                state.pop();
+            }
+            #[cfg(feature = "multi-template")]
+            ast::Stmt::Block(stmt) => {
+                state.push();
+                state.assign("super");
                 stmt.body.iter().for_each(|x| walk(x, state));
                 state.pop();
             }

--- a/minijinja/src/compiler/parser.rs
+++ b/minijinja/src/compiler/parser.rs
@@ -150,6 +150,7 @@ impl<'a> TokenStream<'a> {
 
 struct Parser<'a> {
     stream: TokenStream<'a>,
+    #[allow(unused)]
     in_macro: bool,
     depth: usize,
 }
@@ -638,13 +639,14 @@ impl<'a> Parser<'a> {
                 SetParseResult::Set(rv) => ast::Stmt::Set(respan!(rv)),
                 SetParseResult::SetBlock(rv) => ast::Stmt::SetBlock(respan!(rv)),
             },
-            Token::Ident("block") => ast::Stmt::Block(respan!(ok!(self.parse_block()))),
             Token::Ident("autoescape") => {
                 ast::Stmt::AutoEscape(respan!(ok!(self.parse_auto_escape())))
             }
             Token::Ident("filter") => {
                 ast::Stmt::FilterBlock(respan!(ok!(self.parse_filter_block())))
             }
+            #[cfg(feature = "multi-template")]
+            Token::Ident("block") => ast::Stmt::Block(respan!(ok!(self.parse_block()))),
             #[cfg(feature = "multi-template")]
             Token::Ident("extends") => ast::Stmt::Extends(respan!(ok!(self.parse_extends()))),
             #[cfg(feature = "multi-template")]
@@ -820,6 +822,7 @@ impl<'a> Parser<'a> {
         }
     }
 
+    #[cfg(feature = "multi-template")]
     fn parse_block(&mut self) -> Result<ast::Block<'a>, Error> {
         if self.in_macro {
             syntax_error!("block tags in macros are not allowed");

--- a/minijinja/src/vm/context.rs
+++ b/minijinja/src/vm/context.rs
@@ -231,6 +231,7 @@ impl<'env> Context<'env> {
     }
 
     /// Increase the stack depth.
+    #[allow(unused)]
     pub fn incr_depth(&mut self, delta: usize) -> Result<(), Error> {
         self.check_depth()?;
         self.outer_stack_depth += delta;
@@ -238,6 +239,7 @@ impl<'env> Context<'env> {
     }
 
     /// Decrease the stack depth.
+    #[allow(unused)]
     pub fn decr_depth(&mut self, delta: usize) {
         self.outer_stack_depth -= delta;
     }

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -8,7 +8,7 @@ use crate::compiler::instructions::{
 };
 use crate::environment::Environment;
 use crate::error::{Error, ErrorKind};
-use crate::output::Output;
+use crate::output::{CaptureMode, Output};
 use crate::utils::AutoEscape;
 use crate::value::{self, ops, MapType, Value, ValueMap, ValueRepr};
 use crate::vm::context::{Context, Frame, LoopState, Stack};
@@ -27,6 +27,7 @@ mod macro_object;
 mod state;
 
 // the cost of a single include against the stack limit.
+#[cfg(feature = "multi-template")]
 const INCLUDE_RECURSION_COST: usize = 10;
 
 /// Helps to evaluate something.
@@ -151,6 +152,12 @@ impl<'env> Vm<'env> {
         let mut loaded_filters = [None; MAX_LOCALS];
         let mut loaded_tests = [None; MAX_LOCALS];
 
+        // If we are extending we are holding the instructions of the target parent
+        // template here.  This is used to detect multiple extends and the evaluation
+        // uses these instructions when RenderParent is evaluated.
+        #[cfg(feature = "multi-template")]
+        let mut parent_instructions = None;
+
         macro_rules! recurse_loop {
             ($capture:expr) => {{
                 let jump_target = ctx_ok!(self.prepare_loop_recursion(state));
@@ -160,7 +167,7 @@ impl<'env> Vm<'env> {
                 // to.
                 next_loop_recursion_jump = Some((pc + 1, $capture));
                 if $capture {
-                    out.begin_capture();
+                    out.begin_capture(CaptureMode::Capture);
                 }
                 pc = jump_target;
                 continue;
@@ -377,24 +384,27 @@ impl<'env> Vm<'env> {
                         stack.pop();
                     }
                 }
+                #[cfg(feature = "multi-template")]
                 Instruction::CallBlock(name) => {
-                    let old_block = state.current_block;
-                    state.current_block = Some(name);
-                    if let Some(block_stack) = state.blocks.get(name) {
-                        let old_instructions =
-                            mem::replace(&mut state.instructions, block_stack.instructions());
-                        ctx_ok!(state.ctx.push_frame(Frame::default()));
-                        let rv = self.eval_state(state, out);
-                        state.ctx.pop_frame();
-                        state.instructions = old_instructions;
-                        ctx_ok!(rv);
-                    } else {
-                        bail!(Error::new(
-                            ErrorKind::InvalidOperation,
-                            "tried to invoke unknown block"
-                        ));
+                    if parent_instructions.is_none() {
+                        let old_block = state.current_block;
+                        state.current_block = Some(name);
+                        if let Some(block_stack) = state.blocks.get(name) {
+                            let old_instructions =
+                                mem::replace(&mut state.instructions, block_stack.instructions());
+                            ctx_ok!(state.ctx.push_frame(Frame::default()));
+                            let rv = self.eval_state(state, out);
+                            state.ctx.pop_frame();
+                            state.instructions = old_instructions;
+                            ctx_ok!(rv);
+                        } else {
+                            bail!(Error::new(
+                                ErrorKind::InvalidOperation,
+                                "tried to invoke unknown block"
+                            ));
+                        }
+                        state.current_block = old_block;
                     }
-                    state.current_block = old_block;
                 }
                 Instruction::PushAutoEscape => {
                     a = stack.pop();
@@ -404,8 +414,8 @@ impl<'env> Vm<'env> {
                 Instruction::PopAutoEscape => {
                     state.auto_escape = auto_escape_stack.pop().unwrap();
                 }
-                Instruction::BeginCapture => {
-                    out.begin_capture();
+                Instruction::BeginCapture(mode) => {
+                    out.begin_capture(*mode);
                 }
                 Instruction::EndCapture => {
                     stack.push(out.end_capture(state.auto_escape));
@@ -494,10 +504,43 @@ impl<'env> Vm<'env> {
                 Instruction::FastRecurse => {
                     recurse_loop!(false);
                 }
+                // Explanation on the behavior of `LoadBlocks` and `RenderParent`.
+                // MiniJinja inherits the behavior from Jinja2 where extending
+                // loads the blocks (`LoadBlocks`) and the rest of the template
+                // keeps executing but with output disabled, only at the end the
+                // parent template is then invoked (`RenderParent`).  This has the
+                // effect that you can still set variables or declare macros and
+                // that they become visible in the blocks.
+                // 
+                // This behavior has a few downsides.  First of all what happens
+                // in the parent template overrides what happens in the child.
+                // For instance if you declare a macro named `foo` after `{%
+                // extends %}` and then a variable with that named is also set
+                // in the parent template, then you won't be able to call that
+                // macro in the body.
+                //
+                // The reason for this is that blocks unlike macros do not have
+                // closures in Jinja2/MiniJinja.
+                //
+                // However for the common case this is convenient because it
+                // lets you put some imports there and for as long as you do not
+                // create name clashes this works fine.
                 #[cfg(feature = "multi-template")]
                 Instruction::LoadBlocks => {
                     a = stack.pop();
-                    ctx_ok!(self.load_blocks(a, state));
+                    if parent_instructions.is_some() {
+                        bail!(Error::new(
+                            ErrorKind::InvalidOperation,
+                            "tried to extend a second time in a template"
+                        ));
+                    }
+                    parent_instructions = Some(ctx_ok!(self.load_blocks(a, state)));
+                    out.begin_capture(CaptureMode::Discard);
+                }
+                #[cfg(feature = "multi-template")]
+                Instruction::RenderParent => {
+                    out.end_capture(AutoEscape::None);
+                    state.instructions = parent_instructions.take().unwrap();
 
                     // then replace the instructions and set the pc to 0 again.
                     // this effectively means that the template engine will now
@@ -622,7 +665,7 @@ impl<'env> Vm<'env> {
         }
 
         if capture {
-            out.begin_capture();
+            out.begin_capture(CaptureMode::Capture);
         }
 
         let old_instructions = mem::replace(&mut state.instructions, block_stack.instructions());
@@ -661,7 +704,11 @@ impl<'env> Vm<'env> {
     }
 
     #[cfg(feature = "multi-template")]
-    fn load_blocks(&self, name: Value, state: &mut State<'_, 'env>) -> Result<(), Error> {
+    fn load_blocks(
+        &self,
+        name: Value,
+        state: &mut State<'_, 'env>,
+    ) -> Result<&'env Instructions<'env>, Error> {
         let name = match name.as_str() {
             Some(name) => name,
             None => {
@@ -689,8 +736,7 @@ impl<'env> Vm<'env> {
                 .or_insert_with(BlockStack::default)
                 .append_instructions(instr);
         }
-        state.instructions = tmpl.instructions();
-        Ok(())
+        Ok(tmpl.instructions())
     }
 
     fn derive_auto_escape(

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -511,7 +511,7 @@ impl<'env> Vm<'env> {
                 // parent template is then invoked (`RenderParent`).  This has the
                 // effect that you can still set variables or declare macros and
                 // that they become visible in the blocks.
-                // 
+                //
                 // This behavior has a few downsides.  First of all what happens
                 // in the parent template overrides what happens in the child.
                 // For instance if you declare a macro named `foo` after `{%

--- a/minijinja/src/vm/state.rs
+++ b/minijinja/src/vm/state.rs
@@ -27,6 +27,7 @@ pub struct State<'vm, 'env> {
     pub(crate) auto_escape: AutoEscape,
     pub(crate) instructions: &'vm Instructions<'env>,
     pub(crate) blocks: BTreeMap<&'env str, BlockStack<'vm, 'env>>,
+    #[allow(unused)]
     pub(crate) loaded_templates: BTreeSet<&'env str>,
     #[cfg(feature = "macros")]
     pub(crate) macros: std::sync::Arc<Vec<(&'vm Instructions<'env>, usize)>>,

--- a/minijinja/tests/inputs/block_scope_extends.txt
+++ b/minijinja/tests/inputs/block_scope_extends.txt
@@ -1,0 +1,6 @@
+{
+  "template": "var_referencing_layout.txt"
+}
+---
+{% extends template %}
+{% block item_block %}[{{ item }}]{% endblock %}

--- a/minijinja/tests/inputs/err_extends_twice.txt
+++ b/minijinja/tests/inputs/err_extends_twice.txt
@@ -1,0 +1,6 @@
+{
+  "template": "simple_layout.txt"
+}
+---
+{% extends template %}
+{% extends template %}

--- a/minijinja/tests/inputs/extends_set.txt
+++ b/minijinja/tests/inputs/extends_set.txt
@@ -1,0 +1,6 @@
+{
+  "template": "layout_with_var.txt"
+}
+---
+{% extends template %}
+{% set var = "the value from the child" %}

--- a/minijinja/tests/inputs/macro_extends.txt
+++ b/minijinja/tests/inputs/macro_extends.txt
@@ -1,0 +1,8 @@
+{
+  "template": "simple_layout.txt"
+}
+---
+{%- extends template %}
+{%- macro foo() %}inside foo{% endmacro %}
+{%- block title %}{{ foo() }}{% endblock %}
+{%- block body %}new body{% endblock %}

--- a/minijinja/tests/inputs/refs/layout_with_var.txt
+++ b/minijinja/tests/inputs/refs/layout_with_var.txt
@@ -1,0 +1,1 @@
+{% block body %}{{ var }}{% endblock %}

--- a/minijinja/tests/inputs/refs/var_referencing_layout.txt
+++ b/minijinja/tests/inputs/refs/var_referencing_layout.txt
@@ -1,0 +1,3 @@
+{% for item in [1, 2, 3] %}
+  {% block item_block %}{{ item }}{% endblock %}
+{% endfor %}

--- a/minijinja/tests/snapshots/test_templates__vm@block_scope_extends.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@block_scope_extends.txt.snap
@@ -1,0 +1,15 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{% extends template %}\n{% block item_block %}[{{ item }}]{% endblock %}"
+info:
+  template: var_referencing_layout.txt
+input_file: minijinja/tests/inputs/block_scope_extends.txt
+---
+
+  [1]
+
+  [2]
+
+  [3]
+
+

--- a/minijinja/tests/snapshots/test_templates__vm@debug.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@debug.txt.snap
@@ -85,6 +85,7 @@ State {
             "simple_include.txt",
             "simple_layout.txt",
             "super_with_html.html",
+            "var_referencing_layout.txt",
             "var_setting_layout.txt",
         ],
     },

--- a/minijinja/tests/snapshots/test_templates__vm@debug.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@debug.txt.snap
@@ -78,6 +78,7 @@ State {
             "debug.txt",
             "example_macro.txt",
             "include_with_var_and_macro.txt",
+            "layout_with_var.txt",
             "self-extends.txt",
             "self-include.txt",
             "simple2_layout.txt",

--- a/minijinja/tests/snapshots/test_templates__vm@err_extends_twice.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@err_extends_twice.txt.snap
@@ -1,0 +1,27 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{% extends template %}\n{% extends template %}"
+info:
+  template: simple_layout.txt
+input_file: minijinja/tests/inputs/err_extends_twice.txt
+---
+!!!ERROR!!!
+
+Error {
+    kind: InvalidOperation,
+    detail: "tried to extend a second time in a template",
+    name: "err_extends_twice.txt",
+    line: 2,
+}
+
+invalid operation: tried to extend a second time in a template (in err_extends_twice.txt:2)
+---------------------------- err_extends_twice.txt ----------------------------
+   1 | {% extends template %}
+   2 > {% extends template %}
+     i    ^^^^^^^^^^^^^^^^ invalid operation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Referenced variables: {
+    template: "simple_layout.txt",
+}
+-------------------------------------------------------------------------------
+

--- a/minijinja/tests/snapshots/test_templates__vm@err_self_extends.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@err_self_extends.txt.snap
@@ -16,6 +16,7 @@ Error {
 invalid operation: cycle in template inheritance. "self-extends.txt" was referenced more than once (in self-extends.txt:1)
 ------------------------------ self-extends.txt -------------------------------
    1 > {% extends "self-extends.txt" %}
+     i    ^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid operation
    2 | {% block wat %}{% endblock %}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 No referenced variables

--- a/minijinja/tests/snapshots/test_templates__vm@extends_set.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@extends_set.txt.snap
@@ -1,0 +1,9 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{% extends template %}\n{% set var = \"the value from the child\" %}"
+info:
+  template: layout_with_var.txt
+input_file: minijinja/tests/inputs/extends_set.txt
+---
+the value from the child
+

--- a/minijinja/tests/snapshots/test_templates__vm@macro_extends.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@macro_extends.txt.snap
@@ -1,0 +1,10 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{%- extends template %}\n{%- macro foo() %}inside foo{% endmacro %}\n{%- block title %}{{ foo() }}{% endblock %}\n{%- block body %}new body{% endblock %}"
+info:
+  template: simple_layout.txt
+input_file: minijinja/tests/inputs/macro_extends.txt
+---
+<title>inside foo</title>
+new body
+


### PR DESCRIPTION
This aligns the runtime behavior of `{% extends %}` with Jinja2. Fixes #136 

Specifically top level assignments (or macro declarations) still execute before the parent template is included. This behavior is somewhat dubious because it can lead to unexpected results if the parent template uses the same variable name. Longer term it might be wise to correct this, but for now this is an acceptable tradeoff.

This also removes `{% block %}` if the `multi-template` feature is not turned on which was an accidental omission.