### PR TITLE
Improve downcast to support SeqObject/StructObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to MiniJinja are documented here.
 
 ## 1.0.8
 
+- Relatex the trait bounds of `Value::downcast_object_ref` /
+  `Object::downcast_ref` / `Object::is` and added support for downcasting
+  of types that were directly created with `Value::from_seq_object`
+  and `Value::from_struct_object`.  #349
 - Fixed a few overflow panics: dividing integers with an overflow and
   related overflows in the `abs` and `neg` filter.  #347
 

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -661,9 +661,6 @@ impl Value {
     ///
     /// This is a simplified API for creating dynamic sequences
     /// without having to implement the entire [`Object`] protocol.
-    ///
-    /// **Note:** objects created this way cannot be downcasted via
-    /// [`downcast_object_ref`](Self::downcast_object_ref).
     pub fn from_seq_object<T: SeqObject + 'static>(value: T) -> Value {
         Value::from_object(SimpleSeqObject(value))
     }
@@ -672,9 +669,6 @@ impl Value {
     ///
     /// This is a simplified API for creating dynamic structs
     /// without having to implement the entire [`Object`] protocol.
-    ///
-    /// **Note:** objects created this way cannot be downcasted via
-    /// [`downcast_object_ref`](Self::downcast_object_ref).
     pub fn from_struct_object<T: StructObject + 'static>(value: T) -> Value {
         Value::from_object(SimpleStructObject(value))
     }
@@ -967,8 +961,9 @@ impl Value {
 
     /// Returns some reference to the boxed object if it is of type `T`, or None if it isn’t.
     ///
-    /// This is basically the "reverse" of [`from_object`](Self::from_object).  It's also
-    /// a shortcut for [`downcast_ref`](trait.Object.html#method.downcast_ref)
+    /// This is basically the "reverse" of [`from_object`](Self::from_object),
+    /// [`from_seq_object`](Self::from_seq_object) and [`from_struct_object`](Self::from_struct_object).
+    /// It's also a shortcut for [`downcast_ref`](trait.Object.html#method.downcast_ref)
     /// on the return value of [`as_object`](Self::as_object).
     ///
     /// # Example
@@ -994,7 +989,30 @@ impl Value {
     /// let thing = x_value.downcast_object_ref::<Thing>().unwrap();
     /// assert_eq!(thing.id, 42);
     /// ```
-    pub fn downcast_object_ref<T: Object>(&self) -> Option<&T> {
+    ///
+    /// It also works with [`SeqObject`] or [`StructObject`]:
+    ///
+    /// ```rust
+    /// # use minijinja::value::{Value, SeqObject};
+    ///
+    /// struct Thing {
+    ///     id: usize,
+    /// }
+    ///
+    /// impl SeqObject for Thing {
+    ///     fn get_item(&self, idx: usize) -> Option<Value> {
+    ///         (idx < 3).then(|| Value::from(idx))
+    ///     }
+    ///     fn item_count(&self) -> usize {
+    ///         3
+    ///     }
+    /// }
+    ///
+    /// let x_value = Value::from_seq_object(Thing { id: 42 });
+    /// let thing = x_value.downcast_object_ref::<Thing>().unwrap();
+    /// assert_eq!(thing.id, 42);
+    /// ```
+    pub fn downcast_object_ref<T: 'static>(&self) -> Option<&T> {
         self.as_object().and_then(|x| x.downcast_ref())
     }
 

--- a/minijinja/tests/test_value.rs
+++ b/minijinja/tests/test_value.rs
@@ -315,6 +315,49 @@ fn test_obj_downcast() {
 }
 
 #[test]
+fn test_seq_object_downcast() {
+    struct Thing {
+        moo: i32,
+    }
+
+    impl SeqObject for Thing {
+        fn get_item(&self, idx: usize) -> Option<Value> {
+            if idx < 3 {
+                Some(Value::from(idx))
+            } else {
+                None
+            }
+        }
+
+        fn item_count(&self) -> usize {
+            3
+        }
+    }
+
+    let obj = Value::from_seq_object(Thing { moo: 42 });
+
+    let seq = obj.downcast_object_ref::<Thing>().unwrap();
+    assert_eq!(seq.moo, 42);
+}
+
+#[test]
+fn test_struct_object_downcast() {
+    struct Thing {
+        moo: i32,
+    }
+
+    impl StructObject for Thing {
+        fn get_field(&self, name: &str) -> Option<Value> {
+            None
+        }
+    }
+
+    let obj = Value::from_struct_object(Thing { moo: 42 });
+    let seq = obj.downcast_object_ref::<Thing>().unwrap();
+    assert_eq!(seq.moo, 42);
+}
+
+#[test]
 fn test_value_cmp() {
     assert_eq!(Value::from(&[1][..]), Value::from(&[1][..]));
     assert_ne!(Value::from(&[1][..]), Value::from(&[2][..]));


### PR DESCRIPTION
This adds support for downcasting objects directly created from `Value::from_seq_object` and `Value::from_struct_object`.