### PR TITLE
Improved Callbacks for Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to MiniJinja are documented here.
 
 - The `in` operator now does not fail if the value is undefined and the
   undefined behavior is not strict. (#235)
+- The Python binding now supports finalizers. (#238)
 
 ## 0.31.0
 

--- a/minijinja-py/README.md
+++ b/minijinja-py/README.md
@@ -108,6 +108,26 @@ env = Environment(auto_escape_callback=lambda x: x.endswith((".html", ".foo")))
 MiniJinja uses [markupsafe](https://github.com/pallets/markupsafe) if it's available
 on the Python side.  It will honor `__html__`.
 
+## Finalizers
+
+Instead of custom formatters like in MiniJinja, you can define a finalizer instead
+which is similar to how it works in Jinja2.  It's passed a value (or optional also
+the state as first argument whne `pass_state` is used) and can return a new value.
+If the special `NotImplemented` value is returned, the original value is rendered
+without any modification:
+
+```
+from minijinja import Environment
+
+def finalizer(value):
+    if value is None:
+	return ""
+    return NotImplemented
+
+env = Environment(finalizer=finalizer)
+assert env.render_str("{{ none }}") == ""
+```
+
 ## State Access
 
 Functions passed to the environment such as filters or global functions can

--- a/minijinja-py/python/minijinja/__init__.py
+++ b/minijinja-py/python/minijinja/__init__.py
@@ -29,6 +29,7 @@ class Environment(_lowlevel.Environment):
         fuel=None,
         undefined_behavior=None,
         auto_escape_callback=None,
+        finalizer=None,
         reload_before_render=False,
     ):
         super().__init__()
@@ -52,6 +53,8 @@ class Environment(_lowlevel.Environment):
         self.debug = debug
         if auto_escape_callback is not None:
             self.auto_escape_callback = auto_escape_callback
+        if finalizer is not None:
+            self.finalizer = finalizer
         if undefined_behavior is not None:
             self.undefined_behavior = undefined_behavior
         self.reload_before_render = reload_before_render

--- a/minijinja-py/src/environment.rs
+++ b/minijinja-py/src/environment.rs
@@ -286,7 +286,6 @@ impl Environment {
                     let args = std::slice::from_ref(value);
                     let (py_args, py_kwargs) = to_python_args(py, callback.as_ref(py), args)
                         .map_err(to_minijinja_error)?;
-                    dbg!(&py_args, py_kwargs);
                     let rv = callback
                         .call(py, py_args, py_kwargs)
                         .map_err(to_minijinja_error)?;

--- a/minijinja-py/src/environment.rs
+++ b/minijinja-py/src/environment.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use std::sync::Mutex;
 
 use minijinja::value::{Rest, Value};
-use minijinja::{context, AutoEscape, Error, Source, State, UndefinedBehavior};
+use minijinja::{context, escape_formatter, AutoEscape, Error, Source, State, UndefinedBehavior};
 use pyo3::conversion::AsPyPointer;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -23,6 +23,7 @@ struct Inner {
     env: minijinja::Environment<'static>,
     loader: Option<Py<PyAny>>,
     auto_escape_callback: Option<Py<PyAny>>,
+    finalizer_callback: Option<Py<PyAny>>,
 }
 
 /// Represents a MiniJinja environment.
@@ -41,6 +42,7 @@ impl Environment {
                 env: minijinja::Environment::new(),
                 loader: None,
                 auto_escape_callback: None,
+                finalizer_callback: None,
             }),
             reload_before_render: AtomicBool::new(false),
         })
@@ -265,6 +267,48 @@ impl Environment {
     #[getter]
     pub fn get_auto_escape_callback(&self) -> PyResult<Option<Py<PyAny>>> {
         Ok(self.inner.lock().unwrap().auto_escape_callback.clone())
+    }
+
+    /// Sets a finalizer.
+    ///
+    /// A finalizer is called before a value is rendered to customize it.
+    #[setter]
+    pub fn set_finalizer(&self, callback: &PyAny) -> PyResult<()> {
+        if !callback.is_callable() {
+            return Err(PyRuntimeError::new_err("expected callback"));
+        }
+        let callback: Py<PyAny> = callback.into();
+        let mut inner = self.inner.lock().unwrap();
+        inner.finalizer_callback = Some(callback.clone());
+        inner.env.set_formatter(move |output, state, value| {
+            Python::with_gil(|py| -> Result<(), Error> {
+                let maybe_new_value = bind_state(state, || -> Result<_, Error> {
+                    let args = std::slice::from_ref(value);
+                    let (py_args, py_kwargs) = to_python_args(py, callback.as_ref(py), args)
+                        .map_err(to_minijinja_error)?;
+                    dbg!(&py_args, py_kwargs);
+                    let rv = callback
+                        .call(py, py_args, py_kwargs)
+                        .map_err(to_minijinja_error)?;
+                    if rv.is(&py.NotImplemented()) {
+                        Ok(None)
+                    } else {
+                        Ok(Some(to_minijinja_value(rv.as_ref(py))))
+                    }
+                })?;
+                let value = match maybe_new_value {
+                    Some(ref new_value) => new_value,
+                    None => value,
+                };
+                escape_formatter(output, state, value)
+            })
+        });
+        Ok(())
+    }
+
+    #[getter]
+    pub fn get_finalizer(&self) -> PyResult<Option<Py<PyAny>>> {
+        Ok(self.inner.lock().unwrap().finalizer_callback.clone())
     }
 
     /// Sets a loader function for the environment.

--- a/minijinja-py/tests/test_basic.py
+++ b/minijinja-py/tests/test_basic.py
@@ -130,6 +130,8 @@ def test_loader_reload():
 
 
 def test_autoescape():
+    assert Environment().auto_escape_callback is None
+
     def auto_escape(name):
         assert name == "foo.html"
         return "html"
@@ -138,6 +140,7 @@ def test_autoescape():
         auto_escape_callback=auto_escape,
         loader=lambda x: "Hello {{ foo }}",
     )
+    assert env.auto_escape_callback is auto_escape
 
     rv = env.render_template("foo.html", foo="<x>")
     assert rv == "Hello &lt;x&gt;"

--- a/minijinja-py/tests/test_basic.py
+++ b/minijinja-py/tests/test_basic.py
@@ -1,5 +1,8 @@
+import binascii
+import pytest
+
 from _pytest.unraisableexception import catch_unraisable_exception
-from minijinja import Environment, TemplateError, safe
+from minijinja import Environment, TemplateError, safe, pass_state
 
 
 def test_expression():
@@ -149,6 +152,38 @@ def test_autoescape():
         rv = env.render_template("invalid.html", foo="<x>")
         assert rv == "Hello <x>"
         assert cm.unraisable[0] is AssertionError
+
+
+def test_finalizer():
+    assert Environment().finalizer is None
+
+    @pass_state
+    def my_finalizer(state, value):
+        assert state.name == "<string>"
+        if value is None:
+            return ""
+        elif isinstance(value, bytes):
+            return binascii.b2a_hex(value).decode("utf-8")
+        return NotImplemented
+
+    env = Environment(finalizer=my_finalizer)
+
+    rv = env.render_str("[{{ foo }}]")
+    assert rv == "[]"
+    rv = env.render_str("[{{ foo }}]", foo=None)
+    assert rv == "[]"
+    rv = env.render_str("[{{ foo }}]", foo="test")
+    assert rv == "[test]"
+    rv = env.render_str("[{{ foo }}]", foo=b"test")
+    assert rv == "[74657374]"
+
+    def raising_finalizer(value):
+        1 / 0
+
+    env = Environment(finalizer=raising_finalizer)
+
+    with pytest.raises(ZeroDivisionError):
+        env.render_str("{{ whatever }}")
 
 
 def test_globals():


### PR DESCRIPTION
This adds a new `finalizer` callback to the Python API that can be used to modify the value before it is rendered with the formatter. This is not quite the same as the formatter system in MiniJinja but it better resembles how this works in Jinja2.

Refs https://github.com/mitsuhiko/minijinja/discussions/237