### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/minijinja/src/compiler/codegen.rs
+++ b/minijinja/src/compiler/codegen.rs
@@ -108,7 +108,7 @@ impl<'source> CodeGenerator<'source> {
         self.instructions.len()
     }
 
-    /// Creats a sub generator.
+    /// Creates a sub generator.
     #[cfg(feature = "multi-template")]
     fn new_subgenerator(&self) -> CodeGenerator<'source> {
         let mut sub = CodeGenerator::new(self.instructions.name(), self.instructions.source());

--- a/minijinja/src/compiler/instructions.rs
+++ b/minijinja/src/compiler/instructions.rs
@@ -77,7 +77,7 @@ pub enum Instruction<'source> {
     /// Divide the top two values
     Div,
 
-    /// Integer divde the top two values as "integer".
+    /// Integer divide the top two values as "integer".
     ///
     /// Note that in MiniJinja this currently uses an euclidean
     /// division to match the rem implementation.  In Python this

--- a/minijinja/src/compiler/parser.rs
+++ b/minijinja/src/compiler/parser.rs
@@ -206,7 +206,7 @@ macro_rules! with_recursion_guard {
         if $parser.depth > MAX_RECURSION {
             return Err(Error::new(
                 ErrorKind::SyntaxError,
-                "template exceeds maximum recusion limits",
+                "template exceeds maximum recursion limits",
             ));
         }
         let rv = $expr;

--- a/minijinja/src/error.rs
+++ b/minijinja/src/error.rs
@@ -248,7 +248,7 @@ impl Error {
         self.repr.name.as_deref()
     }
 
-    /// Returns the line number where the error ocurred.
+    /// Returns the line number where the error occurred.
     pub fn line(&self) -> Option<usize> {
         if self.repr.lineno > 0 {
             Some(self.repr.lineno)
@@ -257,7 +257,7 @@ impl Error {
         }
     }
 
-    /// Returns the line number where the error ocurred.
+    /// Returns the line number where the error occurred.
     #[cfg(feature = "debug")]
     pub(crate) fn span(&self) -> Option<Span> {
         self.repr.span

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -47,7 +47,7 @@
 //!
 //! # Accessing State
 //!
-//! In some cases it can be necesary to access the execution [`State`].  Since a borrowed
+//! In some cases it can be necessary to access the execution [`State`].  Since a borrowed
 //! state implements [`ArgType`](crate::value::ArgType) it's possible to add a
 //! parameter that holds the state.  For instance the following filter appends
 //! the current template name to the string:
@@ -319,7 +319,7 @@ mod builtins {
 
     /// Does a string replace.
     ///
-    /// It replaces all ocurrences of the first parameter with the second.
+    /// It replaces all occurrences of the first parameter with the second.
     ///
     /// ```jinja
     /// {{ "Hello World"|replace("Hello", "Goodbye") }}

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -117,7 +117,7 @@ pub(crate) struct BoxedFunction(Arc<FuncFunc>, #[cfg(feature = "debug")] &'stati
 /// ```
 ///
 /// ```jinja
-/// {{ include_file("filname.txt") }}
+/// {{ include_file("filename.txt") }}
 /// ```
 ///
 /// # Variadic

--- a/minijinja/src/key/mod.rs
+++ b/minijinja/src/key/mod.rs
@@ -92,7 +92,7 @@ impl<'a> Key<'a> {
             ValueRepr::F64(x) => {
                 // if a float is in fact looking like an integer we
                 // allow this to be used for indexing.  Why?  Because
-                // in Jinja division is always a division resuling
+                // in Jinja division is always a division resulting
                 // in floating point values (4 / 2 == 2.0).
                 let intval = x as i64;
                 if intval as f64 == x {

--- a/minijinja/src/syntax.rs
+++ b/minijinja/src/syntax.rs
@@ -97,7 +97,7 @@
 //! - ``+``: Adds two numbers up. ``{{ 1 + 1 }}`` is ``2``.
 //! - ``-``: Subtract the second number from the first one.  ``{{ 3 - 2 }}`` is ``1``.
 //! - ``/``: Divide two numbers. ``{{ 1 / 2 }}`` is ``0.5``.  See note on divisions below.
-//! - ``//``: Integer divide two numbers. ``{{ 5 // 3 }}`` is ``1``.  See note on divisons below.
+//! - ``//``: Integer divide two numbers. ``{{ 5 // 3 }}`` is ``1``.  See note on divisions below.
 //! - ``%``: Calculate the remainder of an integer division.  ``{{ 11 % 7 }}`` is ``4``.
 //! - ``*``: Multiply the left operand with the right one.  ``{{ 2 * 2 }}`` would return ``4``.
 //! - ``**``: Raise the left operand to the power of the right operand.  ``{{ 2**3 }}``

--- a/minijinja/tests/snapshots/test_parser__parser@max-recursion-expr.txt.snap
+++ b/minijinja/tests/snapshots/test_parser__parser@max-recursion-expr.txt.snap
@@ -6,7 +6,7 @@ input_file: minijinja/tests/parser-inputs/max-recursion-expr.txt
 Err(
     Error {
         kind: SyntaxError,
-        detail: "template exceeds maximum recusion limits",
+        detail: "template exceeds maximum recursion limits",
         name: "max-recursion-expr.txt",
         line: 1,
     },

--- a/minijinja/tests/snapshots/test_parser__parser@max-recursion-tags.txt.snap
+++ b/minijinja/tests/snapshots/test_parser__parser@max-recursion-tags.txt.snap
@@ -6,7 +6,7 @@ input_file: minijinja/tests/parser-inputs/max-recursion-tags.txt
 Err(
     Error {
         kind: SyntaxError,
-        detail: "template exceeds maximum recusion limits",
+        detail: "template exceeds maximum recursion limits",
         name: "max-recursion-tags.txt",
         line: 30,
     },

--- a/minijinja/tests/snapshots/test_parser__parser@max-recursion.txt.snap
+++ b/minijinja/tests/snapshots/test_parser__parser@max-recursion.txt.snap
@@ -6,7 +6,7 @@ input_file: minijinja/tests/parser-inputs/max-recursion.txt
 Err(
     Error {
         kind: SyntaxError,
-        detail: "template exceeds maximum recusion limits",
+        detail: "template exceeds maximum recursion limits",
         name: "max-recursion.txt",
         line: 1,
     },


### PR DESCRIPTION
[`codespell --ignore-words-list=crate,nd,ser,unkown,worl --skip="./.*,*.ai"`](https://pypi.org/project/codespell)