### PR TITLE
ci: add test for fuel feature

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,18 @@ jobs:
       - name: Check
         run: cargo check --all-features -p minijinja --target armv5te-unknown-linux-gnueabi
 
+  test-fuel-feature:
+    name: Check on 1.61.0 (fuel feature)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.61.0
+      - name: Check
+        run: cargo check --no-default-features -p minijinja --features fuel
+
   test-stable:
     name: Test on 1.61.0
     runs-on: ubuntu-latest

--- a/minijinja/src/vm/fuel.rs
+++ b/minijinja/src/vm/fuel.rs
@@ -39,10 +39,6 @@ impl FuelTracker {
 fn fuel_for_instruction(instruction: &Instruction) -> isize {
     match instruction {
         Instruction::BeginCapture(_)
-        | Instruction::LoadBlocks
-        | Instruction::RenderParent
-        | Instruction::BuildMacro(..)
-        | Instruction::ExportLocals
         | Instruction::PushLoop(_)
         | Instruction::PushDidNotIterate
         | Instruction::PushWith
@@ -50,8 +46,14 @@ fn fuel_for_instruction(instruction: &Instruction) -> isize {
         | Instruction::DupTop
         | Instruction::DiscardTop
         | Instruction::PushAutoEscape
-        | Instruction::PopAutoEscape
-        | Instruction::Return => 0,
+        | Instruction::PopAutoEscape => 0,
+        #[cfg(feature = "multi_template")]
+        Instruction::ExportLocals => 0,
+        #[cfg(feature = "macros")]
+        Instruction::LoadBlocks
+        | Instruction::BuildMacro(..)
+        | Instruction::Return
+        | Instruction::RenderParent => 0,
         _ => 1,
     }
 }


### PR DESCRIPTION
Fuel feature fails to compile if `macros` and `multi_template` features are not enabled too.