### PR TITLE
Fix doc tests failing on nightly

### DIFF
--- a/minijinja-stack-ref/src/lib.rs
+++ b/minijinja-stack-ref/src/lib.rs
@@ -72,7 +72,7 @@
 //! ```
 //! use minijinja::value::{StructObject, Value};
 //! use minijinja::{context, Environment};
-//! use minijinja_stack_ref::scope;
+//! use minijinja_stack_ref::{reborrow, scope};
 //!
 //! struct Config {
 //!     version: &'static str,
@@ -273,7 +273,7 @@ pub fn reborrow<T: ?Sized, R>(obj: &T, f: for<'a> fn(&'a T, &'a Scope) -> R) -> 
 ///                     scope.seq_object_ref(&slf.values[..])
 ///                 }))
 ///             } else {
-///                 Some(Value::from_serializable(&self.values)),
+///                 Some(Value::from_serializable(&self.values))
 ///             },
 ///             _ => None
 ///         }


### PR DESCRIPTION
Was failing with these:

```rust
---- src/lib.rs - can_reborrow (line 260) stdout ----
error: expected one of `.`, `;`, `?`, `}`, or an operator, found `,`
  --> src/lib.rs:276:61
   |
19 |                 Some(Value::from_serializable(&self.values)),
   |                                                             ^ expected one of `.`, `;`, `?`, `}`, or an operator

error: aborting due to previous error

Couldn't compile the test.
---- src/lib.rs - (line 72) stdout ----
error[E0425]: cannot find function `reborrow` in this scope
  --> src/lib.rs:98:30
   |
29 |             "config" => Some(reborrow(self, |slf, scope| {
   |                              ^^^^^^^^
   |
help: try calling `reborrow` as a method
   |
29 ~             "config" => Some(self.reborrow(|slf, scope| {
30 +                 scope.struct_object_ref(&slf.config)
31 ~             })),
   |
help: consider importing this function
   |
2  | use minijinja_stack_ref::reborrow;
   |

error: aborting due to previous error
```