### PR TITLE
Tweak Python binding

### DIFF
--- a/minijinja-py/.gitignore
+++ b/minijinja-py/.gitignore
@@ -1,2 +1,3 @@
 .venv
-python/minijinja_py/minijinja_py.*
+__pycache__
+python/minijinja/_lowlevel.*

--- a/minijinja-py/Cargo.toml
+++ b/minijinja-py/Cargo.toml
@@ -12,3 +12,6 @@ crate-type = ["cdylib"]
 minijinja = { version = "0.29.0", path = "../minijinja", features = ["source", "json", "urlencode", "fuel"] }
 once_cell = "1.17.0"
 pyo3 = { version = "0.17.3", features = ["extension-module", "serde"] }
+
+[package.metadata.maturin]
+name = "minijinja._lowlevel"

--- a/minijinja-py/Cargo.toml
+++ b/minijinja-py/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 minijinja = { version = "0.29.0", path = "../minijinja", features = ["source", "json", "urlencode", "fuel"] }
 once_cell = "1.17.0"
-pyo3 = { version = "0.17.3", features = ["extension-module", "serde"] }
+pyo3 = { version = "0.18.0", features = ["extension-module", "serde"] }
 
 [package.metadata.maturin]
 name = "minijinja._lowlevel"

--- a/minijinja-py/README.md
+++ b/minijinja-py/README.md
@@ -31,7 +31,7 @@ like in `minijinja` with some Python specific changes.  For instance instead of
 directly to the environment or a `loader` function.
 
 ```python
-from minijinja_py import Environment
+from minijinja import Environment
 
 env = Environment(templates={
     "template_name": "Template source"

--- a/minijinja-py/hello.py
+++ b/minijinja-py/hello.py
@@ -1,4 +1,4 @@
-from minijinja_py import Environment
+from minijinja import Environment
 
 INDEX = """{% extends "layout.html" %}
 {% block title %}{{ page.title }}{% endblock %}

--- a/minijinja-py/python/minijinja/__init__.py
+++ b/minijinja-py/python/minijinja/__init__.py
@@ -6,6 +6,9 @@ __all__ = ["Environment", "safe", "escape", "render_str", "eval_expr"]
 
 class Environment(_lowlevel.Environment):
     """Represents a MiniJinja environment"""
+    def __new__(cls, *args, **kwargs):
+        # `_lowlevel.Environment` does not accept any arguments
+        return super().__new__(cls)
 
     def __init__(
         self,

--- a/minijinja-py/python/minijinja/__init__.py
+++ b/minijinja-py/python/minijinja/__init__.py
@@ -1,4 +1,4 @@
-from . import minijinja_py as _lowlevel
+from . import _lowlevel
 
 
 __all__ = ["Environment", "safe", "escape", "render_str", "eval_expr"]

--- a/minijinja-py/src/environment.rs
+++ b/minijinja-py/src/environment.rs
@@ -20,8 +20,7 @@ pub struct Environment {
 #[pymethods]
 impl Environment {
     #[new]
-    #[pyo3(signature = (**_kwargs))]
-    fn py_new(_kwargs: Option<&PyDict>) -> PyResult<Self> {
+    fn py_new() -> PyResult<Self> {
         Ok(Environment {
             inner: Mutex::new(minijinja::Environment::new()),
         })

--- a/minijinja-py/src/environment.rs
+++ b/minijinja-py/src/environment.rs
@@ -12,7 +12,7 @@ use crate::typeconv::{
 };
 
 /// Represents a MiniJinja environment.
-#[pyclass(subclass)]
+#[pyclass(subclass, module = "minijinja._lowlevel")]
 pub struct Environment {
     inner: Mutex<minijinja::Environment<'static>>,
 }
@@ -20,7 +20,8 @@ pub struct Environment {
 #[pymethods]
 impl Environment {
     #[new]
-    fn py_new() -> PyResult<Self> {
+    #[pyo3(signature = (**_kwargs))]
+    fn py_new(_kwargs: Option<&PyDict>) -> PyResult<Self> {
         Ok(Environment {
             inner: Mutex::new(minijinja::Environment::new()),
         })
@@ -234,11 +235,10 @@ impl Environment {
     ///
     /// The first argument is the name of the template, all other arguments must be passed
     /// as keyword arguments and are pass as render context of the template.
-    #[args(ctx = "**")]
-    #[pyo3(text_signature = "(self, template_name, /, **ctx)")]
-    pub fn render_template(&self, __template_name: &str, ctx: Option<&PyDict>) -> PyResult<String> {
+    #[pyo3(signature = (template_name, /, **ctx))]
+    pub fn render_template(&self, template_name: &str, ctx: Option<&PyDict>) -> PyResult<String> {
         let env = self.inner.lock().unwrap();
-        let tmpl = env.get_template(__template_name).map_err(to_py_error)?;
+        let tmpl = env.get_template(template_name).map_err(to_py_error)?;
         let ctx = ctx
             .map(|ctx| Value::from_struct_object(DictLikeObject { inner: ctx.into() }))
             .unwrap_or_else(|| context!());
@@ -249,28 +249,26 @@ impl Environment {
     ///
     /// The first argument is the source of the template, all other arguments must be passed
     /// as keyword arguments and are pass as render context of the template.
-    #[args(ctx = "**")]
-    #[pyo3(text_signature = "(self, source, name=None, /, **ctx)")]
+    #[pyo3(signature = (source, name=None, /, **ctx))]
     pub fn render_str(
         &self,
-        __source: &str,
-        __name: Option<&str>,
+        source: &str,
+        name: Option<&str>,
         ctx: Option<&PyDict>,
     ) -> PyResult<String> {
         let env = self.inner.lock().unwrap();
         let ctx = ctx
             .map(|ctx| Value::from_struct_object(DictLikeObject { inner: ctx.into() }))
             .unwrap_or_else(|| context!());
-        env.render_named_str(__name.unwrap_or("<string>"), __source, ctx)
+        env.render_named_str(name.unwrap_or("<string>"), source, ctx)
             .map_err(to_py_error)
     }
 
     /// Evaluates an expression with a given context.
-    #[args(ctx = "**")]
-    #[pyo3(text_signature = "(self, expr, /, **ctx)")]
-    pub fn eval_expr(&self, __expression: &str, ctx: Option<&PyDict>) -> PyResult<Py<PyAny>> {
+    #[pyo3(signature = (expression, /, **ctx))]
+    pub fn eval_expr(&self, expression: &str, ctx: Option<&PyDict>) -> PyResult<Py<PyAny>> {
         let env = self.inner.lock().unwrap();
-        let expr = env.compile_expression(__expression).map_err(to_py_error)?;
+        let expr = env.compile_expression(expression).map_err(to_py_error)?;
         let ctx = ctx
             .map(|ctx| Value::from_struct_object(DictLikeObject { inner: ctx.into() }))
             .unwrap_or_else(|| context!());

--- a/minijinja-py/src/lib.rs
+++ b/minijinja-py/src/lib.rs
@@ -5,7 +5,7 @@ mod error_support;
 mod typeconv;
 
 #[pymodule]
-fn minijinja(_py: Python, m: &PyModule) -> PyResult<()> {
+fn _lowlevel(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<environment::Environment>()?;
     Ok(())
 }

--- a/minijinja-py/src/lib.rs
+++ b/minijinja-py/src/lib.rs
@@ -5,7 +5,7 @@ mod error_support;
 mod typeconv;
 
 #[pymodule]
-fn minijinja_py(_py: Python, m: &PyModule) -> PyResult<()> {
+fn minijinja(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<environment::Environment>()?;
     Ok(())
 }

--- a/minijinja-py/src/typeconv.rs
+++ b/minijinja-py/src/typeconv.rs
@@ -209,7 +209,7 @@ pub fn to_python_value(value: Value) -> PyResult<Py<PyAny>> {
 
 fn mark_string_safe(py: Python<'_>, value: &str) -> PyResult<Py<PyAny>> {
     let safe: &Py<PyAny> = MARK_SAFE.get_or_try_init::<_, PyErr>(|| {
-        let module = py.import("minijinja_py")?;
+        let module = py.import("minijinja")?;
         Ok(module.getattr("safe")?.into())
     })?;
     safe.call1(py, PyTuple::new(py, [value]))

--- a/minijinja-py/src/typeconv.rs
+++ b/minijinja-py/src/typeconv.rs
@@ -156,13 +156,13 @@ impl StructObject for DynamicObject {
 }
 
 pub fn to_minijinja_value(value: &PyAny) -> Value {
-    if let Ok(dict) = value.cast_as::<PyDict>() {
+    if let Ok(dict) = value.downcast::<PyDict>() {
         Value::from_struct_object(DictLikeObject { inner: dict.into() })
-    } else if let Ok(tup) = value.cast_as::<PyTuple>() {
+    } else if let Ok(tup) = value.downcast::<PyTuple>() {
         Value::from_seq_object(ListLikeObject {
             inner: tup.as_sequence().into(),
         })
-    } else if let Ok(list) = value.cast_as::<PyList>() {
+    } else if let Ok(list) = value.downcast::<PyList>() {
         Value::from_seq_object(ListLikeObject {
             inner: list.as_sequence().into(),
         })

--- a/minijinja-py/tests/test_basic.py
+++ b/minijinja-py/tests/test_basic.py
@@ -1,6 +1,6 @@
 import pytest
 from _pytest.unraisableexception import catch_unraisable_exception
-from minijinja_py import Environment, safe
+from minijinja import Environment, safe
 
 
 def test_expression():


### PR DESCRIPTION
* The first commit changes the import name from `minijinja_py` to `minijinja` and move the extension module to `minijinja._lowlevel`
* The second commit upgrades pyo3 to 0.18.0