### PR TITLE
Add benchmark for askama

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -13,6 +13,7 @@ minijinja = { path = "../minijinja", features = ["unstable_machinery"] }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 tera = "1.17.0"
+askama = "0.11.1"
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }

--- a/benchmarks/askama.toml
+++ b/benchmarks/askama.toml
@@ -1,0 +1,2 @@
+[general]
+dirs = ["inputs"]

--- a/benchmarks/benches/comparison.rs
+++ b/benchmarks/benches/comparison.rs
@@ -26,7 +26,8 @@ struct Site {
     copyright: u32,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, askama::Template)]
+#[template(path = "comparison/askama.html")]
 struct Context {
     items: Vec<String>,
     site: Site,
@@ -195,6 +196,13 @@ pub fn bench_compare_render(c: &mut Criterion) {
         b.iter(|| {
             hbs.render("template.html", &black_box(Context::default()))
                 .unwrap();
+        });
+    });
+
+    g.bench_function("askama", |b| {
+        b.iter(|| {
+            let context = black_box(Context::default());
+            askama::Template::render(&context).unwrap();
         });
     });
 }

--- a/benchmarks/inputs/comparison/askama.html
+++ b/benchmarks/inputs/comparison/askama.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>{{ title }} | Hello</title>
+<link rel="stylesheet" href="styles/index.css">
+<body>
+  <header>
+    <h1>Hello</h1>
+    <nav>
+      <ul class="nav">
+        {% for item in site.nav %}
+          <li><a href="{{ item.url }}"{% if item.is_active %} class="active"{% endif %}>{{ item.title|upper }}</a>
+        {% endfor %}
+      </ul>
+    </nav>
+  </header>
+  <main>
+    <ul>
+    {% for item in items %}
+      <li>{{ loop.index }}: {{ item|upper }}</li>
+    {% endfor %}
+    </ul>
+  </main>
+  <footer>
+    {% include "askama_footer.html" %}
+  </footer>
+</body>

--- a/benchmarks/inputs/comparison/askama_footer.html
+++ b/benchmarks/inputs/comparison/askama_footer.html
@@ -1,0 +1,1 @@
+&copy; Copyright {{ site.copyright }} by Foo


### PR DESCRIPTION
As suggested on mastdon, I added `askama` to the list of benched frameworks. As `askama` is compiling templates at compile time, I didn't add it into the template "compilation" benches.

Here are the results I got locally:

```
cmp_compile/minijinja   time:   [7.3282 µs 7.3511 µs 7.3800 µs]
cmp_compile/tera        time:   [71.494 µs 72.032 µs 72.729 µs]
cmp_compile/liquid      time:   [54.202 µs 55.787 µs 57.225 µs]
cmp_compile/handlebars  time:   [74.124 µs 74.722 µs 75.402 µs]

cmp_render/minijinja    time:   [8.5798 µs 8.6515 µs 8.7736 µs]
cmp_render/tera         time:   [12.118 µs 12.206 µs 12.306 µs]
cmp_render/liquid       time:   [17.483 µs 17.739 µs 18.032 µs]
cmp_render/handlebars   time:   [10.168 µs 10.229 µs 10.296 µs]
cmp_render/askama       time:   [2.3692 µs 2.3902 µs 2.4139 µs]
```