### PR TITLE
track variables that are actually accessed in a template

### DIFF
--- a/minijinja/Cargo.toml
+++ b/minijinja/Cargo.toml
@@ -26,6 +26,7 @@ debug = []
 loader = ["self_cell", "memo-map"]
 unicode = ["unicode-ident", "unicase"]
 custom_syntax = ["dep:aho-corasick"]
+track_used_variables = []
 
 # Speedups
 key_interning = []

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -130,6 +130,8 @@ impl<'env> Vm<'env> {
                 macros: state.macros.clone(),
                 #[cfg(feature = "fuel")]
                 fuel_tracker: state.fuel_tracker.clone(),
+                #[cfg(feature = "track_used_variables")]
+                used_variables: Default::default(),
             },
             out,
             Stack::from(args),

--- a/minijinja/src/vm/state.rs
+++ b/minijinja/src/vm/state.rs
@@ -139,7 +139,7 @@ impl<'template, 'env> State<'template, 'env> {
 
     /// Retrieve names of all variables that were used during execution
     #[cfg(feature = "track_used_variables")]
-    pub fn tracked_loads(&self) -> HashSet<String> {
+    pub fn used_variables(&self) -> HashSet<String> {
         self.used_variables.borrow().clone()
     }
 


### PR DESCRIPTION
For some mildly esoteric use case we would like to know which variable names are _actually_ accessed in a template / expression. This becomes quite difficult to derive once there is some logic in there (if / else) etc.

In Python I think this can be solved by supplying a subclassed dictionary that tracks loads from the context object. I attempted that in Rust, but since the object is de-serialized into a BTreeMap it didn't use my instrumentation.

I haven't found a better solution then adding a `used_variables` field to the state, but would appreciate any alternative ideas.

