### PR TITLE
Fix an issue with autoreloading on file save with Windows.

### DIFF
--- a/minijinja-autoreload/src/lib.rs
+++ b/minijinja-autoreload/src/lib.rs
@@ -267,7 +267,7 @@ impl Notifier {
                         kind,
                         EventKind::Create(_)
                             | EventKind::Remove(_)
-                            | EventKind::Modify(ModifyKind::Data(_) | ModifyKind::Name(_))
+                            | EventKind::Modify(ModifyKind::Data(_) | ModifyKind::Name(_) | ModifyKind::Any)
                     ) {
                         if let Some(inner) = weak_handle.upgrade() {
                             inner.lock().unwrap().should_reload = true;


### PR DESCRIPTION
On Windows, when a file is saved, it sends an EventKind::Modify(ModifyKind::Any) event, which was not currently being handled by the AutoReloader Notifier.

See https://github.com/mitsuhiko/minijinja/issues/247