### PR TITLE
Prevent macros from panicking when called with wrong state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to MiniJinja are documented here.
 
 ## 1.0.7
 
+- Macros called with the wrong state will no longer panic.  #330
 - Debug output of `Value::UNDEFINED` and `Value::from(())` is now
   `undefined` and `none` rather than `Undefined` and `None`.  This was
   an accidental inconsistency.

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -127,6 +127,8 @@ impl<'env> Vm<'env> {
                 blocks: BTreeMap::default(),
                 loaded_templates: Default::default(),
                 #[cfg(feature = "macros")]
+                id: state.id,
+                #[cfg(feature = "macros")]
                 macros: state.macros.clone(),
                 #[cfg(feature = "fuel")]
                 fuel_tracker: state.fuel_tracker.clone(),
@@ -946,6 +948,7 @@ impl<'env> Vm<'env> {
                 name: Arc::from(name.to_string()),
                 arg_spec,
                 macro_ref_id,
+                state_id: state.id,
                 closure,
                 caller_reference: (flags & MACRO_CALLER) != 0,
             }),

--- a/minijinja/src/vm/state.rs
+++ b/minijinja/src/vm/state.rs
@@ -77,6 +77,7 @@ impl<'template, 'env> State<'template, 'env> {
         blocks: BTreeMap<&'env str, BlockStack<'template, 'env>>,
     ) -> State<'template, 'env> {
         State {
+            #[cfg(feature = "macros")]
             id: STATE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             env,
             ctx,

--- a/minijinja/src/vm/state.rs
+++ b/minijinja/src/vm/state.rs
@@ -13,6 +13,14 @@ use crate::vm::context::Context;
 #[cfg(feature = "fuel")]
 use crate::vm::fuel::FuelTracker;
 
+/// When macros are used, the state carries an `id` counter.  Whenever a state is
+/// created, the counter is incremented.  This exists because macros can keep a reference
+/// to instructions from another state by index.  Without this counter it would
+/// be possible for a macro to be called with a different state (different id)
+/// which mean we likely panic.
+#[cfg(feature = "macros")]
+static STATE_ID: std::sync::atomic::AtomicIsize = std::sync::atomic::AtomicIsize::new(0);
+
 /// Provides access to the current execution state of the engine.
 ///
 /// A read only reference is passed to filter functions and similar objects to
@@ -39,6 +47,8 @@ pub struct State<'template, 'env> {
     pub(crate) blocks: BTreeMap<&'env str, BlockStack<'template, 'env>>,
     #[allow(unused)]
     pub(crate) loaded_templates: BTreeSet<&'env str>,
+    #[cfg(feature = "macros")]
+    pub(crate) id: isize,
     #[cfg(feature = "macros")]
     pub(crate) macros: std::sync::Arc<Vec<(&'template Instructions<'env>, usize)>>,
     #[cfg(feature = "fuel")]
@@ -67,6 +77,7 @@ impl<'template, 'env> State<'template, 'env> {
         blocks: BTreeMap<&'env str, BlockStack<'template, 'env>>,
     ) -> State<'template, 'env> {
         State {
+            id: STATE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             env,
             ctx,
             current_block: None,


### PR DESCRIPTION
This does not make macros callable from other states, but it avoids a panic.

Refs #329 