### PR TITLE
Try to pin wasmtime binary as installer is buggy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           curl https://wasmtime.dev/install.sh -sSf | bash
           curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v4.0.0/wasmtime-v4.0.0-x86_64-linux-c-api.tar.xz
-          tar xvf wasmtime-v4.0.0-x86_64-linux-c-api.tar.x
+          tar xvf wasmtime-v4.0.0-x86_64-linux-c-api.tar.xz
           echo `pwd`/wasmtime-v4.0.0-x86_64-linux-c-api >> $GITHUB_PATH
       - name: Test
         run: make wasi-test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Install WasmTime
         run: |
           curl https://wasmtime.dev/install.sh -sSf | bash
-          curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v4.0.0/wasmtime-v4.0.0-x86_64-linux-c-api.tar.xz
-          tar xvf wasmtime-v4.0.0-x86_64-linux-c-api.tar.xz
-          echo `pwd`/wasmtime-v4.0.0-x86_64-linux-c-api >> $GITHUB_PATH
+          curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v4.0.0/wasmtime-v4.0.0-x86_64-linux.tar.xz
+          tar xvf wasmtime-v4.0.0-x86_64-linux.tar.xz
+          echo `pwd`/wasmtime-v4.0.0-x86_64-linux >> $GITHUB_PATH
       - name: Test
         run: make wasi-test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Install WasmTime
         run: |
           curl https://wasmtime.dev/install.sh -sSf | bash
-          echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
+          curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v4.0.0/wasmtime-v4.0.0-x86_64-linux-c-api.tar.xz
+          tar xvf wasmtime-v4.0.0-x86_64-linux-c-api.tar.x
+          echo `pwd`/wasmtime-v4.0.0-x86_64-linux-c-api >> $GITHUB_PATH
       - name: Test
         run: make wasi-test


### PR DESCRIPTION
The current curl to bash installer from wasmtime sometimes produces a 404 error because it reads an invalid response from the API. Instead of pulling in the latest it's possible to just pin on a stable binary instead.