### PR TITLE
Use maturin==0.15.1 to fix venv handling

### DIFF
--- a/minijinja-py/Makefile
+++ b/minijinja-py/Makefile
@@ -4,15 +4,15 @@ all: develop test
 .venv:
 	python3 -mvenv .venv
 	.venv/bin/pip install --upgrade pip
-	.venv/bin/pip install maturin pytest markupsafe black
+	.venv/bin/pip install maturin==1.0.0-beta.1 pytest markupsafe black
 
 .PHONY: test
 develop: .venv
-	. .venv/bin/activate; maturin develop
+	.venv/bin/maturin develop
 
 .PHONY: develop-release
 develop-release: .venv
-	. .venv/bin/activate; maturin develop --release
+	.venv/bin/maturin develop --release
 
 .PHONY: test
 test: .venv

--- a/minijinja-py/Makefile
+++ b/minijinja-py/Makefile
@@ -4,7 +4,7 @@ all: develop test
 .venv:
 	python3 -mvenv .venv
 	.venv/bin/pip install --upgrade pip
-	.venv/bin/pip install maturin==1.0.0-beta.1 pytest markupsafe black
+	.venv/bin/pip install maturin==0.15.1 pytest markupsafe black
 
 .PHONY: test
 develop: .venv

--- a/minijinja-py/pyproject.toml
+++ b/minijinja-py/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15,<0.16"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
This showcases https://github.com/PyO3/maturin/pull/1462 / https://github.com/PyO3/maturin/issues/1461: We don't need to activate the venv anymore for `maturin develop`, a normal `.venv/bin/maturin develop` now uses it automatically just like the other tools do (it's technically different from what e.g. pytest does, but from a user perspective it works the same, so i think it's an appropriate solution).