### PR TITLE
Added with/without context syntax support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to MiniJinja are documented here.
 
 ## 1.0.0-alpha.2
 
+- The `include` block now supports `with context` and `without context`
+  modifiers but they are ignored.  This is mostly helpful to render some
+  Jinja2 templates that depend on this functionality.  (#288)
+
 - Added tests `true`, `false`, `filter`, `test` and filters
   `pprint` and `unique`.  (#287)
 

--- a/minijinja/src/compiler/parser.rs
+++ b/minijinja/src/compiler/parser.rs
@@ -906,8 +906,18 @@ impl<'a> Parser<'a> {
     #[cfg(feature = "multi_template")]
     fn parse_include(&mut self) -> Result<ast::Include<'a>, Error> {
         let name = ok!(self.parse_expr());
+
+        // with/without context is without meaning in MiniJinja, but for syntax
+        // compatibility it's supported.
+        if skip_token!(self, Token::Ident("without" | "with")) {
+            expect_token!(self, Token::Ident("context"), "missing keyword");
+        }
+
         let ignore_missing = if skip_token!(self, Token::Ident("ignore")) {
             expect_token!(self, Token::Ident("missing"), "missing keyword");
+            if skip_token!(self, Token::Ident("without" | "with")) {
+                expect_token!(self, Token::Ident("context"), "missing keyword");
+            }
             true
         } else {
             false

--- a/minijinja/tests/parser-inputs/include.txt
+++ b/minijinja/tests/parser-inputs/include.txt
@@ -1,1 +1,6 @@
 {% include "foo.txt" %}
+{% include "foo.txt" with context %}
+{% include "foo.txt" without context %}
+{% include "foo.txt" ignore missing with context %}
+{% include "foo.txt" ignore missing without context %}
+{% include "foo.txt" ignore missing %}

--- a/minijinja/tests/snapshots/test_parser__parser@include.txt.snap
+++ b/minijinja/tests/snapshots/test_parser__parser@include.txt.snap
@@ -1,7 +1,6 @@
 ---
 source: minijinja/tests/test_parser.rs
-description: "{% include \"foo.txt\" %}"
-input_file: minijinja/tests/parser-inputs/include.txt
+description: "{% include \"foo.txt\" %}\n{% include \"foo.txt\" with context %}\n{% include \"foo.txt\" without context %}\n{% include \"foo.txt\" ignore missing with context %}\n{% include \"foo.txt\" ignore missing without context %}\n{% include \"foo.txt\" ignore missing %}"
 ---
 Ok(
     Template {
@@ -12,6 +11,51 @@ Ok(
                 } @ 1:11-1:20,
                 ignore_missing: false,
             } @ 1:3-1:20,
+            EmitRaw {
+                raw: "\n",
+            } @ 1:23-2:0,
+            Include {
+                name: Const {
+                    value: "foo.txt",
+                } @ 2:11-2:20,
+                ignore_missing: false,
+            } @ 2:3-2:33,
+            EmitRaw {
+                raw: "\n",
+            } @ 2:36-3:0,
+            Include {
+                name: Const {
+                    value: "foo.txt",
+                } @ 3:11-3:20,
+                ignore_missing: false,
+            } @ 3:3-3:36,
+            EmitRaw {
+                raw: "\n",
+            } @ 3:39-4:0,
+            Include {
+                name: Const {
+                    value: "foo.txt",
+                } @ 4:11-4:20,
+                ignore_missing: true,
+            } @ 4:3-4:48,
+            EmitRaw {
+                raw: "\n",
+            } @ 4:51-5:0,
+            Include {
+                name: Const {
+                    value: "foo.txt",
+                } @ 5:11-5:20,
+                ignore_missing: true,
+            } @ 5:3-5:51,
+            EmitRaw {
+                raw: "\n",
+            } @ 5:54-6:0,
+            Include {
+                name: Const {
+                    value: "foo.txt",
+                } @ 6:11-6:20,
+                ignore_missing: true,
+            } @ 6:3-6:35,
         ],
-    } @ 0:0-1:23,
+    } @ 0:0-6:38,
 )


### PR DESCRIPTION
This does not do anything, but if a Jinja2 template uses this it will work in MiniJinja now.