### PR TITLE
Change internal serialization format to fail flattening of values

### DIFF
--- a/minijinja/Cargo.toml
+++ b/minijinja/Cargo.toml
@@ -63,5 +63,6 @@ unicode-ident = { version = "1.0.5", optional = true }
 
 [dev-dependencies]
 insta = { version = "1.26.0", features = ["glob", "serde"] }
+serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 similar-asserts = "1.4.2"

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -1027,15 +1027,15 @@ impl Serialize for Value {
     {
         // enable round tripping of values
         if serializing_for_value() {
-            use serde::ser::SerializeStruct;
+            use serde::ser::SerializeTupleVariant;
             let handle = LAST_VALUE_HANDLE.with(|x| {
                 let rv = x.get() + 1;
                 x.set(rv);
                 rv
             });
             VALUE_HANDLES.with(|handles| handles.borrow_mut().insert(handle, self.clone()));
-            let mut s = ok!(serializer.serialize_struct(VALUE_HANDLE_MARKER, 1));
-            ok!(s.serialize_field("handle", &handle));
+            let mut s = ok!(serializer.serialize_tuple_variant("", 0, VALUE_HANDLE_MARKER, 1));
+            ok!(s.serialize_field(&handle));
             return s.end();
         }
 

--- a/minijinja/tests/test_templates.rs
+++ b/minijinja/tests/test_templates.rs
@@ -338,3 +338,26 @@ fn test_current_call_state() {
     "#
     );
 }
+
+#[test]
+#[should_panic = "can only flatten structs and maps"]
+fn test_flattening() {
+    // ideally this would work, but unfortuantely the way serde flatten works makes it
+    // impossible for us to support with the internal optimizations in the value model.
+    // see https://github.com/mitsuhiko/minijinja/issues/222
+    #[derive(Debug, serde::Serialize)]
+    struct Context {
+        a: i32,
+        #[serde(flatten)]
+        more: Value,
+    }
+
+    let ctx = Context {
+        a: 42,
+        more: Value::from(BTreeMap::from([("b", 23)])),
+    };
+
+    let env = Environment::new();
+    let rv = env.render_str("{{ debug() }}", ctx).unwrap();
+    assert_eq!(rv, "42|23");
+}


### PR DESCRIPTION
Changes the format so that `#[serde(flatten)]` of a `Value` fails with an error, than silently doing the wrong thing. Unfortunately this is not resolvable without changes in serde itself.

Previously you this would flatten out the internal handle which is not what you want, now it fails with an error.

Refs #222