### PR TITLE
Add 'Environment::render_named_str()'

### DIFF
--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -209,19 +209,25 @@ impl<'source> Environment<'source> {
         self._render_str("<string>", source, Value::from_serializable(&ctx))
     }
 
-    /// Like [`render_str()`](Self::render_str()), but provide a name for the
+    /// Parses and renders a template from a string in one go with name.
+    ///
+    /// Like [`render_str`](Self::render_str), but provide a name for the
     /// template to be used instead of the default `<string>`.
     ///
     /// ```
     /// # use minijinja::{Environment, context};
     /// let env = Environment::new();
-    /// let rv = env.render_str_named("Hello {{ name }}", "template", context! { name => "World" });
+    /// let rv = env.render_named_str(
+    ///     "template_name",
+    ///     "Hello {{ name }}",
+    ///     context! { name => "World" }
+    /// );
     /// println!("{}", rv.unwrap());
     /// ```
-    pub fn render_str_named<S: Serialize>(
+    pub fn render_named_str<S: Serialize>(
         &self,
-        source: &str,
         name: &str,
+        source: &str,
         ctx: S,
     ) -> Result<String, Error> {
         // reduce total amount of code faling under mono morphization into

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -206,11 +206,30 @@ impl<'source> Environment<'source> {
     pub fn render_str<S: Serialize>(&self, source: &str, ctx: S) -> Result<String, Error> {
         // reduce total amount of code faling under mono morphization into
         // this function, and share the rest in _eval.
-        self._render_str(source, Value::from_serializable(&ctx))
+        self._render_str("<string>", source, Value::from_serializable(&ctx))
     }
 
-    fn _render_str(&self, source: &str, root: Value) -> Result<String, Error> {
-        let name = "<string>";
+    /// Like [`render_str()`](Self::render_str()), but provide a name for the
+    /// template to be used instead of the default `<string>`.
+    ///
+    /// ```
+    /// # use minijinja::{Environment, context};
+    /// let env = Environment::new();
+    /// let rv = env.render_str_named("Hello {{ name }}", "template", context! { name => "World" });
+    /// println!("{}", rv.unwrap());
+    /// ```
+    pub fn render_str_named<S: Serialize>(
+        &self,
+        source: &str,
+        name: &str,
+        ctx: S,
+    ) -> Result<String, Error> {
+        // reduce total amount of code faling under mono morphization into
+        // this function, and share the rest in _eval.
+        self._render_str(name, source, Value::from_serializable(&ctx))
+    }
+
+    fn _render_str(&self, name: &str, source: &str, root: Value) -> Result<String, Error> {
         let compiled = ok!(CompiledTemplate::from_name_and_source(name, source));
         let mut rv = String::new();
         Vm::new(self)


### PR DESCRIPTION
An alternative to 'Environment::render_str()' which allows specifying the rendered template's name.