### PR TITLE
Allow access to underscore prefixed values in dicts

### DIFF
--- a/minijinja-py/src/typeconv.rs
+++ b/minijinja-py/src/typeconv.rs
@@ -25,9 +25,6 @@ pub struct DictLikeObject {
 
 impl StructObject for DictLikeObject {
     fn get_field(&self, name: &str) -> Option<Value> {
-        if !is_safe_attr(name) {
-            return None;
-        }
         Python::with_gil(|py| {
             let inner = self.inner.as_ref(py);
             inner.get_item(name).map(to_minijinja_value)

--- a/minijinja-py/tests/test_security.py
+++ b/minijinja-py/tests/test_security.py
@@ -1,0 +1,19 @@
+from _pytest.unraisableexception import catch_unraisable_exception
+from minijinja import Environment, TemplateError, safe
+
+
+def test_private_attrs():
+    class MyClass:
+        def __init__(self):
+            self.public = 42
+            self._private = 23
+
+    env = Environment()
+    rv = env.eval_expr("[x.public, x._private]", x=MyClass())
+    assert rv == [42, None]
+
+
+def test_dict_is_always_public():
+    env = Environment()
+    rv = env.eval_expr("[x.public, x._private]", x={"public": 42, "_private": 23})
+    assert rv == [42, 23]


### PR DESCRIPTION
Dicts were accidentally prevented from having underscore prefixed keys accessed. This security protection was supposed to only kick in for objects.

Fixes #196