### PR TITLE
Fix python module configuration with maturin 0.15

### DIFF
--- a/minijinja-py/Cargo.toml
+++ b/minijinja-py/Cargo.toml
@@ -12,6 +12,3 @@ crate-type = ["cdylib"]
 minijinja = { version = "0.32.1", path = "../minijinja", features = ["source", "json", "urlencode", "fuel", "preserve_order", "speedups", "custom_syntax"] }
 once_cell = "1.17.0"
 pyo3 = { version = "0.18.0", features = ["extension-module", "serde", "abi3-py38"] }
-
-[package.metadata.maturin]
-name = "minijinja._lowlevel"

--- a/minijinja-py/pyproject.toml
+++ b/minijinja-py/pyproject.toml
@@ -31,5 +31,6 @@ Repository = "https://github.com/mitsuhiko/minijinja"
 "Donate" = "https://github.com/sponsors/mitsuhiko"
 
 [tool.maturin]
+module-name = "minijinja._lowlevel"
 python-source = "python"
 strip = true


### PR DESCRIPTION
maturin configuration options moved to `pyproject.toml` in 0.15.