### PR TITLE
Fix error message of abs filter

### DIFF
--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -557,7 +557,7 @@ mod builtins {
             ValueRepr::F64(x) => Ok(Value::from(x.abs())),
             _ => Err(Error::new(
                 ErrorKind::InvalidOperation,
-                "cannot round value",
+                "cannot get absolute value",
             )),
         }
     }


### PR DESCRIPTION
I suppose it was copied from round filter and left as is.
