### PR TITLE
Add do tag to allow calling functions/macros and not having output

### DIFF
--- a/minijinja/src/compiler/ast.rs
+++ b/minijinja/src/compiler/ast.rs
@@ -75,6 +75,7 @@ pub enum Stmt<'a> {
     Macro(Spanned<Macro<'a>>),
     #[cfg(feature = "macros")]
     CallBlock(Spanned<CallBlock<'a>>),
+    Do(Spanned<Do<'a>>),
 }
 
 #[cfg(feature = "internal_debug")]
@@ -105,6 +106,7 @@ impl<'a> fmt::Debug for Stmt<'a> {
             Stmt::Macro(s) => fmt::Debug::fmt(s, f),
             #[cfg(feature = "macros")]
             Stmt::CallBlock(s) => fmt::Debug::fmt(s, f),
+            Stmt::Do(s) => fmt::Debug::fmt(s, f),
         }
     }
 }
@@ -250,6 +252,12 @@ pub struct Macro<'a> {
 pub struct CallBlock<'a> {
     pub call: Spanned<Call<'a>>,
     pub macro_decl: Spanned<Macro<'a>>,
+}
+
+/// A call block
+#[cfg_attr(feature = "internal_debug", derive(Debug))]
+pub struct Do<'a> {
+    pub call: Spanned<Call<'a>>,
 }
 
 /// A "from" import

--- a/minijinja/src/compiler/codegen.rs
+++ b/minijinja/src/compiler/codegen.rs
@@ -354,8 +354,8 @@ impl<'source> CodeGenerator<'source> {
             ast::Stmt::CallBlock(call_block) => {
                 self.compile_call_block(call_block);
             }
-            ast::Stmt::Do(do_block) => {
-                self.compile_do_block(do_block);
+            ast::Stmt::Do(do_tag) => {
+                self.compile_do(do_tag);
             }
         }
     }
@@ -441,8 +441,8 @@ impl<'source> CodeGenerator<'source> {
         self.add(Instruction::Emit);
     }
 
-    fn compile_do_block(&mut self, do_block: &ast::Spanned<ast::Do<'source>>) {
-        self.compile_call(&do_block.call, None);
+    fn compile_do(&mut self, do_tag: &ast::Spanned<ast::Do<'source>>) {
+        self.compile_call(&do_tag.call, None);
     }
 
     fn compile_if_stmt(&mut self, if_cond: &ast::Spanned<ast::IfCond<'source>>) {

--- a/minijinja/src/compiler/codegen.rs
+++ b/minijinja/src/compiler/codegen.rs
@@ -354,6 +354,9 @@ impl<'source> CodeGenerator<'source> {
             ast::Stmt::CallBlock(call_block) => {
                 self.compile_call_block(call_block);
             }
+            ast::Stmt::Do(do_block) => {
+                self.compile_do_block(do_block);
+            }
         }
     }
 
@@ -436,6 +439,10 @@ impl<'source> CodeGenerator<'source> {
     fn compile_call_block(&mut self, call_block: &ast::Spanned<ast::CallBlock<'source>>) {
         self.compile_call(&call_block.call, Some(&call_block.macro_decl));
         self.add(Instruction::Emit);
+    }
+
+    fn compile_do_block(&mut self, do_block: &ast::Spanned<ast::Do<'source>>) {
+        self.compile_call(&do_block.call, None);
     }
 
     fn compile_if_stmt(&mut self, if_cond: &ast::Spanned<ast::IfCond<'source>>) {

--- a/minijinja/src/compiler/meta.rs
+++ b/minijinja/src/compiler/meta.rs
@@ -172,6 +172,7 @@ pub fn find_macro_closure<'a>(m: &ast::Macro<'a>) -> HashSet<&'a str> {
             }
             #[cfg(feature = "macros")]
             ast::Stmt::CallBlock(_) => {}
+            ast::Stmt::Do(_) => {}
         }
     }
 

--- a/minijinja/src/compiler/parser.rs
+++ b/minijinja/src/compiler/parser.rs
@@ -1043,7 +1043,7 @@ impl<'a> Parser<'a> {
 
         expect_token!(self, Token::BlockEnd(..), "end of block");
 
-        return Ok(ast::Do { call });
+        Ok(ast::Do { call })
     }
 
     fn subparse(

--- a/minijinja/src/compiler/parser.rs
+++ b/minijinja/src/compiler/parser.rs
@@ -664,6 +664,7 @@ impl<'a> Parser<'a> {
             Token::Ident("macro") => ast::Stmt::Macro(respan!(ok!(self.parse_macro()))),
             #[cfg(feature = "macros")]
             Token::Ident("call") => ast::Stmt::CallBlock(respan!(ok!(self.parse_call_block()))),
+            Token::Ident("do") => ast::Stmt::Do(respan!(ok!(self.parse_do_block()))),
             Token::Ident(name) => syntax_error!("unknown statement {}", name),
             token => syntax_error!("unknown {}, expected statement", token),
         })
@@ -953,7 +954,6 @@ impl<'a> Parser<'a> {
         Ok(ast::FromImport { expr, names })
     }
 
-    #[cfg(feature = "macros")]
     fn parse_args_and_defaults(
         &mut self,
         args: &mut Vec<ast::Expr<'a>>,
@@ -1030,6 +1030,22 @@ impl<'a> Parser<'a> {
         })
     }
 
+    fn parse_do_block(&mut self) -> Result<ast::Do<'a>, Error> {
+        let mut args = Vec::new();
+        let mut defaults = Vec::new();
+        if skip_token!(self, Token::ParenOpen) {
+            self.parse_args_and_defaults(&mut args, &mut defaults)?;
+        }
+        let call = match self.parse_expr()? {
+            ast::Expr::Call(call) => call,
+            _ => syntax_error!("expected call expression in call block"),
+        };
+
+        expect_token!(self, Token::BlockEnd(..), "end of block");
+
+        return Ok(ast::Do { call });
+    }
+
     fn subparse(
         &mut self,
         end_check: &dyn Fn(&Token) -> bool,
@@ -1057,7 +1073,11 @@ impl<'a> Parser<'a> {
                         return Ok(rv);
                     }
                     rv.push(ok!(self.parse_stmt()));
-                    expect_token!(self, Token::BlockEnd(..), "end of block");
+
+                    // End of block may not exist, for example with do block.
+                    if let Some((Token::BlockEnd(..), _)) = ok!(self.stream.current()) {
+                        expect_token!(self, Token::BlockEnd(..), "end of block");
+                    }
                 }
                 _ => unreachable!("lexer produced garbage"),
             }

--- a/minijinja/src/compiler/parser.rs
+++ b/minijinja/src/compiler/parser.rs
@@ -664,7 +664,7 @@ impl<'a> Parser<'a> {
             Token::Ident("macro") => ast::Stmt::Macro(respan!(ok!(self.parse_macro()))),
             #[cfg(feature = "macros")]
             Token::Ident("call") => ast::Stmt::CallBlock(respan!(ok!(self.parse_call_block()))),
-            Token::Ident("do") => ast::Stmt::Do(respan!(ok!(self.parse_do_block()))),
+            Token::Ident("do") => ast::Stmt::Do(respan!(ok!(self.parse_do()))),
             Token::Ident(name) => syntax_error!("unknown statement {}", name),
             token => syntax_error!("unknown {}, expected statement", token),
         })
@@ -1030,7 +1030,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_do_block(&mut self) -> Result<ast::Do<'a>, Error> {
+    fn parse_do(&mut self) -> Result<ast::Do<'a>, Error> {
         let mut args = Vec::new();
         let mut defaults = Vec::new();
         if skip_token!(self, Token::ParenOpen) {

--- a/minijinja/src/syntax.rs
+++ b/minijinja/src/syntax.rs
@@ -599,11 +599,12 @@
 //!
 //! ## `{% do %}`
 //!
-//! The do tag does the same thing as a using regular template tags (`{{ ... }}`);
-//! except it doesn't output anything.
+//! The do tag has the same functionality as regular template tags (`{{ ... }}`);
+//! except it doesn't output anything when called.
 //!
-//! This is useful if you have a function or macro that has verbose output or side effects,
-//! but you don’t want to display output.
+//! This is useful if you have a function or macro that has verbose output, and
+//! you don’t want to display output in the template. The following example shows a macro that
+//! uses the do functionality, and how it can be used:
 //!
 //! ```jinja
 //! {% macro dialog(title) %}
@@ -614,12 +615,18 @@
 //! {{ dialog(title="Hello World") }}
 //! ```
 //!
-//! The above example will not output anything when using the `do` tag,
-//! but will output the dialog body when using the regular template tag.
+//! The above example will not output anything when using the `do` tag, but will output
+//! when using the regular template tag.
 //!
-//! Note that the `do` tag does not support the hidden `caller` keyword argument like `call` does,
-//! as it's not a block. This means that there is no {% enddo %} tag as well, so you can't use it
-//! to call macros that use the `caller` keyword argument.
+//! The `do` tag does not support the hidden `caller` keyword argument like the `call` tag
+//! does, as `do` is not a block but a tag. This means that there is no `{% enddo %}` tag as well,
+//! so you can't use it to call macros that use the `caller` keyword argument or pass in blocks.
+//! Doing so will result in the error `unknown function: caller is unknown`. //! This is the same
+//! functionality that Jinja2 has.
+//!
+//! `Do` tags should be carefully considered, as you probably want to have cleaner
+//! functions/macros. They can however be useful in certain situations, such as functions that
+//! might execute SQL and return a result, but you don't want to display the result in the template.
 //!
 //! ## `{% autoescape %}`
 //!

--- a/minijinja/src/syntax.rs
+++ b/minijinja/src/syntax.rs
@@ -599,8 +599,11 @@
 //!
 //! ## `{% do %}`
 //!
-//! The do tag does the same thing as a using regular template tags (`{{ ... }}`); except it doesn't output anything.
-//! This is useful if you have a function or macro that has verbose output or side effects, but you don’t want to display output.
+//! The do tag does the same thing as a using regular template tags (`{{ ... }}`);
+//! except it doesn't output anything.
+//!
+//! This is useful if you have a function or macro that has verbose output or side effects,
+//! but you don’t want to display output.
 //!
 //! ```jinja
 //! {% macro dialog(title) %}
@@ -611,7 +614,12 @@
 //! {{ dialog(title="Hello World") }}
 //! ```
 //!
-//! The above example will not output anything when using the `do` tag, but will output the dialog body when using the regular template tag.
+//! The above example will not output anything when using the `do` tag,
+//! but will output the dialog body when using the regular template tag.
+//!
+//! Note that the `do` tag does not support the hidden `caller` keyword argument like `call` does,
+//! as it's not a block. This means that there is no {% enddo %} tag as well, so you can't use it
+//! to call macros that use the `caller` keyword argument.
 //!
 //! ## `{% autoescape %}`
 //!

--- a/minijinja/src/syntax.rs
+++ b/minijinja/src/syntax.rs
@@ -597,6 +597,22 @@
 //! {% endcall %}
 //! ```
 //!
+//! ## `{% do %}`
+//!
+//! The do tag does the same thing as a using regular template tags (`{{ ... }}`); except it doesn't output anything.
+//! This is useful if you have a function or macro that has verbose output or side effects, but you don’t want to display output.
+//!
+//! ```jinja
+//! {% macro dialog(title) %}
+//!   Dialog is {{ title }}
+//! {% endmacro %}
+//!
+//! {% do dialog(title="Hello World") %}
+//! {{ dialog(title="Hello World") }}
+//! ```
+//!
+//! The above example will not output anything when using the `do` tag, but will output the dialog body when using the regular template tag.
+//!
 //! ## `{% autoescape %}`
 //!
 //! If you want you can activate and deactivate the autoescaping from within

--- a/minijinja/tests/inputs/do_macro.txt
+++ b/minijinja/tests/inputs/do_macro.txt
@@ -1,0 +1,6 @@
+{}
+---
+{% macro dialog(title) %}Dialog is {{ title }}{% endmacro %}
+
+Should be empty: {% do dialog(title="Hello World") %}
+Should show: {{ dialog(title="Hello World") }}

--- a/minijinja/tests/inputs/do_macro_caller_error.txt
+++ b/minijinja/tests/inputs/do_macro_caller_error.txt
@@ -1,0 +1,8 @@
+{}
+---
+{% macro dialog(title) %}
+    Dialog is {{ title }}
+    {{ caller() }}
+{% endmacro %}
+
+Should error: {{ dialog(title="Hello World") }}

--- a/minijinja/tests/inputs/do_macro_calling_macro.txt
+++ b/minijinja/tests/inputs/do_macro_calling_macro.txt
@@ -1,0 +1,5 @@
+{}
+---
+{%- from "call_macro.txt" import call %}
+{%- macro my_macro(value) %}[{{ value }}]{% endmacro %}
+{% do call(my_macro, 42) %}

--- a/minijinja/tests/snapshots/test_templates__vm@do_macro.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@do_macro.txt.snap
@@ -1,0 +1,11 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{% macro dialog(title) %}Dialog is {{ title }}{% endmacro %}\n\nShould be empty: {% do dialog(title=\"Hello World\") %}\nShould show: {{ dialog(title=\"Hello World\") }}"
+info: {}
+input_file: minijinja/tests/inputs/do_macro.txt
+---
+
+
+Should be empty: 
+Should show: Dialog is Hello World
+

--- a/minijinja/tests/snapshots/test_templates__vm@do_macro_caller_error.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@do_macro_caller_error.txt.snap
@@ -1,0 +1,30 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{% macro dialog(title) %}\n    Dialog is {{ title }}\n    {{ caller() }}\n{% endmacro %}\n\nShould error: {{ dialog(title=\"Hello World\") }}"
+info: {}
+input_file: minijinja/tests/inputs/do_macro_caller_error.txt
+---
+!!!ERROR!!!
+
+Error {
+    kind: UnknownFunction,
+    detail: "caller is unknown",
+    name: "do_macro_caller_error.txt",
+    line: 3,
+}
+
+unknown function: caller is unknown (in do_macro_caller_error.txt:3)
+-------------------------- do_macro_caller_error.txt --------------------------
+   1 | {% macro dialog(title) %}
+   2 |     Dialog is {{ title }}
+   3 >     {{ caller() }}
+     i        ^^^^^^^^ unknown function
+   4 | {% endmacro %}
+   5 | 
+   6 | Should error: {{ dialog(title="Hello World") }}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Referenced variables: {
+    title: "Hello World",
+}
+-------------------------------------------------------------------------------
+

--- a/minijinja/tests/snapshots/test_templates__vm@do_macro_calling_macro.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@do_macro_calling_macro.txt.snap
@@ -1,0 +1,9 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{%- from \"call_macro.txt\" import call %}\n{%- macro my_macro(value) %}[{{ value }}]{% endmacro %}\n{% do call(my_macro, 42) %}"
+info: {}
+input_file: minijinja/tests/inputs/do_macro_calling_macro.txt
+---
+
+
+


### PR DESCRIPTION
Based off this conversation: https://github.com/mitsuhiko/minijinja/issues/83

Happy to discuss if this should be merged. Also happy for this to be tweaked/reworked to make it in the best possible state. :rocket: 

I also initially named this DoBlock, but imho it's confusing to name that as someone might think they could use it the same way they would the `call` tag.

## What is a do tag?
The do tag does the same thing as a using regular template tags (`{{ ... }}`); except it doesn't output anything.

This is useful if you have a function or macro that has verbose output or side effects, but you don’t want to display output.

> Note: Jinja2 puts this into their extensions.

## Reasoning
The reasoning for adding this is that this is super handy when working with projects that use jinja2 extensively like dbt, where it's quite useful.

[Example (from dbt-utils readme)](https://github.com/dbt-labs/dbt-utils#get_relations_by_pattern-source).

(I know you know most/all of this, but the explanation is for everyone else, and when I forget :D )