### PR TITLE
Kill RenderParent opcode

### DIFF
--- a/minijinja/src/compiler/codegen.rs
+++ b/minijinja/src/compiler/codegen.rs
@@ -48,8 +48,6 @@ pub struct CodeGenerator<'source> {
     filter_local_ids: BTreeMap<&'source str, LocalId>,
     test_local_ids: BTreeMap<&'source str, LocalId>,
     raw_template_bytes: usize,
-    #[cfg(feature = "multi_template")]
-    has_extends: bool,
 }
 
 impl<'source> CodeGenerator<'source> {
@@ -64,8 +62,6 @@ impl<'source> CodeGenerator<'source> {
             filter_local_ids: BTreeMap::new(),
             test_local_ids: BTreeMap::new(),
             raw_template_bytes: 0,
-            #[cfg(feature = "multi_template")]
-            has_extends: false,
         }
     }
 
@@ -237,12 +233,6 @@ impl<'source> CodeGenerator<'source> {
                 for node in &t.children {
                     self.compile_stmt(node);
                 }
-                #[cfg(feature = "multi_template")]
-                {
-                    if self.has_extends {
-                        self.add(Instruction::RenderParent);
-                    }
-                }
             }
             ast::Stmt::EmitExpr(expr) => {
                 self.compile_emit_expr(expr);
@@ -341,7 +331,6 @@ impl<'source> CodeGenerator<'source> {
                 self.set_line_from_span(extends.span());
                 self.compile_expr(&extends.name);
                 self.add_with_span(Instruction::LoadBlocks, extends.span());
-                self.has_extends = true;
             }
             #[cfg(feature = "multi_template")]
             ast::Stmt::Include(include) => {

--- a/minijinja/src/compiler/instructions.rs
+++ b/minijinja/src/compiler/instructions.rs
@@ -203,10 +203,6 @@ pub enum Instruction<'source> {
     #[cfg(feature = "multi_template")]
     LoadBlocks,
 
-    /// Renders the parent template
-    #[cfg(feature = "multi_template")]
-    RenderParent,
-
     /// Includes another template.
     #[cfg(feature = "multi_template")]
     Include(bool),

--- a/minijinja/src/vm/fuel.rs
+++ b/minijinja/src/vm/fuel.rs
@@ -50,10 +50,7 @@ fn fuel_for_instruction(instruction: &Instruction) -> isize {
         #[cfg(feature = "multi_template")]
         Instruction::ExportLocals => 0,
         #[cfg(feature = "macros")]
-        Instruction::LoadBlocks
-        | Instruction::BuildMacro(..)
-        | Instruction::Return
-        | Instruction::RenderParent => 0,
+        Instruction::LoadBlocks | Instruction::BuildMacro(..) | Instruction::Return => 0,
         _ => 1,
     }
 }


### PR DESCRIPTION
The `RenderParent` opcode is in some ways an unnecessary leftover. When looking at how to implement #260 I realized the engine simplifies slightly by not having this opcode.