### PR TITLE
Add an args! macro

### DIFF
--- a/examples/call-block-function/src/main.rs
+++ b/examples/call-block-function/src/main.rs
@@ -1,17 +1,14 @@
 use std::iter::FromIterator;
 
 use minijinja::value::{Kwargs, Value};
-use minijinja::{Environment, Error, ErrorKind, State};
+use minijinja::{args, Environment, Error, ErrorKind, State};
 
 fn custom_loop(state: &State, num: i64, kwargs: Kwargs) -> Result<String, Error> {
     let mut rv = String::new();
     let caller = kwargs.get::<Value>("caller")?;
     kwargs.assert_all_used()?;
     for it in 0..num {
-        let rendered = caller.call(
-            state,
-            &[Kwargs::from_iter([("it", Value::from(it + 1))]).into()],
-        )?;
+        let rendered = caller.call(state, args!(it => it + 1))?;
         rv.push_str(rendered.as_str().ok_or_else(|| {
             Error::new(
                 ErrorKind::InvalidOperation,

--- a/examples/eval-to-state/src/main.rs
+++ b/examples/eval-to-state/src/main.rs
@@ -1,5 +1,4 @@
-use minijinja::value::Value;
-use minijinja::{context, Environment};
+use minijinja::{args, context, Environment};
 
 fn main() {
     let mut env = Environment::new();
@@ -19,7 +18,7 @@ fn main() {
     println!("Block 'body': {:?}", state.render_block("body").unwrap());
     println!(
         "Macro 'utility': {:?}",
-        state.call_macro("utility", &[]).unwrap()
+        state.call_macro("utility", args!()).unwrap()
     );
     println!(
         "Variable 'global_variable': {:?}",
@@ -38,7 +37,7 @@ fn main() {
         state
             .lookup("range")
             .unwrap()
-            .call(&state, &[Value::from(5)])
+            .call(&state, args!(5))
             .unwrap()
     );
 }

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -1049,6 +1049,22 @@ impl Value {
     /// ).unwrap();
     /// assert_eq!(rv, Value::from(84));
     /// ```
+    ///
+    /// With the [`args!`](crate::args) macro creating an argument slice is
+    /// simplified:
+    ///
+    /// ```
+    /// # use minijinja::{Environment, args, value::{Value, Kwargs}};
+    /// # let mut env = Environment::new();
+    /// # env.add_template("foo", "").unwrap();
+    /// # let tmpl = env.get_template("foo").unwrap();
+    /// # let state = tmpl.new_state(); let state = &state;
+    /// let func = Value::from_function(|v: i64, kwargs: Kwargs| {
+    ///     v * kwargs.get::<i64>("mult").unwrap_or(1)
+    /// });
+    /// let rv = func.call(state, args!(42, mult => 2)).unwrap();
+    /// assert_eq!(rv, Value::from(84));
+    /// ```
     pub fn call(&self, state: &State, args: &[Value]) -> Result<Value, Error> {
         if let ValueRepr::Dynamic(ref dy) = self.0 {
             dy.call(state, args)

--- a/minijinja/tests/test_macros.rs
+++ b/minijinja/tests/test_macros.rs
@@ -1,7 +1,7 @@
 use similar_asserts::assert_eq;
 
-use minijinja::value::Value;
-use minijinja::{context, render, Environment};
+use minijinja::value::{Kwargs, Value};
+use minijinja::{args, context, render, Environment};
 
 #[test]
 fn test_context() {
@@ -22,4 +22,18 @@ fn test_render() {
 
     let rv = render!("Hello World!");
     assert_eq!(rv, "Hello World!");
+}
+
+#[test]
+fn test_args() {
+    let args = args!(1, 2);
+    assert_eq!(args[0], Value::from(1));
+    assert_eq!(args[1], Value::from(2));
+
+    let args = args!(1, 2, foo => 42, bar => 23);
+    assert_eq!(args[0], Value::from(1));
+    assert_eq!(args[1], Value::from(2));
+    let kwargs = Kwargs::try_from(args[2].clone()).unwrap();
+    assert_eq!(kwargs.get::<i32>("foo").unwrap(), 42);
+    assert_eq!(kwargs.get::<i32>("bar").unwrap(), 23);
 }

--- a/minijinja/tests/test_tests.rs
+++ b/minijinja/tests/test_tests.rs
@@ -1,7 +1,6 @@
 use similar_asserts::assert_eq;
 
-use minijinja::value::Value;
-use minijinja::{Environment, State};
+use minijinja::{args, Environment, State};
 
 #[test]
 fn test_basics() {
@@ -13,7 +12,5 @@ fn test_basics() {
     let mut env = Environment::new();
     env.add_test("test", test);
     let state = env.empty_state();
-    assert!(state
-        .perform_test("test", &[Value::from(23), Value::from(23)][..])
-        .unwrap());
+    assert!(state.perform_test("test", args!(23, 23)).unwrap());
 }

--- a/minijinja/tests/test_value.rs
+++ b/minijinja/tests/test_value.rs
@@ -4,7 +4,7 @@ use insta::assert_snapshot;
 use similar_asserts::assert_eq;
 
 use minijinja::value::{Kwargs, Object, ObjectKind, Rest, SeqObject, StructObject, Value};
-use minijinja::{Environment, Error};
+use minijinja::{args, Environment, Error};
 
 #[test]
 fn test_sort() {
@@ -365,7 +365,7 @@ fn test_filter_basics() {
     env.add_filter("test", test);
     assert_eq!(
         env.empty_state()
-            .apply_filter("test", &[Value::from(23), Value::from(42)])
+            .apply_filter("test", args!(23, 42))
             .unwrap(),
         Value::from(65)
     );
@@ -381,15 +381,7 @@ fn test_rest_args() {
     env.add_filter("sum", sum);
     assert_eq!(
         env.empty_state()
-            .apply_filter(
-                "sum",
-                &[
-                    Value::from(1),
-                    Value::from(2),
-                    Value::from(3),
-                    Value::from(4)
-                ][..]
-            )
+            .apply_filter("sum", args!(1, 2, 3, 4))
             .unwrap(),
         Value::from(1 + 2 + 3 + 4)
     );
@@ -411,27 +403,17 @@ fn test_optional_args() {
     env.add_filter("add", add);
     let state = env.empty_state();
     assert_eq!(
-        state
-            .apply_filter("add", &[Value::from(23), Value::from(42)][..])
-            .unwrap(),
+        state.apply_filter("add", args!(23, 42)).unwrap(),
         Value::from(65)
     );
     assert_eq!(
         state
-            .apply_filter(
-                "add",
-                &[Value::from(23), Value::from(42), Value::UNDEFINED][..]
-            )
+            .apply_filter("add", args!(23, 42, Value::UNDEFINED))
             .unwrap(),
         Value::from(65)
     );
     assert_eq!(
-        state
-            .apply_filter(
-                "add",
-                &[Value::from(23), Value::from(42), Value::from(1)][..]
-            )
-            .unwrap(),
+        state.apply_filter("add", args!(23, 42, 1)).unwrap(),
         Value::from(66)
     );
 }
@@ -452,16 +434,12 @@ fn test_values_in_vec() {
     let state = env.empty_state();
 
     assert_eq!(
-        state
-            .apply_filter("upper", &[Value::from("Hello World!")])
-            .unwrap(),
+        state.apply_filter("upper", args!("Hello World!")).unwrap(),
         Value::from("HELLO WORLD!")
     );
 
     assert_eq!(
-        state
-            .apply_filter("sum", &[Value::from(vec![Value::from(1), Value::from(2)])])
-            .unwrap(),
+        state.apply_filter("sum", args!(vec![1, 2])).unwrap(),
         Value::from(3)
     );
 }
@@ -483,7 +461,7 @@ fn test_seq_object_borrow() {
         state
             .apply_filter(
                 "connect",
-                &[Value::from(vec![Value::from("HELLO"), Value::from(42)])]
+                args!(vec![Value::from("HELLO"), Value::from(42)])
             )
             .unwrap(),
         Value::from("HELLO42")


### PR DESCRIPTION
This adds an `args!` macro to create argument slices. I found it quite annoying particularly when working with keyword arguments to do this manually.