### PR TITLE
Add a size hint for the initial buffer size

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2018"
 speedups = ["minijinja/speedups"]
 
 [dependencies]
-handlebars = "4.3.4"
+handlebars = "4.3.6"
 liquid = "0.26.0"
 minijinja = { path = "../minijinja", default-features = false, features = ["unstable_machinery", "multi-template", "builtins"] }
-serde = { version = "1.0.144", features = ["derive"] }
-serde_json = "1.0.85"
-tera = "1.17.0"
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.93"
+tera = "1.17.1"
 askama = "0.11.1"
 
 [dev-dependencies]

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,16 +17,16 @@ $ cargo bench
 These are the results run on a MacBook Pro 16" 2021:
 
 ```
-cmp_compile/handlebars  time:   [47.559 µs 47.671 µs 47.798 µs]
-cmp_compile/liquid      time:   [35.900 µs 35.916 µs 35.932 µs]
-cmp_compile/minijinja   time:   [5.9289 µs 5.9435 µs 5.9617 µs]
-cmp_compile/tera        time:   [39.341 µs 39.370 µs 39.402 µs]
+cmp_compile/handlebars  time:   [49.507 µs 49.559 µs 49.613 µs]
+cmp_compile/liquid      time:   [81.102 µs 81.198 µs 81.301 µs]
+cmp_compile/minijinja   time:   [4.9363 µs 4.9433 µs 4.9506 µs]
+cmp_compile/tera        time:   [89.963 µs 90.059 µs 90.156 µs]
 
-cmp_render/askama       time:   [1.7161 µs 1.7188 µs 1.7222 µs]
-cmp_render/handlebars   time:   [6.4346 µs 6.4413 µs 6.4484 µs]
-cmp_render/liquid       time:   [11.802 µs 11.810 µs 11.821 µs]
-cmp_render/minijinja    time:   [5.5019 µs 5.5078 µs 5.5147 µs]
-cmp_render/tera         time:   [8.0550 µs 8.0638 µs 8.0725 µs]
+cmp_render/askama       time:   [1.8098 µs 1.8121 µs 1.8145 µs]
+cmp_render/handlebars   time:   [6.5743 µs 6.5821 µs 6.5911 µs]
+cmp_render/liquid       time:   [12.604 µs 12.623 µs 12.642 µs]
+cmp_render/minijinja    time:   [5.4388 µs 5.4460 µs 5.4534 µs]
+cmp_render/tera         time:   [8.4889 µs 8.5013 µs 8.5157 µs]
 ```
 
 Note that Askama compiles templates as part of the Rust build

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,16 +17,16 @@ $ cargo bench
 These are the results run on a MacBook Pro 16" 2021:
 
 ```
-cmp_compile/handlebars  time:   [49.507 µs 49.559 µs 49.613 µs]
-cmp_compile/liquid      time:   [81.102 µs 81.198 µs 81.301 µs]
-cmp_compile/minijinja   time:   [4.9363 µs 4.9433 µs 4.9506 µs]
-cmp_compile/tera        time:   [89.963 µs 90.059 µs 90.156 µs]
+cmp_compile/handlebars  time:   [47.102 µs 47.234 µs 47.406 µs]
+cmp_compile/liquid      time:   [77.832 µs 78.082 µs 78.387 µs]
+cmp_compile/minijinja   time:   [4.7069 µs 4.7191 µs 4.7335 µs]
+cmp_compile/tera        time:   [85.692 µs 85.948 µs 86.244 µs]
 
-cmp_render/askama       time:   [1.8098 µs 1.8121 µs 1.8145 µs]
-cmp_render/handlebars   time:   [6.5743 µs 6.5821 µs 6.5911 µs]
-cmp_render/liquid       time:   [12.604 µs 12.623 µs 12.642 µs]
-cmp_render/minijinja    time:   [5.4388 µs 5.4460 µs 5.4534 µs]
-cmp_render/tera         time:   [8.4889 µs 8.5013 µs 8.5157 µs]
+cmp_render/askama       time:   [1.6835 µs 1.6854 µs 1.6876 µs]
+cmp_render/handlebars   time:   [6.2346 µs 6.2484 µs 6.2663 µs]
+cmp_render/liquid       time:   [12.024 µs 12.041 µs 12.062 µs]
+cmp_render/minijinja    time:   [4.9884 µs 5.0016 µs 5.0166 µs]
+cmp_render/tera         time:   [8.0609 µs 8.0681 µs 8.0761 µs]
 ```
 
 Note that Askama compiles templates as part of the Rust build

--- a/minijinja/src/compiler/codegen.rs
+++ b/minijinja/src/compiler/codegen.rs
@@ -47,6 +47,7 @@ pub struct CodeGenerator<'source> {
     span_stack: Vec<Span>,
     filter_local_ids: BTreeMap<&'source str, LocalId>,
     test_local_ids: BTreeMap<&'source str, LocalId>,
+    size_hint: usize,
     #[cfg(feature = "multi-template")]
     has_extends: bool,
 }
@@ -62,6 +63,7 @@ impl<'source> CodeGenerator<'source> {
             span_stack: Vec::new(),
             filter_local_ids: BTreeMap::new(),
             test_local_ids: BTreeMap::new(),
+            size_hint: 0,
             #[cfg(feature = "multi-template")]
             has_extends: false,
         }
@@ -248,6 +250,7 @@ impl<'source> CodeGenerator<'source> {
             ast::Stmt::EmitRaw(raw) => {
                 self.set_line_from_span(raw.span());
                 self.add(Instruction::EmitRaw(raw.raw));
+                self.size_hint += raw.raw.len();
             }
             ast::Stmt::ForLoop(for_loop) => {
                 self.compile_for_loop(for_loop);
@@ -793,6 +796,13 @@ impl<'source> CodeGenerator<'source> {
         self.compile_expr(&c.right);
         self.add(instr);
         self.pop_span();
+    }
+
+    /// Returns the size hint.
+    ///
+    /// This is a proposal for the initial buffer size when rendering directly to a string.
+    pub fn size_hint(&self) -> usize {
+        self.size_hint
     }
 
     /// Converts the compiler into the instructions.

--- a/minijinja/src/compiler/codegen.rs
+++ b/minijinja/src/compiler/codegen.rs
@@ -47,7 +47,7 @@ pub struct CodeGenerator<'source> {
     span_stack: Vec<Span>,
     filter_local_ids: BTreeMap<&'source str, LocalId>,
     test_local_ids: BTreeMap<&'source str, LocalId>,
-    size_hint: usize,
+    raw_template_bytes: usize,
     #[cfg(feature = "multi-template")]
     has_extends: bool,
 }
@@ -63,7 +63,7 @@ impl<'source> CodeGenerator<'source> {
             span_stack: Vec::new(),
             filter_local_ids: BTreeMap::new(),
             test_local_ids: BTreeMap::new(),
-            size_hint: 0,
+            raw_template_bytes: 0,
             #[cfg(feature = "multi-template")]
             has_extends: false,
         }
@@ -250,7 +250,7 @@ impl<'source> CodeGenerator<'source> {
             ast::Stmt::EmitRaw(raw) => {
                 self.set_line_from_span(raw.span());
                 self.add(Instruction::EmitRaw(raw.raw));
-                self.size_hint += raw.raw.len();
+                self.raw_template_bytes += raw.raw.len();
             }
             ast::Stmt::ForLoop(for_loop) => {
                 self.compile_for_loop(for_loop);
@@ -798,11 +798,15 @@ impl<'source> CodeGenerator<'source> {
         self.pop_span();
     }
 
-    /// Returns the size hint.
+    /// Returns the size hint for buffers.
     ///
     /// This is a proposal for the initial buffer size when rendering directly to a string.
-    pub fn size_hint(&self) -> usize {
-        self.size_hint
+    pub fn buffer_size_hint(&self) -> usize {
+        // for now the assumption is made that twice the bytes of template code without
+        // control structures, rounded up to the next power of two is a good default.  The
+        // round to the next power of two is chosen because the underlying vector backing
+        // strings prefers powers of two.
+        (self.raw_template_bytes * 2).next_power_of_two()
     }
 
     /// Converts the compiler into the instructions.

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -249,7 +249,7 @@ impl<'source> Environment<'source> {
 
     fn _render_str(&self, name: &str, source: &str, root: Value) -> Result<String, Error> {
         let compiled = ok!(CompiledTemplate::from_name_and_source(name, source));
-        let mut rv = String::with_capacity(compiled.size_hint);
+        let mut rv = String::with_capacity(compiled.buffer_size_hint);
         Vm::new(self)
             .eval(
                 &compiled.instructions,

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -249,7 +249,7 @@ impl<'source> Environment<'source> {
 
     fn _render_str(&self, name: &str, source: &str, root: Value) -> Result<String, Error> {
         let compiled = ok!(CompiledTemplate::from_name_and_source(name, source));
-        let mut rv = String::new();
+        let mut rv = String::with_capacity(compiled.size_hint);
         Vm::new(self)
             .eval(
                 &compiled.instructions,

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -239,7 +239,10 @@ pub fn escape(state: &State, v: Value) -> Result<Value, Error> {
         },
         other => other,
     };
-    let mut rv = String::new();
+    let mut rv = match v.as_str() {
+        Some(s) => String::with_capacity(s.len()),
+        None => String::new(),
+    };
     let mut out = Output::with_string(&mut rv);
     ok!(write_escaped(&mut out, auto_escape, &v));
     Ok(Value::from_safe_string(rv))

--- a/minijinja/src/template.rs
+++ b/minijinja/src/template.rs
@@ -88,7 +88,7 @@ impl<'env> Template<'env> {
     }
 
     fn _render(&self, root: Value) -> Result<String, Error> {
-        let mut rv = String::with_capacity(self.compiled.size_hint);
+        let mut rv = String::with_capacity(self.compiled.buffer_size_hint);
         self._eval(root, &mut Output::with_string(&mut rv))
             .map(|_| rv)
     }
@@ -165,7 +165,7 @@ pub struct CompiledTemplate<'source> {
     /// Block local instructions.
     pub blocks: BTreeMap<&'source str, Instructions<'source>>,
     /// Optional size hint for string rendering.
-    pub size_hint: usize,
+    pub buffer_size_hint: usize,
 }
 
 impl<'env> fmt::Debug for CompiledTemplate<'env> {
@@ -199,12 +199,12 @@ impl<'source> CompiledTemplate<'source> {
             let ast = ok!(parse(source, name));
             let mut gen = CodeGenerator::new(name, source);
             gen.compile_stmt(&ast);
-            let size_hint = gen.size_hint();
+            let buffer_size_hint = gen.buffer_size_hint();
             let (instructions, blocks) = gen.finish();
             Ok(CompiledTemplate {
                 instructions,
                 blocks,
-                size_hint,
+                buffer_size_hint,
             })
         })
     }

--- a/minijinja/src/template.rs
+++ b/minijinja/src/template.rs
@@ -88,7 +88,7 @@ impl<'env> Template<'env> {
     }
 
     fn _render(&self, root: Value) -> Result<String, Error> {
-        let mut rv = String::new();
+        let mut rv = String::with_capacity(self.compiled.size_hint);
         self._eval(root, &mut Output::with_string(&mut rv))
             .map(|_| rv)
     }
@@ -164,6 +164,8 @@ pub struct CompiledTemplate<'source> {
     pub instructions: Instructions<'source>,
     /// Block local instructions.
     pub blocks: BTreeMap<&'source str, Instructions<'source>>,
+    /// Optional size hint for string rendering.
+    pub size_hint: usize,
 }
 
 impl<'env> fmt::Debug for CompiledTemplate<'env> {
@@ -197,10 +199,12 @@ impl<'source> CompiledTemplate<'source> {
             let ast = ok!(parse(source, name));
             let mut gen = CodeGenerator::new(name, source);
             gen.compile_stmt(&ast);
+            let size_hint = gen.size_hint();
             let (instructions, blocks) = gen.finish();
             Ok(CompiledTemplate {
                 instructions,
                 blocks,
+                size_hint,
             })
         })
     }


### PR DESCRIPTION
This calculates the number of bytes of raw template output instructions to set a initial buffer capacity when rendering into a string. This is not a real lower bound, but it's one in probably most cases.

Results in a tiny speedup.

Refs #203