### PR TITLE
Expose a way to hold on to the arc on object creation

### DIFF
--- a/minijinja/src/vm/context.rs
+++ b/minijinja/src/vm/context.rs
@@ -179,7 +179,7 @@ impl<'env> Context<'env> {
             // if we are a loop, check if we are looking up the special loop var.
             if let Some(ref l) = frame.current_loop {
                 if l.with_loop_var && key == "loop" {
-                    return Some(Value::from_rc_object(l.object.clone()));
+                    return Some(Value::from_arc_object(l.object.clone()));
                 }
             }
 


### PR DESCRIPTION
Since the value is already `Arc`ed there are cases where it's nice to be able to hold on to them.

Refs #139 