### PR TITLE
Update documentation in filters.rs

### DIFF
--- a/minijinja-contrib/src/filters.rs
+++ b/minijinja-contrib/src/filters.rs
@@ -18,7 +18,7 @@ use minijinja::{Error, ErrorKind};
 /// ```
 ///
 /// ```jinja
-/// {{ entities|length }} entit{{ users|pluralize("y", "ies") }}.
+/// {{ entities|length }} entit{{ entities|pluralize("y", "ies") }}.
 /// ```
 ///
 /// ```jinja


### PR DESCRIPTION
One of the examples for using the pluralize filter had the wrong variable name.