### PR TITLE
Fuel Tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to MiniJinja are documented here.
   but never is executed.
 - Fixed recursion detection for macros.
 - Enforce a maximum size of 10000 items on the range output.
+- Added fuel tracking support.
 
 # 0.28.0
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 arbitrary = { version = "1.1.6", features = ["derive"] }
 libfuzzer-sys = "0.4"
 serde = { version = "1.0.145", features = ["derive"] }
-minijinja = { path = "../minijinja", features = ["json", "urlencode"] }
+minijinja = { path = "../minijinja", features = ["json", "urlencode", "fuel"] }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/fuzz_targets/render.rs
+++ b/fuzz/fuzz_targets/render.rs
@@ -21,6 +21,10 @@ fuzz_target!(|data: (&str, Vec<(&str, &str)>, Value)| {
 
     let mut env = minijinja::Environment::new();
 
+    // set a rather conservative default fuel so that we don't spend too much
+    // time on badly fuzzed templates that can be protected against.
+    env.set_fuel(50000);
+
     if env.add_template("fuzz", root).is_err() {
         return;
     }

--- a/minijinja/Cargo.toml
+++ b/minijinja/Cargo.toml
@@ -34,6 +34,7 @@ speedups = ["v_htmlescape", "key_interning"]
 builtins = []
 macros = []
 multi-template = []
+fuel = []
 
 # Extra Filters
 json = ["serde_json"]

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -70,6 +70,8 @@ pub struct Environment<'source> {
     formatter: Arc<FormatterFunc>,
     #[cfg(feature = "debug")]
     debug: bool,
+    #[cfg(feature = "fuel")]
+    fuel: Option<u64>,
 }
 
 impl<'source> Default for Environment<'source> {
@@ -106,6 +108,8 @@ impl<'source> Environment<'source> {
             formatter: Arc::new(defaults::escape_formatter),
             #[cfg(feature = "debug")]
             debug: cfg!(debug_assertions),
+            #[cfg(feature = "fuel")]
+            fuel: None,
         }
     }
 
@@ -123,6 +127,8 @@ impl<'source> Environment<'source> {
             formatter: Arc::new(defaults::escape_formatter),
             #[cfg(feature = "debug")]
             debug: cfg!(debug_assertions),
+            #[cfg(feature = "fuel")]
+            fuel: None,
         }
     }
 
@@ -338,6 +344,28 @@ impl<'source> Environment<'source> {
     #[cfg(feature = "debug")]
     pub(crate) fn debug(&self) -> bool {
         self.debug
+    }
+
+    /// Sets the optional fuel of the engine.
+    ///
+    /// When MiniJinja is compiled with the `fuel` feature then every
+    /// instruction consumes a certain amount of fuel.  Usually `1`, some will
+    /// consume no fuel.  By default the engine has the fuel feature disabled
+    /// (`None`).  To turn on fuel set something like `Some(50000)` which will
+    /// allow 50.000 instructions to execute before running out of fuel.
+    ///
+    /// Fuel consumed per-render.
+    #[cfg(feature = "fuel")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "fuel")))]
+    pub fn set_fuel(&mut self, fuel: Option<u64>) {
+        self.fuel = fuel;
+    }
+
+    /// Returns the configured fuel.
+    #[cfg(feature = "fuel")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "fuel")))]
+    pub fn fuel(&self) -> Option<u64> {
+        self.fuel
     }
 
     /// Sets the template source for the environment.

--- a/minijinja/src/error.rs
+++ b/minijinja/src/error.rs
@@ -134,6 +134,9 @@ pub enum ErrorKind {
     CannotUnpack,
     /// Failed writing output.
     WriteFailure,
+    /// Engine ran out of fuel
+    #[cfg(feature = "fuel")]
+    OutOfFuel,
 }
 
 impl ErrorKind {
@@ -157,6 +160,8 @@ impl ErrorKind {
             ErrorKind::EvalBlock => "could not render block",
             ErrorKind::CannotUnpack => "cannot unpack",
             ErrorKind::WriteFailure => "failed to write output",
+            #[cfg(feature = "fuel")]
+            ErrorKind::OutOfFuel => "engine ran out of fuel",
         }
     }
 }

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -150,7 +150,7 @@ pub(crate) struct BoxedFilter(Arc<FilterFunc>);
 /// use minijinja::value::Rest;
 ///
 /// fn pyjoin(joiner: String, values: Rest<String>) -> String {
-///     values.connect(&joiner)
+///     values.join(&joiner)
 /// }
 ///
 /// env.add_filter("pyjoin", pyjoin);

--- a/minijinja/src/lib.rs
+++ b/minijinja/src/lib.rs
@@ -157,6 +157,8 @@
 //!
 //! There are some additional features that can be enabled:
 //!
+//! - `fuel`: enables the `fuel` feature which makes the engine track fuel consumption which
+//!   can be used to better protect against expensive templates.
 //! - `source`: enables the `Source` type which helps with dynamic loading of templates.
 //! - `speedups`: enables all speedups, in particular it turns on the `v_htmlescape` dependency
 //!   for faster HTML escapling.  This also turns on `key_interning` automatically.

--- a/minijinja/src/vm/fuel.rs
+++ b/minijinja/src/vm/fuel.rs
@@ -1,0 +1,55 @@
+use crate::compiler::instructions::Instruction;
+use crate::error::{Error, ErrorKind};
+
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+
+/// Helper for tracking fuel consumption
+pub struct FuelTracker {
+    remaining: AtomicI64,
+}
+
+impl FuelTracker {
+    /// Creates a new fuel tracker.
+    ///
+    /// The fuel tracker is always wrapped in an `Arc` so that it can be
+    /// shared across nested invocations of the template evaluation.
+    pub fn new(fuel: u64) -> Arc<FuelTracker> {
+        Arc::new(FuelTracker {
+            remaining: AtomicI64::new(fuel as i64),
+        })
+    }
+
+    /// Tracks an instruction.  If it runs out of fuel an error is returned.
+    pub fn track(&self, instr: &Instruction) -> Result<(), Error> {
+        let fuel_to_consume = fuel_for_instruction(instr);
+        if fuel_to_consume != 0 {
+            let old_fuel = self.remaining.fetch_sub(fuel_to_consume, Ordering::Relaxed);
+            if old_fuel - fuel_to_consume <= 0 {
+                return Err(Error::from(ErrorKind::OutOfFuel));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// How much fuel does an instruction consume?
+fn fuel_for_instruction(instruction: &Instruction) -> i64 {
+    match instruction {
+        Instruction::BeginCapture(_)
+        | Instruction::LoadBlocks
+        | Instruction::RenderParent
+        | Instruction::BuildMacro(..)
+        | Instruction::ExportLocals
+        | Instruction::PushLoop(_)
+        | Instruction::PushDidNotIterate
+        | Instruction::PushWith
+        | Instruction::PopFrame
+        | Instruction::DupTop
+        | Instruction::DiscardTop
+        | Instruction::PushAutoEscape
+        | Instruction::PopAutoEscape
+        | Instruction::Return => 0,
+        _ => 1,
+    }
+}

--- a/minijinja/src/vm/loop_object.rs
+++ b/minijinja/src/vm/loop_object.rs
@@ -80,6 +80,12 @@ impl StructObject for Loop {
 
     fn get_field(&self, name: &str) -> Option<Value> {
         let idx = self.idx.load(Ordering::Relaxed) as u64;
+        // if we never iterated, then all attributes are undefined.
+        // this can happen in some rare circumstances where the engine
+        // did not manage to iterate
+        if idx == !0 {
+            return Some(Value::UNDEFINED);
+        }
         let len = self.len as u64;
         match name {
             "index0" => Some(Value::from(idx)),

--- a/minijinja/src/vm/state.rs
+++ b/minijinja/src/vm/state.rs
@@ -8,6 +8,9 @@ use crate::value::{ArgType, Value};
 use crate::vm::context::Context;
 use crate::AutoEscape;
 
+#[cfg(feature = "fuel")]
+use crate::vm::fuel::FuelTracker;
+
 /// Provides access to the current execution state of the engine.
 ///
 /// A read only reference is passed to filter functions and similar objects to
@@ -32,6 +35,8 @@ pub struct State<'vm, 'env> {
     pub(crate) loaded_templates: BTreeSet<&'env str>,
     #[cfg(feature = "macros")]
     pub(crate) macros: std::sync::Arc<Vec<(&'vm Instructions<'env>, usize)>>,
+    #[cfg(feature = "fuel")]
+    pub(crate) fuel_tracker: Option<std::sync::Arc<FuelTracker>>,
 }
 
 impl<'vm, 'env> fmt::Debug for State<'vm, 'env> {
@@ -91,6 +96,8 @@ impl<'vm, 'env> State<'vm, 'env> {
             loaded_templates: BTreeSet::new(),
             macros: Default::default(),
             current_call: None,
+            #[cfg(feature = "fuel")]
+            fuel_tracker: env.fuel().map(FuelTracker::new),
         })
     }
 

--- a/minijinja/tests/test_fuel.rs
+++ b/minijinja/tests/test_fuel.rs
@@ -1,0 +1,50 @@
+#![cfg(feature = "fuel")]
+use minijinja::{context, Environment, ErrorKind};
+
+#[test]
+fn test_basic() {
+    let mut env = Environment::new();
+    assert_eq!(env.fuel(), None);
+    env.set_fuel(Some(100));
+    assert_eq!(env.fuel(), Some(100));
+    env.add_template("test", "{% for x in seq %}{{ x }}\n{% endfor %}")
+        .unwrap();
+    let t = env.get_template("test").unwrap();
+
+    // this will still manage to run with 100 fuel
+    let rv = t
+        .render(context!(seq => (0..15).collect::<Vec<_>>()))
+        .unwrap();
+    assert_eq!(rv.lines().count(), 15);
+
+    // this is above the limit
+    let rv = t
+        .render(context!(seq => (0..20).collect::<Vec<_>>()))
+        .unwrap_err();
+    assert_eq!(rv.kind(), ErrorKind::OutOfFuel);
+}
+
+#[cfg(feature = "macros")]
+#[test]
+fn test_macro_fuel() {
+    let mut env = Environment::new();
+    assert_eq!(env.fuel(), None);
+    env.set_fuel(Some(100));
+    assert_eq!(env.fuel(), Some(100));
+    env.add_template(
+        "test",
+        "
+        {% macro x() %}{% for item in range(5) %}...{% endfor %}{% endmacro %}
+        {% for count in range(macros) %}{{ x() }}{% endfor %}
+    ",
+    )
+    .unwrap();
+    let t = env.get_template("test").unwrap();
+
+    // this should succeed
+    t.render(context!(macros => 3)).unwrap();
+
+    // but running more macros should not
+    let err = t.render(context!(macros => 5)).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::OutOfFuel);
+}


### PR DESCRIPTION
In order to better sandbox the engine, this adds the ability to track fuel consumption during execution. Once the engine runs out of fuel, an error is produced.