### PR TITLE
Implemented Revamped Object Model

### DIFF
--- a/examples/dynamic/src/main.rs
+++ b/examples/dynamic/src/main.rs
@@ -50,7 +50,7 @@ impl Object for Magic {
             Ok(Value::from(format!("magic-{}", tag)))
         } else {
             Err(Error::new(
-                minijinja::ErrorKind::InvalidOperation,
+                minijinja::ErrorKind::UnknownMethod,
                 format!("object has no method named {}", name),
             ))
         }

--- a/examples/dynamic/src/main.rs
+++ b/examples/dynamic/src/main.rs
@@ -2,7 +2,7 @@
 use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use minijinja::value::{from_args, Object, Value};
+use minijinja::value::{from_args, Object, SeqObject, Value};
 use minijinja::{Environment, Error, State};
 
 #[derive(Debug)]
@@ -57,10 +57,27 @@ impl Object for Magic {
     }
 }
 
+struct SimpleDynamicSeq;
+
+impl SeqObject for SimpleDynamicSeq {
+    fn get_item(&self, idx: usize) -> Option<Value> {
+        if idx < 3 {
+            Some(Value::from(idx * 2))
+        } else {
+            None
+        }
+    }
+
+    fn item_count(&self) -> usize {
+        3
+    }
+}
+
 fn main() {
     let mut env = Environment::new();
     env.add_function("cycler", make_cycler);
     env.add_global("magic", Value::from_object(Magic));
+    env.add_global("seq", Value::from_seq_object(SimpleDynamicSeq));
     env.add_template("template.html", include_str!("template.html"))
         .unwrap();
 

--- a/examples/dynamic/src/template.html
+++ b/examples/dynamic/src/template.html
@@ -5,3 +5,7 @@
   {%- endfor %}
   </ul>
 {%- endwith %}
+
+{% for item in seq %}
+  [{{ item }}]
+{% endfor %}

--- a/examples/load-lazy/src/main.rs
+++ b/examples/load-lazy/src/main.rs
@@ -4,8 +4,8 @@ use std::fmt;
 use std::fs;
 use std::sync::Mutex;
 
-use minijinja::value::AsStruct;
-use minijinja::value::ObjectBehavior;
+use minijinja::value::ObjectKind;
+use minijinja::value::StructObject;
 use minijinja::value::{Object, Value};
 use minijinja::Environment;
 
@@ -21,12 +21,12 @@ impl fmt::Display for Site {
 }
 
 impl Object for Site {
-    fn behavior(&self) -> ObjectBehavior<'_> {
-        ObjectBehavior::Struct(self)
+    fn kind(&self) -> ObjectKind<'_> {
+        ObjectKind::Struct(self)
     }
 }
 
-impl AsStruct for Site {
+impl StructObject for Site {
     /// This loads a file on attribute access.  Note that attribute access
     /// can neither access the state nor return failures as such it can at
     /// max turn into an undefined object.

--- a/examples/load-lazy/src/main.rs
+++ b/examples/load-lazy/src/main.rs
@@ -33,7 +33,7 @@ impl StructObject for Site {
     ///
     /// If that is necessary, use `call_method()` instead which is able to
     /// both access interpreter state and fail.
-    fn get(&self, name: &str) -> Option<Value> {
+    fn get_field(&self, name: &str) -> Option<Value> {
         let mut cache = self.cache.lock().unwrap();
         if let Some(rv) = cache.get(name) {
             return Some(rv.clone());

--- a/examples/load-lazy/src/main.rs
+++ b/examples/load-lazy/src/main.rs
@@ -4,6 +4,8 @@ use std::fmt;
 use std::fs;
 use std::sync::Mutex;
 
+use minijinja::value::AsStruct;
+use minijinja::value::ObjectBehavior;
 use minijinja::value::{Object, Value};
 use minijinja::Environment;
 
@@ -19,13 +21,19 @@ impl fmt::Display for Site {
 }
 
 impl Object for Site {
+    fn behavior(&self) -> ObjectBehavior<'_> {
+        ObjectBehavior::Struct(self)
+    }
+}
+
+impl AsStruct for Site {
     /// This loads a file on attribute access.  Note that attribute access
     /// can neither access the state nor return failures as such it can at
     /// max turn into an undefined object.
     ///
     /// If that is necessary, use `call_method()` instead which is able to
     /// both access interpreter state and fail.
-    fn get_attr(&self, name: &str) -> Option<Value> {
+    fn get(&self, name: &str) -> Option<Value> {
         let mut cache = self.cache.lock().unwrap();
         if let Some(rv) = cache.get(name) {
             return Some(rv.clone());

--- a/minijinja/src/error.rs
+++ b/minijinja/src/error.rs
@@ -118,6 +118,8 @@ pub enum ErrorKind {
     UnknownTest,
     /// A function is unknown
     UnknownFunction,
+    /// Un unknown method was called
+    UnknownMethod,
     /// A bad escape sequence in a string was encountered.
     BadEscape,
     /// An operation on an undefined value was attempted.
@@ -147,6 +149,7 @@ impl ErrorKind {
             ErrorKind::UnknownFilter => "unknown filter",
             ErrorKind::UnknownFunction => "unknown function",
             ErrorKind::UnknownTest => "unknown test",
+            ErrorKind::UnknownMethod => "unknown method",
             ErrorKind::BadEscape => "bad string escape",
             ErrorKind::UndefinedError => "undefined value",
             ErrorKind::BadSerialization => "could not serialize to internal format",

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -405,12 +405,7 @@ mod builtins {
         if let Some(s) = v.as_str() {
             Ok(Value::from(s.chars().rev().collect::<String>()))
         } else if let Some(seq) = v.as_seq() {
-            Ok(Value::from(
-                (0..seq.seq_len())
-                    .rev()
-                    .map(|idx| seq.get_item(idx).unwrap_or(Value::UNDEFINED))
-                    .collect::<Vec<_>>(),
-            ))
+            Ok(Value::from(seq.iter().rev().collect::<Vec<_>>()))
         } else {
             Err(Error::new(
                 ErrorKind::InvalidOperation,
@@ -451,8 +446,7 @@ mod builtins {
             Ok(rv)
         } else if let Some(seq) = val.as_seq() {
             let mut rv = String::new();
-            for idx in 0..seq.seq_len() {
-                let item = seq.get_item(idx).unwrap_or(Value::UNDEFINED);
+            for item in seq.iter() {
                 if !rv.is_empty() {
                     rv.push_str(joiner);
                 }
@@ -573,13 +567,7 @@ mod builtins {
         if let Some(s) = value.as_str() {
             Ok(s.chars().rev().next().map_or(Value::UNDEFINED, Value::from))
         } else if let Some(seq) = value.as_seq() {
-            let len = seq.seq_len();
-            Ok(if len == 0 {
-                None
-            } else {
-                seq.get_item(len - 1)
-            }
-            .unwrap_or(Value::UNDEFINED))
+            Ok(seq.iter().last().unwrap_or(Value::UNDEFINED))
         } else {
             Err(Error::new(
                 ErrorKind::InvalidOperation,

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -406,7 +406,11 @@ mod builtins {
             Ok(Value::from(s.chars().rev().collect::<String>()))
         } else if matches!(v.kind(), ValueKind::Seq) {
             Ok(Value::from(
-                ok!(v.as_cow_slice()).iter().rev().cloned().collect::<Vec<_>>(),
+                ok!(v.as_cow_slice())
+                    .iter()
+                    .rev()
+                    .cloned()
+                    .collect::<Vec<_>>(),
             ))
         } else {
             Err(Error::new(

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -406,7 +406,7 @@ mod builtins {
             Ok(Value::from(s.chars().rev().collect::<String>()))
         } else if matches!(v.kind(), ValueKind::Seq) {
             Ok(Value::from(
-                ok!(v.as_slice()).iter().rev().cloned().collect::<Vec<_>>(),
+                ok!(v.as_cow_slice()).iter().rev().cloned().collect::<Vec<_>>(),
             ))
         } else {
             Err(Error::new(
@@ -448,7 +448,7 @@ mod builtins {
             Ok(rv)
         } else if matches!(val.kind(), ValueKind::Seq) {
             let mut rv = String::new();
-            for item in ok!(val.as_slice()) {
+            for item in &ok!(val.as_cow_slice())[..] {
                 if !rv.is_empty() {
                     rv.push_str(joiner);
                 }

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -869,6 +869,36 @@ mod builtins {
             );
         });
     }
+
+    #[test]
+    fn test_values_in_vec() {
+        fn upper(value: &str) -> String {
+            value.to_uppercase()
+        }
+
+        fn sum(value: Vec<i64>) -> i64 {
+            value.into_iter().sum::<i64>()
+        }
+
+        let upper = BoxedFilter::new(upper);
+        let sum = BoxedFilter::new(sum);
+
+        let env = crate::Environment::new();
+        State::with_dummy(&env, |state| {
+            assert_eq!(
+                upper
+                    .apply_to(state, &[Value::from("Hello World!")])
+                    .unwrap(),
+                Value::from("HELLO WORLD!")
+            );
+
+            assert_eq!(
+                sum.apply_to(state, &[Value::from(vec![Value::from(1), Value::from(2)])])
+                    .unwrap(),
+                Value::from(3)
+            );
+        });
+    }
 }
 
 #[cfg(feature = "builtins")]

--- a/minijinja/src/value/argtypes.rs
+++ b/minijinja/src/value/argtypes.rs
@@ -466,18 +466,6 @@ impl<'a> ArgType<'a> for &Value {
     }
 }
 
-impl<'a> ArgType<'a> for Cow<'_, [Value]> {
-    type Output = Cow<'a, [Value]>;
-
-    #[inline(always)]
-    fn from_value(value: Option<&'a Value>) -> Result<Cow<'a, [Value]>, Error> {
-        match value {
-            Some(value) => Ok(ok!(value.as_cow_slice())),
-            None => Err(Error::from(ErrorKind::MissingArgument)),
-        }
-    }
-}
-
 impl<'a> ArgType<'a> for &[Value] {
     type Output = &'a [Value];
 

--- a/minijinja/src/value/argtypes.rs
+++ b/minijinja/src/value/argtypes.rs
@@ -5,7 +5,9 @@ use std::ops::{Deref, DerefMut};
 
 use crate::error::{Error, ErrorKind};
 use crate::key::{Key, StaticKey};
-use crate::value::{Arc, MapType, Object, Packed, StringType, Value, ValueKind, ValueRepr};
+use crate::value::{
+    Arc, MapType, Object, Packed, SeqObject, StringType, Value, ValueKind, ValueRepr,
+};
 use crate::vm::State;
 
 /// A utility trait that represents the return value of functions and filters.
@@ -90,10 +92,11 @@ where
 /// * signed integers: [`i8`], [`i16`], [`i32`], [`i64`], [`i128`]
 /// * floats: [`f32`], [`f64`]
 /// * bool: [`bool`]
-/// * string: [`String`], [`&str`], `Cow<'_, str>` ([`char`])
+/// * string: [`String`], [`&str`], `Cow<'_, str>`, [`char`]
 /// * bytes: [`&[u8]`][`slice`]
 /// * values: [`Value`], `&Value`
-/// * vectors: [`Vec<T>`], `&[Value]`
+/// * vectors: [`Vec<T>`]
+/// * sequences: [`&dyn SeqObject`](crate::value::SeqObject)
 ///
 /// The type is also implemented for optional values (`Option<T>`) which is used
 /// to encode optional parameters to filters, functions or tests.  Additionally
@@ -111,8 +114,9 @@ where
 /// Byte slices will borrow out of values carrying bytes or strings.  In the latter
 /// case the utf-8 bytes are returned.
 ///
-/// Similarly it's not possible to borrow dynamic slices
-/// ([`SeqObject`](crate::value::SeqObject)) into `&[Value]`.
+/// There are also further restrictions imposed on borrowing in some situations.
+/// For instance you cannot implicitly borrow out of sequences which means that
+/// for instance `Vec<&str>` is not a legal argument.
 ///
 /// ## Notes on State
 ///
@@ -125,6 +129,14 @@ pub trait ArgType<'a> {
 
     #[doc(hidden)]
     fn from_value(value: Option<&'a Value>) -> Result<Self::Output, Error>;
+
+    #[doc(hidden)]
+    fn from_value_owned(_value: Value) -> Result<Self::Output, Error> {
+        Err(Error::new(
+            ErrorKind::InvalidOperation,
+            "type conversion is not legal in this situation (implicit borrow)",
+        ))
+    }
 
     #[doc(hidden)]
     fn from_state_and_value(
@@ -354,6 +366,10 @@ macro_rules! primitive_try_from {
                     None => Err(Error::from(ErrorKind::MissingArgument))
                 }
             }
+
+            fn from_value_owned(value: Value) -> Result<Self, Error> {
+                TryFrom::try_from(value)
+            }
         }
     }
 }
@@ -425,6 +441,20 @@ impl<'a> ArgType<'a> for &[u8] {
     }
 }
 
+impl<'a> ArgType<'a> for &dyn SeqObject {
+    type Output = &'a dyn SeqObject;
+
+    #[inline(always)]
+    fn from_value(value: Option<&'a Value>) -> Result<Self::Output, Error> {
+        match value {
+            Some(value) => value
+                .as_seq()
+                .ok_or_else(|| Error::new(ErrorKind::InvalidOperation, "value is not a sequence")),
+            None => Err(Error::from(ErrorKind::MissingArgument)),
+        }
+    }
+}
+
 impl<'a, T: ArgType<'a>> ArgType<'a> for Option<T> {
     type Output = Option<T::Output>;
 
@@ -438,6 +468,14 @@ impl<'a, T: ArgType<'a>> ArgType<'a> for Option<T> {
                 }
             }
             None => Ok(None),
+        }
+    }
+
+    fn from_value_owned(value: Value) -> Result<Self::Output, Error> {
+        if value.is_undefined() || value.is_none() {
+            Ok(None)
+        } else {
+            T::from_value_owned(value).map(Some)
         }
     }
 }
@@ -461,18 +499,6 @@ impl<'a> ArgType<'a> for &Value {
     fn from_value(value: Option<&'a Value>) -> Result<&'a Value, Error> {
         match value {
             Some(value) => Ok(value),
-            None => Err(Error::from(ErrorKind::MissingArgument)),
-        }
-    }
-}
-
-impl<'a> ArgType<'a> for &[Value] {
-    type Output = &'a [Value];
-
-    #[inline(always)]
-    fn from_value(value: Option<&'a Value>) -> Result<&'a [Value], Error> {
-        match value {
-            Some(value) => value.as_slice(),
             None => Err(Error::from(ErrorKind::MissingArgument)),
         }
     }
@@ -550,6 +576,10 @@ impl<'a> ArgType<'a> for Value {
             None => Err(Error::from(ErrorKind::MissingArgument)),
         }
     }
+
+    fn from_value_owned(value: Value) -> Result<Self, Error> {
+        Ok(value)
+    }
 }
 
 impl<'a> ArgType<'a> for String {
@@ -560,6 +590,41 @@ impl<'a> ArgType<'a> for String {
             Some(value) => Ok(value.to_string()),
             None => Err(Error::from(ErrorKind::MissingArgument)),
         }
+    }
+
+    fn from_value_owned(value: Value) -> Result<Self, Error> {
+        Ok(value.to_string())
+    }
+}
+
+impl<'a, T: ArgType<'a, Output = T>> ArgType<'a> for Vec<T> {
+    type Output = Vec<T>;
+
+    fn from_value(value: Option<&'a Value>) -> Result<Self, Error> {
+        match value {
+            None => Ok(Vec::new()),
+            Some(value) => {
+                let seq = ok!(value
+                    .as_seq()
+                    .ok_or_else(|| { Error::new(ErrorKind::InvalidOperation, "not a sequence") }));
+                let mut rv = Vec::new();
+                for value in seq.iter() {
+                    rv.push(ok!(T::from_value_owned(value)));
+                }
+                Ok(rv)
+            }
+        }
+    }
+
+    fn from_value_owned(value: Value) -> Result<Self, Error> {
+        let seq = ok!(value
+            .as_seq()
+            .ok_or_else(|| { Error::new(ErrorKind::InvalidOperation, "not a sequence") }));
+        let mut rv = Vec::new();
+        for value in seq.iter() {
+            rv.push(ok!(T::from_value_owned(value)));
+        }
+        Ok(rv)
     }
 }
 
@@ -572,23 +637,5 @@ impl From<Value> for String {
 impl From<usize> for Value {
     fn from(val: usize) -> Self {
         Value::from(val as u64)
-    }
-}
-
-impl<'a, T: ArgType<'a, Output = T>> ArgType<'a> for Vec<T> {
-    type Output = Vec<T>;
-
-    fn from_value(value: Option<&'a Value>) -> Result<Self, Error> {
-        match value {
-            None => Ok(Vec::new()),
-            Some(values) => {
-                let values = ok!(values.as_slice());
-                let mut rv = Vec::new();
-                for value in values {
-                    rv.push(ok!(T::from_value(Some(value))));
-                }
-                Ok(rv)
-            }
-        }
     }
 }

--- a/minijinja/src/value/argtypes.rs
+++ b/minijinja/src/value/argtypes.rs
@@ -111,8 +111,8 @@ where
 /// Byte slices will borrow out of values carrying bytes or strings.  In the latter
 /// case the utf-8 bytes are returned.
 ///
-/// Similarly it's not possible to borrow dynamic slices ([`AsSlice`](crate::value::AsSlice))
-/// into `&[Value]`.
+/// Similarly it's not possible to borrow dynamic slices
+/// ([`SeqObject`](crate::value::SeqObject)) into `&[Value]`.
 ///
 /// ## Notes on State
 ///

--- a/minijinja/src/value/argtypes.rs
+++ b/minijinja/src/value/argtypes.rs
@@ -582,7 +582,6 @@ impl<'a, T: ArgType<'a, Output = T>> ArgType<'a> for Vec<T> {
         match value {
             None => Ok(Vec::new()),
             Some(values) => {
-                // TODO: can we somehow use values.as_cow_slice?
                 let values = ok!(values.as_slice());
                 let mut rv = Vec::new();
                 for value in values {

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -120,7 +120,7 @@ use crate::value::serialize::ValueSerializer;
 use crate::vm::State;
 
 pub use crate::value::argtypes::{from_args, ArgType, FunctionArgs, FunctionResult, Rest};
-pub use crate::value::object::{Object, ObjectKind, SeqObject, StructObject};
+pub use crate::value::object::{Object, ObjectKind, SeqIter, SeqObject, StructObject};
 
 mod argtypes;
 #[cfg(feature = "deserialization")]
@@ -997,8 +997,8 @@ impl Serialize for Value {
                 ObjectKind::Seq(s) => {
                     use serde::ser::SerializeSeq;
                     let mut seq = ok!(serializer.serialize_seq(Some(s.seq_len())));
-                    for idx in 0..s.seq_len() {
-                        ok!(seq.serialize_element(&s.get_item(idx).unwrap_or(Value::UNDEFINED)));
+                    for item in s.iter() {
+                        ok!(seq.serialize_element(&item));
                     }
                     seq.end()
                 }

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -642,25 +642,6 @@ impl Value {
         None
     }
 
-    /// If the value is a sequence it's returned as slice.
-    pub(crate) fn as_slice(&self) -> Result<&[Value], Error> {
-        match self.0 {
-            ValueRepr::Undefined | ValueRepr::None => return Ok(&[][..]),
-            ValueRepr::Seq(ref v) => return Ok(&v[..]),
-            ValueRepr::Dynamic(ref dy) if matches!(dy.kind(), ObjectKind::Seq(_)) => {
-                return Err(Error::new(
-                    ErrorKind::InvalidOperation,
-                    "dynamic sequence value cannot be borrowed as slice",
-                ));
-            }
-            _ => {}
-        }
-        Err(Error::new(
-            ErrorKind::InvalidOperation,
-            format!("value of type {} is not a sequence", self.kind()),
-        ))
-    }
-
     /// Returns the length of the contained value.
     ///
     /// Values without a length will return `None`.
@@ -1180,19 +1161,4 @@ fn test_dynamic_object_roundtrip() {
 #[cfg(target_pointer_width = "64")]
 fn test_sizes() {
     assert_eq!(std::mem::size_of::<Value>(), 24);
-}
-
-#[test]
-fn test_value_as_slice() {
-    let val = Value::from(vec![1u32, 2, 3]);
-    assert_eq!(
-        val.as_slice().unwrap(),
-        &[Value::from(1), Value::from(2), Value::from(3)]
-    );
-    assert_eq!(Value::UNDEFINED.as_slice().unwrap(), &[]);
-    assert_eq!(Value::from(()).as_slice().unwrap(), &[]);
-    assert_eq!(
-        Value::from("foo").as_slice().unwrap_err().kind(),
-        ErrorKind::InvalidOperation
-    );
 }

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -824,7 +824,18 @@ impl Value {
                 }
             }
             ValueRepr::Dynamic(ref dy) => match dy.kind() {
-                ObjectKind::Basic | ObjectKind::Seq(_) => {}
+                ObjectKind::Basic => {}
+                ObjectKind::Seq(s) => {
+                    if let Key::I64(idx) = key {
+                        let idx = some!(isize::try_from(idx).ok());
+                        let idx = if idx < 0 {
+                            some!(s.len().checked_sub(-idx as usize))
+                        } else {
+                            idx as usize
+                        };
+                        return s.get(idx);
+                    }
+                }
                 ObjectKind::Struct(s) => match key {
                     Key::String(ref key) => return s.get(key),
                     Key::Str(key) => return s.get(key),

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -593,7 +593,7 @@ impl Value {
         }
     }
 
-    /// If the value is a sequence it's returned as sequence object.
+    /// If the value is a sequence it's returned as [`SeqObject`].
     pub fn as_seq(&self) -> Option<&dyn SeqObject> {
         match self.0 {
             ValueRepr::Seq(ref v) => return Some(&**v as &dyn SeqObject),
@@ -603,6 +603,16 @@ impl Value {
                 }
             }
             _ => {}
+        }
+        None
+    }
+
+    /// If the value is a struct, return it as [`StructObject`].
+    pub fn as_struct(&self) -> Option<&dyn StructObject> {
+        if let ValueRepr::Dynamic(ref dy) = self.0 {
+            if let ObjectKind::Struct(s) = dy.kind() {
+                return Some(s);
+            }
         }
         None
     }

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -120,7 +120,7 @@ use crate::value::serialize::ValueSerializer;
 use crate::vm::State;
 
 pub use crate::value::argtypes::{from_args, ArgType, FunctionArgs, FunctionResult, Rest};
-pub use crate::value::object::{Object, ObjectKind, SeqIter, SeqObject, StructObject};
+pub use crate::value::object::{Object, ObjectKind, SeqObject, SeqObjectIter, StructObject};
 
 mod argtypes;
 #[cfg(feature = "deserialization")]

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -156,7 +156,7 @@ pub enum ObjectKind<'a> {
 ///         }
 ///     }
 ///
-///     fn seq_len(&self) -> usize {
+///     fn item_count(&self) -> usize {
 ///         3
 ///     }
 /// }
@@ -166,13 +166,13 @@ pub enum ObjectKind<'a> {
 pub trait SeqObject {
     /// Looks up an item by index.
     ///
-    /// Sequences should provide a value for all items in the range of `0..seq_len`
+    /// Sequences should provide a value for all items in the range of `0..item_count`
     /// but the engine will assume that items within the range are `Undefined`
     /// if `None` is returned.
     fn get_item(&self, idx: usize) -> Option<Value>;
 
     /// Returns the number of items in the sequence.
-    fn seq_len(&self) -> usize;
+    fn item_count(&self) -> usize;
 }
 
 impl dyn SeqObject + '_ {
@@ -180,7 +180,7 @@ impl dyn SeqObject + '_ {
     pub fn iter(&self) -> SeqObjectIter<'_> {
         SeqObjectIter {
             seq: self,
-            range: 0..self.seq_len(),
+            range: 0..self.item_count(),
         }
     }
 }
@@ -192,7 +192,7 @@ impl<'a> SeqObject for &'a [Value] {
     }
 
     #[inline(always)]
-    fn seq_len(&self) -> usize {
+    fn item_count(&self) -> usize {
         self.len()
     }
 }
@@ -204,7 +204,7 @@ impl SeqObject for Vec<Value> {
     }
 
     #[inline(always)]
-    fn seq_len(&self) -> usize {
+    fn item_count(&self) -> usize {
         self.len()
     }
 }
@@ -311,7 +311,7 @@ pub trait StructObject {
     /// Returns the number of fields in the struct.
     ///
     /// The default implementation returns the number of fields.
-    fn struct_size(&self) -> usize {
+    fn field_count(&self) -> usize {
         self.fields().count()
     }
 }

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -164,6 +164,10 @@ pub enum ObjectKind<'a> {
 /// ```
 pub trait SeqObject {
     /// Looks up an item by index.
+    ///
+    /// Sequences should provide a value for all items in the range of `0..len`
+    /// but the engine will assume that items within the range are `Undefined`
+    /// if `None` is returned.
     fn get(&self, idx: usize) -> Option<Value>;
 
     /// Returns the number of items in the sequence.

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -177,8 +177,8 @@ pub trait SeqObject {
 
 impl dyn SeqObject + '_ {
     /// Convenient iterator over a [`SeqObject`].
-    pub fn iter(&self) -> SeqIter<'_> {
-        SeqIter {
+    pub fn iter(&self) -> SeqObjectIter<'_> {
+        SeqObjectIter {
             seq: self,
             range: 0..self.seq_len(),
         }
@@ -210,12 +210,12 @@ impl SeqObject for Vec<Value> {
 }
 
 /// Iterates over [`SeqObject`]
-pub struct SeqIter<'a> {
+pub struct SeqObjectIter<'a> {
     seq: &'a dyn SeqObject,
     range: Range<usize>,
 }
 
-impl<'a> Iterator for SeqIter<'a> {
+impl<'a> Iterator for SeqObjectIter<'a> {
     type Item = Value;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -230,7 +230,7 @@ impl<'a> Iterator for SeqIter<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for SeqIter<'a> {
+impl<'a> DoubleEndedIterator for SeqObjectIter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.range
             .next_back()
@@ -238,7 +238,7 @@ impl<'a> DoubleEndedIterator for SeqIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for SeqIter<'a> {}
+impl<'a> ExactSizeIterator for SeqObjectIter<'a> {}
 
 /// Views an [`Object`] as a struct.
 ///

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -218,19 +218,21 @@ pub struct SeqObjectIter<'a> {
 impl<'a> Iterator for SeqObjectIter<'a> {
     type Item = Value;
 
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         self.range
             .next()
             .map(|idx| self.seq.get_item(idx).unwrap_or(Value::UNDEFINED))
     }
 
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.seq.seq_len();
-        (len, Some(len))
+        self.range.size_hint()
     }
 }
 
 impl<'a> DoubleEndedIterator for SeqObjectIter<'a> {
+    #[inline(always)]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.range
             .next_back()

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -22,33 +22,23 @@ use crate::vm::State;
 /// Objects need to implement [`Display`](std::fmt::Display) which is used by
 /// the engine to convert the object into a string if needed.  Additionally
 /// [`Debug`](std::fmt::Debug) is required as well.
+///
+/// To customize the behavior of the object one needs to implement
+/// [`behavior`](Self::behavior).  This defines for instance if an object is a
+/// sequence or a map.
+///
+/// For examples of how to implement objects refer to [`AsSeq`] and
+/// [`AsStruct`].
 pub trait Object: fmt::Display + fmt::Debug + Any + Sync + Send {
-    /// Invoked by the engine to get the attribute of an object.
+    /// Describes the behavior of the object.
     ///
-    /// Where possible it's a good idea for this to align with the return value
-    /// of [`attributes`](Self::attributes) but it's not necessary.
+    /// If not implemented behavior for an object is [`ObjectBehavior::Basic`]
+    /// which just means that it's stringifyable and potentially can be
+    /// called or has methods.
     ///
-    /// If an attribute does not exist, `None` shall be returned.
-    ///
-    /// A note should be made here on side effects: unlike calling objects or
-    /// calling methods on objects, accessing attributes is not supposed to
-    /// have side effects.  Neither does this API get access to the interpreter
-    /// [`State`] nor is there a channel to send out failures as only an option
-    /// can be returned.  If you do plan on doing something in attribute access
-    /// that is fallible, instead use a method call.
-    fn get_attr(&self, name: &str) -> Option<Value> {
-        let _name = name;
-        None
-    }
-
-    /// An enumeration of attributes that are known to exist on this object.
-    ///
-    /// The default implementation returns an empty iterator.  If it's not possible
-    /// to implement this, it's fine for the implementation to be omitted.  The
-    /// enumeration here is used by the `for` loop to iterate over the attributes
-    /// on the value.
-    fn attributes(&self) -> Box<dyn Iterator<Item = &str> + '_> {
-        Box::new(None.into_iter())
+    /// For more information see [`ObjectBehavior`].
+    fn behavior(&self) -> ObjectBehavior<'_> {
+        ObjectBehavior::Basic
     }
 
     /// Called when the engine tries to call a method on the object.
@@ -85,12 +75,8 @@ pub trait Object: fmt::Display + fmt::Debug + Any + Sync + Send {
 }
 
 impl<T: Object> Object for std::sync::Arc<T> {
-    fn get_attr(&self, name: &str) -> Option<Value> {
-        T::get_attr(self, name)
-    }
-
-    fn attributes(&self) -> Box<dyn Iterator<Item = &str> + '_> {
-        T::attributes(self)
+    fn behavior(&self) -> ObjectBehavior<'_> {
+        T::behavior(self)
     }
 
     fn call_method(&self, state: &State, name: &str, args: &[Value]) -> Result<Value, Error> {
@@ -99,5 +85,169 @@ impl<T: Object> Object for std::sync::Arc<T> {
 
     fn call(&self, state: &State, args: &[Value]) -> Result<Value, Error> {
         T::call(self, state, args)
+    }
+}
+
+/// Returns the object's behavior.
+///
+/// When the engine works with a dynamic object it will typically try to
+/// determine the behavior by invoking [`Object::behavior`].  More behaviors
+/// can be added in the future so this enum is non-exhaustive.
+///
+/// Today object's can have the behavior of structs and sequences but this
+/// might expand in the future.  It does mean that not all types of values can
+/// be represented by objects.
+#[non_exhaustive]
+pub enum ObjectBehavior<'a> {
+    /// This object is a basic object.
+    ///
+    /// Such an object has no attributes but it might be callable and it
+    /// can be stringified.  When serialized it's serialized in it's
+    /// stringified form.
+    Basic,
+    /// This object is a sequence.
+    Seq(&'a dyn AsSeq),
+    /// This object is a struct.
+    ///
+    /// Structs are maps with string keys.
+    Struct(&'a dyn AsStruct),
+}
+
+/// Views an [`Object`] as sequence of values.
+///
+/// # Example
+///
+/// The following example shows how to implement a dynamic object which
+/// represents a sequence of three items:
+///
+/// ```
+/// use std::fmt;
+/// use minijinja::value::{Value, Object, ObjectBehavior, AsSeq};
+///
+/// #[derive(Debug, Clone)]
+/// struct Point(f32, f32, f32);
+///
+/// impl fmt::Display for Point {
+///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+///         write!(f, "({}, {}, {})", self.0, self.1, self.2)
+///     }
+/// }
+///
+/// impl Object for Point {
+///     fn behavior(&self) -> ObjectBehavior<'_> {
+///         ObjectBehavior::Seq(self)
+///     }
+/// }
+///
+/// impl AsSeq for Point {
+///     fn get(&self, idx: usize) -> Option<Value> {
+///         match idx {
+///             0 => Some(Value::from(self.0)),
+///             1 => Some(Value::from(self.1)),
+///             2 => Some(Value::from(self.2)),
+///             _ => None,
+///         }
+///     }
+///
+///     fn len(&self) -> usize {
+///         3
+///     }
+/// }
+///
+/// let value = Value::from_object(Point(1.0, 2.5, 3.0));
+/// ```
+pub trait AsSeq {
+    /// Looks up an item by index.
+    fn get(&self, idx: usize) -> Option<Value>;
+
+    /// Returns the number of items in the sequence.
+    fn len(&self) -> usize;
+
+    /// Checks if the struct is empty.
+    ///
+    /// The default implementation checks if the length is 0.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Views an [`Object`] as a struct.
+///
+/// # Example
+///
+/// The following example shows how to implement a dynamic object which
+/// represents a struct:
+///
+/// ```
+/// use std::fmt;
+/// use minijinja::value::{Value, Object, ObjectBehavior, AsStruct};
+///
+/// #[derive(Debug, Clone)]
+/// struct Point(f32, f32, f32);
+///
+/// impl fmt::Display for Point {
+///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+///         write!(f, "({}, {}, {})", self.0, self.1, self.2)
+///     }
+/// }
+///
+/// impl Object for Point {
+///     fn behavior(&self) -> ObjectBehavior<'_> {
+///         ObjectBehavior::Struct(self)
+///     }
+/// }
+///
+/// impl AsStruct for Point {
+///     fn get(&self, name: &str) -> Option<Value> {
+///         match name {
+///             "x" => Some(Value::from(self.0)),
+///             "y" => Some(Value::from(self.1)),
+///             "z" => Some(Value::from(self.2)),
+///             _ => None,
+///         }
+///     }
+///
+///     fn fields(&self) -> Box<dyn Iterator<Item = &str> + '_> {
+///         Box::new(["x", "y", "z"].into_iter())
+///     }
+/// }
+///
+/// let value = Value::from_object(Point(1.0, 2.5, 3.0));
+/// ```
+pub trait AsStruct {
+    /// Invoked by the engine to get a field of a struct.
+    ///
+    /// Where possible it's a good idea for this to align with the return value
+    /// of [`fields`](Self::fields) but it's not necessary.
+    ///
+    /// If an field does not exist, `None` shall be returned.
+    ///
+    /// A note should be made here on side effects: unlike calling objects or
+    /// calling methods on objects, accessing fields is not supposed to
+    /// have side effects.  Neither does this API get access to the interpreter
+    /// [`State`] nor is there a channel to send out failures as only an option
+    /// can be returned.  If you do plan on doing something in field access
+    /// that is fallible, instead use a method call.
+    fn get(&self, idx: &str) -> Option<Value>;
+
+    /// Iterates over the fields.
+    ///
+    /// The default implementation returns an empty iterator.
+    fn fields(&self) -> Box<dyn Iterator<Item = &str> + '_> {
+        Box::new(None.into_iter())
+    }
+
+    /// Returns the number of fields in the struct.
+    ///
+    /// The default implementation returns the number of fields.
+    fn len(&self) -> usize {
+        self.fields().count()
+    }
+
+    /// Checks if the struct is empty.
+    ///
+    /// The default implementation checks if the length is 0.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }

--- a/minijinja/src/value/ops.rs
+++ b/minijinja/src/value/ops.rs
@@ -124,11 +124,10 @@ pub fn slice(value: Value, start: Value, stop: Value, step: Value) -> Result<Val
         Some(seq) => {
             let (start, len) = get_offset_and_len(start, stop, || seq.seq_len());
             Ok(Value::from(
-                (0..seq.seq_len())
+                seq.iter()
                     .skip(start)
                     .take(len)
                     .step_by(step)
-                    .map(|idx| seq.get_item(idx).unwrap_or(Value::UNDEFINED))
                     .collect::<Vec<_>>(),
             ))
         }
@@ -272,7 +271,7 @@ pub fn contains(container: &Value, value: &Value) -> Result<Value, Error> {
             s.contains(&value.to_string())
         }
     } else if let Some(seq) = container.as_seq() {
-        (0..seq.seq_len()).any(|idx| seq.get_item(idx).as_ref() == Some(value))
+        seq.iter().any(|item| &item == value)
     } else if let ValueRepr::Map(ref map, _) = container.0 {
         let key = match value.clone().try_into_key() {
             Ok(key) => key,

--- a/minijinja/src/value/ops.rs
+++ b/minijinja/src/value/ops.rs
@@ -122,7 +122,7 @@ pub fn slice(value: Value, start: Value, stop: Value, step: Value) -> Result<Val
 
     match maybe_seq {
         Some(seq) => {
-            let (start, len) = get_offset_and_len(start, stop, || seq.seq_len());
+            let (start, len) = get_offset_and_len(start, stop, || seq.item_count());
             Ok(Value::from(
                 seq.iter()
                     .skip(start)

--- a/minijinja/src/value/ops.rs
+++ b/minijinja/src/value/ops.rs
@@ -2,7 +2,7 @@ use std::convert::{TryFrom, TryInto};
 use std::fmt::Write;
 
 use crate::error::{Error, ErrorKind};
-use crate::value::{Arc, ObjectBehavior, Value, ValueKind, ValueRepr};
+use crate::value::{Arc, ObjectKind, Value, ValueKind, ValueRepr};
 
 pub enum CoerceResult {
     I128(i128, i128),
@@ -121,7 +121,7 @@ pub fn slice(value: Value, start: Value, stop: Value, step: Value) -> Result<Val
             ));
         }
         ValueRepr::Dynamic(ref dy) => {
-            if let ObjectBehavior::Seq(s) = dy.behavior() {
+            if let ObjectKind::Seq(s) = dy.kind() {
                 let (start, len) = get_offset_and_len(start, stop, || s.len());
                 return Ok(Value::from(
                     (0..s.len())

--- a/minijinja/src/value/ops.rs
+++ b/minijinja/src/value/ops.rs
@@ -108,7 +108,9 @@ pub fn slice(value: Value, start: Value, stop: Value, step: Value) -> Result<Val
         ));
     }
 
-    let slice = ok!(value.as_slice());
+    // TODO: this converts the entire value into a slice before throwing away
+    // values which is wasteful.
+    let slice = ok!(value.as_cow_slice());
     let (start, len) = get_offset_and_len(start, stop, || slice.len());
     Ok(Value::from(
         slice

--- a/minijinja/src/vm/loop_object.rs
+++ b/minijinja/src/vm/loop_object.rs
@@ -17,7 +17,7 @@ impl fmt::Debug for Loop {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = f.debug_struct("Loop");
         for attr in self.fields() {
-            s.field(attr, &self.get(attr).unwrap());
+            s.field(attr, &self.get_field(attr).unwrap());
         }
         s.finish()
     }
@@ -79,7 +79,7 @@ impl StructObject for Loop {
         )
     }
 
-    fn get(&self, name: &str) -> Option<Value> {
+    fn get_field(&self, name: &str) -> Option<Value> {
         let idx = self.idx.load(Ordering::Relaxed) as u64;
         let len = self.len as u64;
         match name {

--- a/minijinja/src/vm/loop_object.rs
+++ b/minijinja/src/vm/loop_object.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 use crate::error::{Error, ErrorKind};
-use crate::value::{AsStruct, Object, ObjectBehavior, Value};
+use crate::value::{Object, ObjectKind, StructObject, Value};
 use crate::vm::state::State;
 
 pub(crate) struct Loop {
@@ -24,8 +24,8 @@ impl fmt::Debug for Loop {
 }
 
 impl Object for Loop {
-    fn behavior(&self) -> ObjectBehavior<'_> {
-        ObjectBehavior::Struct(self)
+    fn kind(&self) -> ObjectKind<'_> {
+        ObjectKind::Struct(self)
     }
 
     fn call(&self, _state: &State, _args: &[Value]) -> Result<Value, Error> {
@@ -54,14 +54,14 @@ impl Object for Loop {
             }
         } else {
             Err(Error::new(
-                ErrorKind::InvalidOperation,
+                ErrorKind::UnknownMethod,
                 format!("loop object has no method named {}", name),
             ))
         }
     }
 }
 
-impl AsStruct for Loop {
+impl StructObject for Loop {
     fn fields(&self) -> Box<dyn Iterator<Item = &str> + '_> {
         Box::new(
             [

--- a/minijinja/src/vm/macro_object.rs
+++ b/minijinja/src/vm/macro_object.rs
@@ -6,7 +6,7 @@ use crate::error::{Error, ErrorKind};
 use crate::key::Key;
 use crate::output::Output;
 use crate::utils::AutoEscape;
-use crate::value::{AsStruct, MapType, Object, ObjectBehavior, StringType, Value, ValueRepr};
+use crate::value::{MapType, Object, ObjectKind, StringType, StructObject, Value, ValueRepr};
 use crate::vm::state::State;
 use crate::vm::Vm;
 
@@ -41,8 +41,8 @@ impl fmt::Display for Macro {
 }
 
 impl Object for Macro {
-    fn behavior(&self) -> ObjectBehavior<'_> {
-        ObjectBehavior::Struct(self)
+    fn kind(&self) -> ObjectKind<'_> {
+        ObjectKind::Struct(self)
     }
 
     fn call(&self, state: &State, args: &[Value]) -> Result<Value, Error> {
@@ -134,7 +134,7 @@ impl Object for Macro {
     }
 }
 
-impl AsStruct for Macro {
+impl StructObject for Macro {
     fn fields(&self) -> Box<dyn Iterator<Item = &str> + '_> {
         Box::new(["name", "arguments"].into_iter())
     }

--- a/minijinja/src/vm/macro_object.rs
+++ b/minijinja/src/vm/macro_object.rs
@@ -6,7 +6,7 @@ use crate::error::{Error, ErrorKind};
 use crate::key::Key;
 use crate::output::Output;
 use crate::utils::AutoEscape;
-use crate::value::{MapType, Object, StringType, Value, ValueRepr};
+use crate::value::{AsStruct, MapType, Object, ObjectBehavior, StringType, Value, ValueRepr};
 use crate::vm::state::State;
 use crate::vm::Vm;
 
@@ -41,25 +41,8 @@ impl fmt::Display for Macro {
 }
 
 impl Object for Macro {
-    fn attributes(&self) -> Box<dyn Iterator<Item = &str> + '_> {
-        Box::new(["name", "arguments"].into_iter())
-    }
-
-    fn get_attr(&self, name: &str) -> Option<Value> {
-        match name {
-            "name" => Some(Value(ValueRepr::String(
-                self.data.name.clone(),
-                StringType::Normal,
-            ))),
-            "arguments" => Some(Value::from(
-                self.data
-                    .arg_spec
-                    .iter()
-                    .map(|x| Value(ValueRepr::String(x.clone(), StringType::Normal)))
-                    .collect::<Vec<_>>(),
-            )),
-            _ => None,
-        }
+    fn behavior(&self) -> ObjectBehavior<'_> {
+        ObjectBehavior::Struct(self)
     }
 
     fn call(&self, state: &State, args: &[Value]) -> Result<Value, Error> {
@@ -148,5 +131,28 @@ impl Object for Macro {
         } else {
             Value::from(rv)
         })
+    }
+}
+
+impl AsStruct for Macro {
+    fn fields(&self) -> Box<dyn Iterator<Item = &str> + '_> {
+        Box::new(["name", "arguments"].into_iter())
+    }
+
+    fn get(&self, name: &str) -> Option<Value> {
+        match name {
+            "name" => Some(Value(ValueRepr::String(
+                self.data.name.clone(),
+                StringType::Normal,
+            ))),
+            "arguments" => Some(Value::from(
+                self.data
+                    .arg_spec
+                    .iter()
+                    .map(|x| Value(ValueRepr::String(x.clone(), StringType::Normal)))
+                    .collect::<Vec<_>>(),
+            )),
+            _ => None,
+        }
     }
 }

--- a/minijinja/src/vm/macro_object.rs
+++ b/minijinja/src/vm/macro_object.rs
@@ -139,7 +139,7 @@ impl StructObject for Macro {
         Box::new(["name", "arguments"].into_iter())
     }
 
-    fn get(&self, name: &str) -> Option<Value> {
+    fn get_field(&self, name: &str) -> Option<Value> {
         match name {
             "name" => Some(Value(ValueRepr::String(
                 self.data.name.clone(),

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -820,13 +820,13 @@ impl<'env> Vm<'env> {
         let seq = ok!(top
             .as_seq()
             .ok_or_else(|| Error::new(ErrorKind::CannotUnpack, "not a sequence")));
-        if seq.seq_len() != *count {
+        if seq.item_count() != *count {
             return Err(Error::new(
                 ErrorKind::CannotUnpack,
                 format!(
                     "sequence of wrong length (expected {}, got {})",
                     *count,
-                    seq.seq_len()
+                    seq.item_count()
                 ),
             ));
         }

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -814,10 +814,11 @@ impl<'env> Vm<'env> {
 
     fn unpack_list(&self, stack: &mut Stack, count: &usize) -> Result<(), Error> {
         let top = stack.pop();
-        let v =
-            ok!(top
-                .as_cow_slice()
-                .map_err(|e| Error::new(ErrorKind::CannotUnpack, "not a sequence").with_source(e)));
+        let v = ok!(top.as_cow_slice().map_err(|e| Error::new(
+            ErrorKind::CannotUnpack,
+            "not a sequence"
+        )
+        .with_source(e)));
         if v.len() != *count {
             return Err(Error::new(
                 ErrorKind::CannotUnpack,

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -609,8 +609,7 @@ impl<'env> Vm<'env> {
             .unwrap_or(&single_name_slice as &dyn SeqObject);
 
         let mut templates_tried = vec![];
-        for idx in 0..choices.seq_len() {
-            let choice = choices.get_item(idx).unwrap_or(Value::UNDEFINED);
+        for choice in choices.iter() {
             let name = ok!(choice.as_str().ok_or_else(|| {
                 Error::new(
                     ErrorKind::InvalidOperation,
@@ -831,8 +830,8 @@ impl<'env> Vm<'env> {
                 ),
             ));
         }
-        for idx in (0..seq.seq_len()).rev() {
-            stack.push(seq.get_item(idx).unwrap_or(Value::UNDEFINED));
+        for item in seq.iter().rev() {
+            stack.push(item);
         }
         Ok(())
     }

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -816,7 +816,7 @@ impl<'env> Vm<'env> {
         let top = stack.pop();
         let v =
             ok!(top
-                .as_slice()
+                .as_cow_slice()
                 .map_err(|e| Error::new(ErrorKind::CannotUnpack, "not a sequence").with_source(e)));
         if v.len() != *count {
             return Err(Error::new(

--- a/minijinja/tests/snapshots/test_templates__vm@err_bad_filter.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@err_bad_filter.txt.snap
@@ -8,12 +8,12 @@ input_file: minijinja/tests/inputs/err_bad_filter.txt
 
 Error {
     kind: InvalidOperation,
-    detail: "object is not iterable",
+    detail: "number is not iterable",
     name: "err_bad_filter.txt",
     line: 1,
 }
 
-invalid operation: object is not iterable (in err_bad_filter.txt:1)
+invalid operation: number is not iterable (in err_bad_filter.txt:1)
 ----------------------------- err_bad_filter.txt ------------------------------
    1 > {% for item in 42|slice(4) %}
      i                   ^^^^^^^^ invalid operation

--- a/minijinja/tests/snapshots/test_templates__vm@loop_bad_unpacking.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@loop_bad_unpacking.txt.snap
@@ -15,10 +15,6 @@ Error {
     detail: "not a sequence",
     name: "loop_bad_unpacking.txt",
     line: 2,
-    source: Error {
-        kind: InvalidOperation,
-        detail: "value of type number is not a sequence",
-    },
 }
 
 cannot unpack: not a sequence (in loop_bad_unpacking.txt:2)
@@ -49,6 +45,4 @@ Referenced variables: {
     ],
 }
 -------------------------------------------------------------------------------
-
-caused by: invalid operation: value of type number is not a sequence
 

--- a/minijinja/tests/snapshots/test_templates__vm@loop_over_non_iterable.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@loop_over_non_iterable.txt.snap
@@ -9,12 +9,12 @@ input_file: minijinja/tests/inputs/loop_over_non_iterable.txt
 
 Error {
     kind: InvalidOperation,
-    detail: "object is not iterable",
+    detail: "number is not iterable",
     name: "loop_over_non_iterable.txt",
     line: 1,
 }
 
-invalid operation: object is not iterable (in loop_over_non_iterable.txt:1)
+invalid operation: number is not iterable (in loop_over_non_iterable.txt:1)
 ------------------------- loop_over_non_iterable.txt --------------------------
    1 > [{% for item in seq %}{% endfor %}]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/minijinja/tests/test_value.rs
+++ b/minijinja/tests/test_value.rs
@@ -3,7 +3,6 @@ use std::fmt;
 
 use insta::assert_snapshot;
 use minijinja::value::{Object, ObjectKind, SeqObject, StructObject, Value};
-use minijinja::ErrorKind;
 
 #[test]
 fn test_sort() {
@@ -64,21 +63,6 @@ fn test_float_to_string() {
 }
 
 #[test]
-fn test_value_as_slice() {
-    let val = Value::from(vec![1u32, 2, 3]);
-    assert_eq!(
-        val.as_slice().unwrap(),
-        &[Value::from(1), Value::from(2), Value::from(3)]
-    );
-    assert_eq!(Value::UNDEFINED.as_slice().unwrap(), &[]);
-    assert_eq!(Value::from(()).as_slice().unwrap(), &[]);
-    assert_eq!(
-        Value::from("foo").as_slice().unwrap_err().kind(),
-        ErrorKind::InvalidOperation
-    );
-}
-
-#[test]
 fn test_value_as_bytes() {
     assert_eq!(Value::from("foo").as_bytes(), Some(&b"foo"[..]));
     assert_eq!(Value::from(&b"foo"[..]).as_bytes(), Some(&b"foo"[..]));
@@ -109,7 +93,7 @@ fn test_map_object_iteration_and_indexing() {
     }
 
     impl StructObject for Point {
-        fn get(&self, name: &str) -> Option<Value> {
+        fn get_field(&self, name: &str) -> Option<Value> {
             match name {
                 "x" => Some(Value::from(self.0)),
                 "y" => Some(Value::from(self.1)),
@@ -158,7 +142,7 @@ fn test_seq_object_iteration_and_indexing() {
     }
 
     impl SeqObject for Point {
-        fn get(&self, index: usize) -> Option<Value> {
+        fn get_item(&self, index: usize) -> Option<Value> {
             match index {
                 0 => Some(Value::from(self.0)),
                 1 => Some(Value::from(self.1)),
@@ -167,7 +151,7 @@ fn test_seq_object_iteration_and_indexing() {
             }
         }
 
-        fn len(&self) -> usize {
+        fn seq_len(&self) -> usize {
             3
         }
     }

--- a/minijinja/tests/test_value.rs
+++ b/minijinja/tests/test_value.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::fmt;
 
 use insta::assert_snapshot;
-use minijinja::value::{AsSeq, AsStruct, Object, ObjectBehavior, Value};
+use minijinja::value::{Object, ObjectKind, SeqObject, StructObject, Value};
 use minijinja::ErrorKind;
 
 #[test]
@@ -103,12 +103,12 @@ fn test_map_object_iteration() {
     }
 
     impl Object for Point {
-        fn behavior(&self) -> ObjectBehavior<'_> {
-            ObjectBehavior::Struct(self)
+        fn kind(&self) -> ObjectKind<'_> {
+            ObjectKind::Struct(self)
         }
     }
 
-    impl AsStruct for Point {
+    impl StructObject for Point {
         fn get(&self, name: &str) -> Option<Value> {
             match name {
                 "x" => Some(Value::from(self.0)),
@@ -147,12 +147,12 @@ fn test_seq_object_iteration() {
     }
 
     impl Object for Point {
-        fn behavior(&self) -> ObjectBehavior<'_> {
-            ObjectBehavior::Seq(self)
+        fn kind(&self) -> ObjectKind<'_> {
+            ObjectKind::Seq(self)
         }
     }
 
-    impl AsSeq for Point {
+    impl SeqObject for Point {
         fn get(&self, index: usize) -> Option<Value> {
             match index {
                 0 => Some(Value::from(self.0)),

--- a/minijinja/tests/test_value.rs
+++ b/minijinja/tests/test_value.rs
@@ -92,7 +92,7 @@ fn test_value_by_index() {
 }
 
 #[test]
-fn test_map_object_iteration() {
+fn test_map_object_iteration_and_indexing() {
     #[derive(Debug, Clone)]
     struct Point(i32, i32, i32);
 
@@ -123,20 +123,25 @@ fn test_map_object_iteration() {
         }
     }
 
-    let point = Point(1, 2, 3);
     let rv = minijinja::render!(
         "{% for key in point %}{{ key }}: {{ point[key] }}\n{% endfor %}",
-        point => Value::from_object(point)
+        point => Value::from_object(Point(1, 2, 3))
     );
     assert_snapshot!(rv, @r###"
     x: 1
     y: 2
     z: 3
     "###);
+
+    let rv = minijinja::render!(
+        "{{ [point.x, point.z, point.missing_attribute] }}",
+        point => Value::from_object(Point(1, 2, 3))
+    );
+    assert_snapshot!(rv, @r###"[1, 3, Undefined]"###);
 }
 
 #[test]
-fn test_seq_object_iteration() {
+fn test_seq_object_iteration_and_indexing() {
     #[derive(Debug, Clone)]
     struct Point(i32, i32, i32);
 
@@ -167,14 +172,19 @@ fn test_seq_object_iteration() {
         }
     }
 
-    let point = Point(1, 2, 3);
     let rv = minijinja::render!(
         "{% for value in point %}{{ loop.index0 }}: {{ value }}\n{% endfor %}",
-        point => Value::from_object(point)
+        point => Value::from_object(Point(1, 2, 3))
     );
     assert_snapshot!(rv, @r###"
     0: 1
     1: 2
     2: 3
     "###);
+
+    let rv = minijinja::render!(
+        "{{ [point[0], point[2], point[42]] }}",
+        point => Value::from_object(Point(1, 2, 3))
+    );
+    assert_snapshot!(rv, @r###"[1, 3, Undefined]"###);
 }

--- a/minijinja/tests/test_value.rs
+++ b/minijinja/tests/test_value.rs
@@ -151,7 +151,7 @@ fn test_seq_object_iteration_and_indexing() {
             }
         }
 
-        fn seq_len(&self) -> usize {
+        fn item_count(&self) -> usize {
             3
         }
     }


### PR DESCRIPTION
This changes the object interface to support both structs and sequences with the possibility to add extra behavior (eg: arbitrary key maps) at a future point. There are some challenges with this design however.

**Issues:**

These are probably something I need to accept:

* `impl<'a, T: ArgType<'a, Output = T>> ArgType<'a> for Vec<T>` cannot be implemented to support these new dynamic sequences because the lifetime constraints cannot be enabled. Restrict?

**Things to resolve:**

This is stuff that can be fixed:

* [x] Similarly the slice syntax `x[:5]` first converts the entire value before slicing down.
* [x] Decide on the names.
* [x] The `Value::as_slice` API cannot return borrowed values for dynamic slices. Internally a `as_cow_slice` has been added. Potential solution is to retire `as_slice` entirely for `SeqObject`.
* [x] Iteration over dynamic slices first makes a real slice out of it. This is mostly done because of lifetime issues that are annoying to work around.
* [x] Consider adding `SeqObject::iter`

Refs #147