### PR TITLE
Support nested assignment tracking

### DIFF
--- a/minijinja/src/expression.rs
+++ b/minijinja/src/expression.rs
@@ -68,12 +68,15 @@ impl<'env, 'source> Expression<'env, 'source> {
     ///
     /// This works the same as
     /// [`Template::undeclared_variables`](crate::Template::undeclared_variables).
-    pub fn undeclared_variables(&self) -> HashSet<&str> {
+    pub fn undeclared_variables(&self, nested: bool) -> HashSet<String> {
         match parse_expr(self.instructions.source(), SyntaxConfig::default()) {
-            Ok(expr) => find_undeclared(&ast::Stmt::EmitExpr(ast::Spanned::new(
-                ast::EmitExpr { expr },
-                Default::default(),
-            ))),
+            Ok(expr) => find_undeclared(
+                &ast::Stmt::EmitExpr(ast::Spanned::new(
+                    ast::EmitExpr { expr },
+                    Default::default(),
+                )),
+                nested,
+            ),
             Err(_) => HashSet::new(),
         }
     }

--- a/minijinja/tests/test_environment.rs
+++ b/minijinja/tests/test_environment.rs
@@ -48,9 +48,20 @@ fn test_expression_lifetimes() {
 #[test]
 fn test_expression_undeclared_variables() {
     let env = Environment::new();
-    let expr = env.compile_expression("[foo, bar]").unwrap();
-    let undeclared = expr.undeclared_variables();
-    assert_eq!(undeclared, ["foo", "bar"].into_iter().collect());
+    let expr = env.compile_expression("[foo, bar.baz]").unwrap();
+    let undeclared = expr.undeclared_variables(false);
+    assert_eq!(
+        undeclared,
+        ["bar", "foo"].into_iter().map(|x| x.to_string()).collect()
+    );
+    let undeclared = expr.undeclared_variables(true);
+    assert_eq!(
+        undeclared,
+        ["foo", "bar.baz"]
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect()
+    );
 }
 
 #[test]

--- a/minijinja/tests/test_templates.rs
+++ b/minijinja/tests/test_templates.rs
@@ -449,9 +449,24 @@ fn test_custom_syntax() {
 #[test]
 fn test_undeclared_variables() {
     let mut env = Environment::new();
-    env.add_template("demo", "{% set x = foo %}{{ x }}{{ bar }}")
-        .unwrap();
+    env.add_template(
+        "demo",
+        "{% set x = foo %}{{ x }}{{ bar.baz }}{{ bar.blub }}",
+    )
+    .unwrap();
     let tmpl = env.get_template("demo").unwrap();
-    let undeclared = tmpl.undeclared_variables();
-    assert_eq!(undeclared, ["foo", "bar"].into_iter().collect());
+    let undeclared = tmpl.undeclared_variables(false);
+    assert_eq!(
+        undeclared,
+        ["foo", "bar"].into_iter().map(|x| x.to_string()).collect()
+    );
+    let undeclared = tmpl.undeclared_variables(true);
+    dbg!(&undeclared);
+    assert_eq!(
+        undeclared,
+        ["foo", "bar.baz", "bar.blub"]
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect()
+    );
 }


### PR DESCRIPTION
Followup to #248 which is a tiny bit more useful as it now supports nested identifier tracking.