### PR TITLE
Improve handling of Kwargs

### DIFF
--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -1142,7 +1142,8 @@ mod builtins {
         let mut rv = Vec::with_capacity(value.len().unwrap_or(0));
 
         // attribute mapping
-        let (args, kwargs) = Kwargs::from_args(&args);
+        let (args, kwargs): (&[Value], Kwargs) = crate::value::from_args(&args)?;
+
         if let Some(attr) = ok!(kwargs.get::<Option<Value>>("attribute")) {
             if !args.is_empty() {
                 return Err(Error::from(ErrorKind::TooManyArguments));

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -228,7 +228,7 @@ mod builtins {
     use std::collections::BTreeMap;
 
     use crate::error::ErrorKind;
-    use crate::value::ValueKind;
+    use crate::value::{MapType, ValueRepr};
 
     /// Returns a range.
     ///
@@ -290,12 +290,10 @@ mod builtins {
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
     pub fn dict(value: Value) -> Result<Value, Error> {
-        if value.is_undefined() {
-            Ok(Value::from(BTreeMap::<bool, Value>::new()))
-        } else if value.kind() != ValueKind::Map {
-            Err(Error::from(ErrorKind::InvalidOperation))
-        } else {
-            Ok(value)
+        match value.0 {
+            ValueRepr::Undefined => Ok(Value::from(BTreeMap::<bool, Value>::new())),
+            ValueRepr::Map(map, _) => Ok(Value(ValueRepr::Map(map, MapType::Normal))),
+            _ => Err(Error::from(ErrorKind::InvalidOperation)),
         }
     }
 


### PR DESCRIPTION
This significantly improves the handling of keyword args in the engine.

* `Kwargs::from_args` is removed for just `from_args`
* Fixed `dict()` accidentally returning kwargs instead of a native map
* Added support to allow unpacking to `&[Value]` before `Kwargs`.