### PR TITLE
allow indexing into strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to MiniJinja are documented here.
 
+## 1.0.0-alpha.2
+
+- Added support for indexing into strings.  (#149)
+
 ## 1.0.0-alpha.1
 
 - Removed `testutils` feature.  New replacement APIs are directly available

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -898,7 +898,7 @@ impl Value {
                 if let Key::I64(idx) = key {
                     let idx = some!(isize::try_from(idx).ok());
                     let idx = if idx < 0 {
-                        some!(s.len().checked_sub(-idx as usize))
+                        some!(s.chars().count().checked_sub(-idx as usize))
                     } else {
                         idx as usize
                     };

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -894,6 +894,19 @@ impl Value {
                     _ => return None,
                 },
             },
+            ValueRepr::String(ref s, _) => {
+                if let Key::I64(idx) = key {
+                    let idx = some!(isize::try_from(idx).ok());
+                    let idx = if idx < 0 {
+                        some!(s.len().checked_sub(-idx as usize))
+                    } else {
+                        idx as usize
+                    };
+                    return s.chars().nth(idx).map(Value::from);
+                } else {
+                    return None;
+                }
+            }
             _ => return None,
         };
 

--- a/minijinja/tests/inputs/indexing.txt
+++ b/minijinja/tests/inputs/indexing.txt
@@ -1,0 +1,13 @@
+{
+  "hello": "Hällo Wörld",
+  "intrange": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+}
+---
+{{ hello[0] }}
+{{ hello[3] }}
+{{ hello[-1] }}
+{{ hello[999] is undefined }}
+{{ intrange[0] }}
+{{ intrange[3] }}
+{{ intrange[-1] }}
+{{ intrange[999] is undefined }}

--- a/minijinja/tests/inputs/slicing.txt
+++ b/minijinja/tests/inputs/slicing.txt
@@ -1,5 +1,5 @@
 {
-  "hello": "Hello World",
+  "hello": "Hällo Wörld",
   "intrange": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 }
 ---

--- a/minijinja/tests/snapshots/test_templates__vm@indexing.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@indexing.txt.snap
@@ -1,0 +1,27 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{{ hello[0] }}\n{{ hello[3] }}\n{{ hello[-1] }}\n{{ hello[999] is undefined }}\n{{ intrange[0] }}\n{{ intrange[3] }}\n{{ intrange[-1] }}\n{{ intrange[999] is undefined }}"
+info:
+  hello: Hello World
+  intrange:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+input_file: minijinja/tests/inputs/indexing.txt
+---
+H
+l
+d
+true
+0
+3
+9
+true
+

--- a/minijinja/tests/snapshots/test_templates__vm@slicing.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@slicing.txt.snap
@@ -2,7 +2,7 @@
 source: minijinja/tests/test_templates.rs
 description: "{{ hello[:] }}\n{{ hello[1:] }}\n{{ hello[1:-1] }}\n{{ hello[::2] }}\n{{ hello[2:10] }}\n{{ hello[2:10:2] }}\n{{ intrange[:] }}\n{{ intrange[1:] }}\n{{ intrange[1:-1] }}\n{{ intrange[::2] }}\n{{ intrange[2:10] }}\n{{ intrange[2:10:2] }}"
 info:
-  hello: Hello World
+  hello: Hällo Wörld
   intrange:
     - 0
     - 1
@@ -16,11 +16,11 @@ info:
     - 9
 input_file: minijinja/tests/inputs/slicing.txt
 ---
-Hello World
-ello World
-ello Worl
+Hällo Wörld
+ällo Wörld
+ällo Wörl
 HloWrd
-llo Worl
+llo Wörl
 loWr
 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 [1, 2, 3, 4, 5, 6, 7, 8, 9]


### PR DESCRIPTION
In the rattler-build project we came across the issue that we couldn't index into strings. Not sure if this is intentional or not, but this PR attempts to fix it (if it wasn't intentional).

https://github.com/prefix-dev/rattler-build/issues/149

I tested it and it works, but before working further on this I wanted to check if this is desired in minijinja or not.

Also `{{ name | first }}` seems to work fine for strings.