### PR TITLE
Implement improved PartialOrd and Ord for Value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to MiniJinja are documented here.
 
+## 1.0.0-alpha.4
+
+- `Value` now implements `Ord`.  This also improves the ability of the engine
+  to sort more complex values in filters.  (#295)
+
 ## 1.0.0-alpha.3
 
 - Removed `char` as a value type.  Characters are nor represented as strings

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -253,7 +253,6 @@ mod builtins {
     use super::*;
 
     use crate::error::ErrorKind;
-    use crate::key::Key;
     use crate::value::{Kwargs, ValueKind, ValueRepr};
     use std::borrow::Cow;
     use std::cmp::Ordering;
@@ -361,11 +360,7 @@ mod builtins {
                 .to_ascii_lowercase()
                 .cmp(&b.to_string().to_ascii_lowercase());
         }
-        match (Key::from_borrowed_value(a), Key::from_borrowed_value(b)) {
-            (Ok(a), Ok(b)) => a.partial_cmp(&b),
-            _ => a.partial_cmp(b),
-        }
-        .unwrap_or(Ordering::Less)
+        a.cmp(b)
     }
 
     /// Dict sorting functionality.
@@ -656,9 +651,7 @@ mod builtins {
         let iter = ok!(state.undefined_behavior().try_iter(value).map_err(|err| {
             Error::new(ErrorKind::InvalidOperation, "cannot convert value to list").with_source(err)
         }));
-        Ok(iter
-            .min_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Less))
-            .unwrap_or(Value::UNDEFINED))
+        Ok(iter.min().unwrap_or(Value::UNDEFINED))
     }
 
     /// Returns the largest item from the list.
@@ -667,9 +660,7 @@ mod builtins {
         let iter = ok!(state.undefined_behavior().try_iter(value).map_err(|err| {
             Error::new(ErrorKind::InvalidOperation, "cannot convert value to list").with_source(err)
         }));
-        Ok(iter
-            .max_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Less))
-            .unwrap_or(Value::UNDEFINED))
+        Ok(iter.max().unwrap_or(Value::UNDEFINED))
     }
 
     /// Returns the sorted version of the given list.

--- a/minijinja/tests/test_value.rs
+++ b/minijinja/tests/test_value.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::fmt;
 use std::sync::Arc;
 
@@ -19,7 +18,7 @@ fn test_sort() {
         Value::from(99i128),
         Value::from(1000f32),
     ];
-    v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+    v.sort();
     insta::assert_debug_snapshot!(&v, @r###"
     [
         false,


### PR DESCRIPTION
Note that `Ord` is lying. It does not implement total ordering but I do not believe that is an issue for how value is implemented. It makes it a lot more convenient to use both in the engine and as a user.

This is in parts in anticipation of experiments for #294 