### PR TITLE
Added `Value::NONE` const

### DIFF
--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -546,6 +546,9 @@ impl Value {
     /// The undefined value
     pub const UNDEFINED: Value = Value(ValueRepr::Undefined);
 
+    /// The none value
+    pub const NONE: Value = Value(ValueRepr::None);
+
     /// Creates a value from something that can be serialized.
     ///
     /// This is the method that MiniJinja will generally use whenever a serializable


### PR DESCRIPTION
`none` and `undefined` have different behavior and sometimes you want a function to return `none`. I could not find a way to construct a `none` other than by adding this `const`.