### PR TITLE
Fix startingwith/endingwith docs

### DIFF
--- a/minijinja/src/tests.rs
+++ b/minijinja/src/tests.rs
@@ -311,8 +311,8 @@ mod builtins {
     /// Checks if the value is starting with a string.
     ///
     /// ```jinja
-    /// {{ "foobar" is startingwith "foo" }} -> true
-    /// {{ "foobar" is startingwith "bar" }} -> false
+    /// {{ "foobar" is startingwith("foo") }} -> true
+    /// {{ "foobar" is startingwith("bar") }} -> false
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
     pub fn is_startingwith(v: Cow<'_, str>, other: Cow<'_, str>) -> bool {
@@ -322,8 +322,8 @@ mod builtins {
     /// Checks if the value is ending with a string.
     ///
     /// ```jinja
-    /// {{ "foobar" is endingwith "bar" }} -> true
-    /// {{ "foobar" is endingwith "foo" }} -> false
+    /// {{ "foobar" is endingwith("bar") }} -> true
+    /// {{ "foobar" is endingwith("foo") }} -> false
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
     pub fn is_endingwith(v: Cow<'_, str>, other: Cow<'_, str>) -> bool {


### PR DESCRIPTION
I think the example codes are misleading and invalid:
```
syntax error: unexpected string, expected end of variable block
```