### PR TITLE
Improve docs and TemplateModule -> Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ All notable changes to MiniJinja are documented here.
   combination of these APIs makes it possible to call values which was
   previously not possible.  (#272)
 
-- Added `Template::eval_to_module` and `TemplateModule`.  This replaces the
+- Added `Template::eval_to_module` and `Module`.  This replaces the
   functionality of the previous `Template::render_block` which is now available
-  via the `TemplateModule`.  This functionality is closer to how how Jinja2
+  via the `Module`.  This functionality is closer to how how Jinja2
   functions and leaves room for future expansion.  It also adds support for
   accessing globals and macros from a template.  (#271)
 
@@ -58,7 +58,7 @@ All notable changes to MiniJinja are documented here.
     ```
 
 - `Template::render_block` and `Template::render_block_to_write` were
-  replaced with the API of the same name on the `TemplateModule`.
+  replaced with the API of the same name on the `Module`.
 
     Before:
 

--- a/examples/template-module/README.md
+++ b/examples/template-module/README.md
@@ -1,6 +1,6 @@
 # template-module
 
-An example that shows how to use `eval_to_module` and the resulting `TemplateModule`
+An example that shows how to use `eval_to_module` and the resulting `Module`
 object.  Together these APIs can be used to render single blocks, invoke macros,
 access exports of a template and more.
 

--- a/minijinja/src/lib.rs
+++ b/minijinja/src/lib.rs
@@ -224,7 +224,7 @@ pub use self::environment::Environment;
 pub use self::error::{Error, ErrorKind};
 pub use self::expression::Expression;
 pub use self::output::Output;
-pub use self::template::{Template, TemplateModule};
+pub use self::template::{Module, Template};
 pub use self::utils::{AutoEscape, HtmlEscape, UndefinedBehavior};
 
 #[cfg(feature = "custom_syntax")]

--- a/minijinja/src/loader.rs
+++ b/minijinja/src/loader.rs
@@ -63,12 +63,16 @@ impl fmt::Debug for LoadedTemplate {
 }
 
 impl<'source> LoaderStore<'source> {
-    pub fn insert<N, S>(&mut self, name: N, source: S) -> Result<(), Error>
-    where
-        N: Into<Cow<'source, str>>,
-        S: Into<Cow<'source, str>>,
-    {
-        match (source.into(), name.into()) {
+    pub fn insert(&mut self, name: &'source str, source: &'source str) -> Result<(), Error> {
+        self.insert_cow(Cow::Borrowed(name), Cow::Borrowed(source))
+    }
+
+    pub fn insert_cow(
+        &mut self,
+        name: Cow<'source, str>,
+        source: Cow<'source, str>,
+    ) -> Result<(), Error> {
+        match (source, name) {
             (Cow::Borrowed(source), Cow::Borrowed(name)) => {
                 self.owned_templates.remove(name);
                 self.borrowed_templates.insert(

--- a/minijinja/src/template.rs
+++ b/minijinja/src/template.rs
@@ -124,15 +124,15 @@ impl<'env, 'source> Template<'env, 'source> {
         .map_err(|err| wrapper.take_err(err))
     }
 
-    /// Evaluates the template into a [`TemplateModule`].
+    /// Evaluates the template into a [`Module`].
     ///
     /// This evaluates the template, discards the output and stores the final
     /// state in the evaluated module.  From there global variables or blocks
     /// can be accessed.  What this does is quite similar to how the engine
     /// interally works with tempaltes that are extended or imported from.
     ///
-    /// For more information see [`TemplateModule`].
-    pub fn eval_to_module<S: Serialize>(&self, ctx: S) -> Result<TemplateModule<'_, 'env>, Error> {
+    /// For more information see [`Module`].
+    pub fn eval_to_module<S: Serialize>(&self, ctx: S) -> Result<Module<'_, 'env>, Error> {
         let root = Value::from_serializable(&ctx);
         let mut out = Output::null();
         let vm = Vm::new(self.env);
@@ -143,7 +143,7 @@ impl<'env, 'source> Template<'env, 'source> {
             &mut out,
             self.initial_auto_escape,
         ));
-        Ok(TemplateModule { state })
+        Ok(Module { state })
     }
 
     fn _eval(&self, root: Value, out: &mut Output) -> Result<Option<Value>, Error> {
@@ -249,11 +249,11 @@ impl<'env, 'source> Template<'env, 'source> {
 /// state of the execution and provides ways to extract some information from
 /// it.
 #[derive(Debug)]
-pub struct TemplateModule<'template: 'env, 'env> {
+pub struct Module<'template: 'env, 'env> {
     state: State<'template, 'env>,
 }
 
-impl<'template, 'env> TemplateModule<'template, 'env> {
+impl<'template, 'env> Module<'template, 'env> {
     /// Returns the [`State`] of the module.
     pub fn state(&self) -> &State<'template, 'env> {
         &self.state

--- a/minijinja/src/vm/state.rs
+++ b/minijinja/src/vm/state.rs
@@ -23,7 +23,7 @@ use crate::vm::fuel::FuelTracker;
 /// In some testing scenarios or more advanced use cases you might need to get
 /// a [`State`].  The state is managed as part of the template execution but the
 /// initial state can be retrieved via [`Template::new_state`](crate::Template::new_state)
-/// or [`TemplateModule::state`](crate::TemplateModule::state).  The most
+/// or [`Module::state`](crate::Module::state).  The most
 /// common way to get hold of the state however is via functions of filters.
 ///
 /// **Notes on lifetimes:** the state object exposes some of the internal


### PR DESCRIPTION
`TemplateModule` is a bit too inviting of a name. You basically never need to name this type, so having it a less obvious name is probably better here. The type people need to care about is just `Template`.