### PR TITLE
Added merge functionality to context! macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to MiniJinja are documented here.
 ## 1.0.5
 
 - Added the ability to merge multiple values with the `context!`
-  macro.
+  macro.  (#317)
 
 ## 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to MiniJinja are documented here.
 
+## 1.0.5
+
+- Added the ability to merge multiple values with the `context!`
+  macro.
+
 ## 1.0.4
 
 - Added the `args!` macro which can be used to create an argument

--- a/examples/merge-context/src/main.rs
+++ b/examples/merge-context/src/main.rs
@@ -1,51 +1,8 @@
-use std::collections::BTreeSet;
-use std::sync::Arc;
-
-use minijinja::value::{StructObject, Value};
 use minijinja::{context, Environment};
-
-/// A struct that looks up from multiple values.
-struct MergeContext(Vec<Value>);
-
-impl StructObject for MergeContext {
-    fn get_field(&self, field: &str) -> Option<Value> {
-        for val in &self.0 {
-            match val.get_attr(field) {
-                Ok(val) if !val.is_undefined() => return Some(val),
-                _ => {}
-            }
-        }
-        None
-    }
-
-    fn fields(&self) -> Vec<Arc<str>> {
-        let mut rv = BTreeSet::new();
-        for val in &self.0 {
-            if let Ok(iter) = val.try_iter() {
-                for item in iter {
-                    if let Some(s) = item.as_str() {
-                        if !rv.contains(s) {
-                            rv.insert(Arc::from(s.to_string()));
-                        }
-                    }
-                }
-            }
-        }
-        rv.into_iter().collect()
-    }
-}
-
-/// Merges one or more contexts.
-pub fn merge_contexts<I>(i: I) -> Value
-where
-    I: Iterator<Item = Value>,
-{
-    Value::from_struct_object(MergeContext(i.into_iter().collect()))
-}
 
 fn main() {
     let env = Environment::new();
-    let ctx = merge_contexts([context! { a => "A" }, context! { b => "B" }].into_iter());
+    let ctx = context! { a => "A", ..context! { b => "B" } };
     println!(
         "{}",
         env.render_str("Two variables: {{ a }} and {{ b }}!", ctx)

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -642,7 +642,7 @@ mod builtins {
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
     pub fn last(value: Value) -> Result<Value, Error> {
         if let Some(s) = value.as_str() {
-            Ok(s.chars().rev().next().map_or(Value::UNDEFINED, Value::from))
+            Ok(s.chars().next_back().map_or(Value::UNDEFINED, Value::from))
         } else if let Some(seq) = value.as_seq() {
             Ok(seq.iter().last().unwrap_or(Value::UNDEFINED))
         } else {

--- a/minijinja/src/value/merge_object.rs
+++ b/minijinja/src/value/merge_object.rs
@@ -1,0 +1,40 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use crate::value::object::StructObject;
+use crate::value::Value;
+
+/// Utility struct used by [`context!`](crate::context) to merge
+/// multiple values.
+pub struct MergeObject(pub Vec<Value>);
+
+impl StructObject for MergeObject {
+    fn get_field(&self, field: &str) -> Option<Value> {
+        for val in &self.0 {
+            match val.get_attr(field) {
+                Ok(val) if !val.is_undefined() => return Some(val),
+                _ => {}
+            }
+        }
+        None
+    }
+
+    fn fields(&self) -> Vec<Arc<str>> {
+        let mut seen = BTreeSet::new();
+        let mut rv = Vec::new();
+        for val in &self.0 {
+            if let Ok(iter) = val.try_iter() {
+                for item in iter {
+                    let s: Result<Arc<str>, _> = item.try_into();
+                    if let Ok(s) = s {
+                        if !seen.contains(&s) {
+                            seen.insert(s.clone());
+                            rv.push(s);
+                        }
+                    }
+                }
+            }
+        }
+        rv
+    }
+}

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -133,6 +133,7 @@ mod argtypes;
 #[cfg(feature = "deserialization")]
 mod deserialize;
 mod keyref;
+pub(crate) mod merge_object;
 mod object;
 pub(crate) mod ops;
 mod serialize;

--- a/minijinja/tests/test_macros.rs
+++ b/minijinja/tests/test_macros.rs
@@ -12,6 +12,20 @@ fn test_context() {
 }
 
 #[test]
+fn test_context_merge() {
+    let one = context!(a => 1);
+    let two = context!(b => 2, a => 42);
+    let ctx = context![..one, ..two];
+    assert_eq!(ctx.get_attr("a").unwrap(), Value::from(1));
+    assert_eq!(ctx.get_attr("b").unwrap(), Value::from(2));
+
+    let two = context!(b => 2, a => 42);
+    let ctx = context!(a => 1, ..two);
+    assert_eq!(ctx.get_attr("a").unwrap(), Value::from(1));
+    assert_eq!(ctx.get_attr("b").unwrap(), Value::from(2));
+}
+
+#[test]
 fn test_render() {
     let env = Environment::new();
     let rv = render!(in env, "Hello {{ name }}!", name => "World");

--- a/minijinja/tests/test_macros.rs
+++ b/minijinja/tests/test_macros.rs
@@ -1,6 +1,6 @@
 use similar_asserts::assert_eq;
 
-use minijinja::value::{Kwargs, Value};
+use minijinja::value::{Kwargs, StructObject, Value};
 use minijinja::{args, context, render, Environment};
 
 #[test]
@@ -22,6 +22,26 @@ fn test_context_merge() {
     let two = context!(b => 2, a => 42);
     let ctx = context!(a => 1, ..two);
     assert_eq!(ctx.get_attr("a").unwrap(), Value::from(1));
+    assert_eq!(ctx.get_attr("b").unwrap(), Value::from(2));
+}
+
+#[test]
+fn test_context_merge_custom() {
+    struct X;
+    impl StructObject for X {
+        fn get_field(&self, name: &str) -> Option<Value> {
+            match name {
+                "a" => Some(Value::from(1)),
+                "b" => Some(Value::from(2)),
+                _ => None,
+            }
+        }
+    }
+
+    let x = Value::from_struct_object(X);
+    let ctx = context! { a => 42, ..x };
+
+    assert_eq!(ctx.get_attr("a").unwrap(), Value::from(42));
     assert_eq!(ctx.get_attr("b").unwrap(), Value::from(2));
 }
 


### PR DESCRIPTION
This adds the ability to merge map values with the `context!` macro.

Fixes #316