### PR TITLE
Fix filter doc example

### DIFF
--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -1197,10 +1197,8 @@ mod builtins {
 
     /// Returns a list of unique items from the given iterable.
     ///
-    /// Returns a list of unique items from the given iterable.
-    ///
     /// ```jinja
-    /// {{ ['foo', 'bar', 'foobar', 'FooBar']|unique|list }}
+    /// {{ ['foo', 'bar', 'foobar', 'foobar']|unique|list }}
     ///   -> ['foo', 'bar', 'foobar']
     /// ```
     ///


### PR DESCRIPTION
First of all, thanks a lot for creating and sharing Jinja2 and MiniJinja!

This pull request fixes the doc example of `unique` filter. It also deletes the duplicated line of comment.
I verified that `unique` filter is case sensitive with the following tests.

```
#[test]
fn test_unique_ok() {
    let mut env = Environment::new();
    env.add_template(
        "test.html",
        "{% autoescape 'none' %}{{ ['foo', 'bar', 'foobar', 'foobar']|unique }}{% endautoescape %}",
    )
    .unwrap();
    let tmpl = env.get_template("test.html").unwrap();
    assert_eq!(tmpl.render(()).unwrap(), "[\"foo\", \"bar\", \"foobar\"]");
}

#[test]
fn test_unique_is_case_sensitive() {
    let mut env = Environment::new();
    env.add_template(
        "test.html",
        "{% autoescape 'none' %}{{ ['foo', 'bar', 'foobar', 'FooBar']|unique }}{% endautoescape %}",
    )
    .unwrap();
    let tmpl = env.get_template("test.html").unwrap();
    assert_eq!(
        tmpl.render(()).unwrap(),
        "[\"foo\", \"bar\", \"foobar\", \"FooBar\"]"
    );
}
```