### PR TITLE
Expose compiler module

### DIFF
--- a/minijinja/src/lib.rs
+++ b/minijinja/src/lib.rs
@@ -181,7 +181,6 @@
 #[macro_use]
 mod macros;
 
-mod compiler;
 mod defaults;
 mod environment;
 mod error;
@@ -197,6 +196,7 @@ pub mod functions;
 pub mod syntax;
 pub mod tests;
 pub mod value;
+pub mod compiler;
 
 #[cfg(feature = "source")]
 mod source;


### PR DESCRIPTION
We have a really specific use-case of wanting to extract Jinja interpolations from a PRQL source file and then stick them back in when PRQL is compiled to SQL. See https://github.com/PRQL/prql/pull/1722

For this I needed a Jinja lexer and I ended up forking minijinja and just adding `pub mod lexer`.

Thank you for your work on Jinja in Rust!