### PR TITLE
Add stacker support for very large recursion

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,10 +99,9 @@ jobs:
           targets: wasm32-wasi
       - name: Install WasmTime
         run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
-          curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v14.0.0/wasmtime-v14.0.0-x86_64-linux.tar.xz
-          tar xvf wasmtime-v14.0.0-x86_64-linux.tar.xz
-          echo `pwd`/wasmtime-v14.0.0-x86_64-linux >> $GITHUB_PATH
+          curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v13.0.0/wasmtime-v13.0.0-x86_64-linux.tar.xz
+          tar xvf wasmtime-v13.0.0-x86_64-linux.tar.xz
+          echo `pwd`/wasmtime-v13.0.0-x86_64-linux >> $GITHUB_PATH
       - name: Test
         run: make wasi-test
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,9 +100,9 @@ jobs:
       - name: Install WasmTime
         run: |
           curl https://wasmtime.dev/install.sh -sSf | bash
-          curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v13.0.0/wasmtime-v13.0.0-x86_64-linux.tar.xz
-          tar xvf wasmtime-v13.0.0-x86_64-linux.tar.xz
-          echo `pwd`/wasmtime-v13.0.0-x86_64-linux >> $GITHUB_PATH
+          curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v14.0.0/wasmtime-v14.0.0-x86_64-linux.tar.xz
+          tar xvf wasmtime-v14.0.0-x86_64-linux.tar.xz
+          echo `pwd`/wasmtime-v14.0.0-x86_64-linux >> $GITHUB_PATH
       - name: Test
         run: make wasi-test
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,8 @@ jobs:
         with:
           toolchain: 1.61.0
           targets: armv5te-unknown-linux-gnueabi
+      - name: Install Cross Deps
+        run: sudo apt-get install -y gcc-arm-linux-gnueabi libc6-dev-armel-cross
       - name: Check
         run: cargo check --all-features -p minijinja --target armv5te-unknown-linux-gnueabi
 
@@ -98,9 +100,9 @@ jobs:
       - name: Install WasmTime
         run: |
           curl https://wasmtime.dev/install.sh -sSf | bash
-          curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v4.0.0/wasmtime-v4.0.0-x86_64-linux.tar.xz
-          tar xvf wasmtime-v4.0.0-x86_64-linux.tar.xz
-          echo `pwd`/wasmtime-v4.0.0-x86_64-linux >> $GITHUB_PATH
+          curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v13.0.0/wasmtime-v13.0.0-x86_64-linux.tar.xz
+          tar xvf wasmtime-v13.0.0-x86_64-linux.tar.xz
+          echo `pwd`/wasmtime-v13.0.0-x86_64-linux >> $GITHUB_PATH
       - name: Test
         run: make wasi-test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to MiniJinja are documented here.
 
+## 1.0.9
+
+- Added a new `stacker` feature which allows raising of the recursion
+  limits.  It enables monitoring of the call stack via [stacker](https://crates.io/crates/stacker)
+  and automatically acquires additional memory when the call stack
+  runs out of space.  #354
+
 ## 1.0.8
 
 - Large integer literals in templates are now correctly handled.  #353

--- a/minijinja/Cargo.toml
+++ b/minijinja/Cargo.toml
@@ -65,6 +65,7 @@ indexmap = { version = "1.9.0", optional = true }
 memo-map = { version = "0.3.1", optional = true }
 unicode-ident = { version = "1.0.5", optional = true }
 unicase = { version = "2.6.0", optional = true }
+stacker = { version = "0.1.15", optional = true }
 
 [dev-dependencies]
 insta = { version = "1.31.0", features = ["glob", "serde"] }

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -21,6 +21,13 @@ type AutoEscapeFunc = dyn Fn(&str) -> AutoEscape + Sync + Send;
 type FormatterFunc = dyn Fn(&mut Output, &State, &Value) -> Result<(), Error> + Sync + Send;
 type PathJoinFunc = dyn for<'s> Fn(&'s str, &'s str) -> Cow<'s, str> + Sync + Send;
 
+/// The maximum recursion in the VM.  Normally each stack frame
+/// adds one to this counter (eg: every time a frame is added).
+/// However in some situations more depth is pushed if the cost
+/// of the stack frame is higher.  Raising this above this limit
+/// requires enabling the `stacker` feature.
+const MAX_RECURSION: usize = 500;
+
 /// An abstraction that holds the engine configuration.
 ///
 /// This object holds the central configuration state for templates.  It is also
@@ -50,6 +57,7 @@ pub struct Environment<'source> {
     debug: bool,
     #[cfg(feature = "fuel")]
     fuel: Option<u64>,
+    recursion_limit: usize,
 }
 
 impl<'source> Default for Environment<'source> {
@@ -90,6 +98,7 @@ impl<'source> Environment<'source> {
             debug: cfg!(debug_assertions),
             #[cfg(feature = "fuel")]
             fuel: None,
+            recursion_limit: MAX_RECURSION,
         }
     }
 
@@ -111,6 +120,7 @@ impl<'source> Environment<'source> {
             debug: cfg!(debug_assertions),
             #[cfg(feature = "fuel")]
             fuel: None,
+            recursion_limit: MAX_RECURSION,
         }
     }
 
@@ -516,6 +526,35 @@ impl<'source> Environment<'source> {
 
     fn _syntax_config(&self) -> &SyntaxConfig {
         &self.templates.syntax_config
+    }
+
+    /// Reconfigures the runtime recursion limit.
+    ///
+    /// This defaults to `500`.  Raising it above that level requires the `stacker`
+    /// feature to be enabled.  Otherwise the limit is silently capped at that safe
+    /// maximum.  Note that the maximum is not necessarily safe if the thread uses
+    /// a lot of stack space already, it's just a value that was validated once to
+    /// provide basic protection.
+    ///
+    /// Every operation that requires recursion in MiniJinja increments an internal
+    /// recursion counter.  The actual cost attributed to that recursion depends on
+    /// the cost of the operation.  If statements and for loops for instance only
+    /// increase the counter by 1, whereas template includes and macros might increase
+    /// it to 10 or more.
+    pub fn set_recursion_limit(&mut self, level: usize) {
+        #[cfg(not(feature = "stacker"))]
+        {
+            self.recursion_limit = level.min(MAX_RECURSION);
+        }
+        #[cfg(feature = "stacker")]
+        {
+            self.recursion_limit = level;
+        }
+    }
+
+    /// Returns the current max recursion limit.
+    pub fn recursion_limit(&self) -> usize {
+        self.recursion_limit
     }
 
     /// Compiles an expression.

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -541,6 +541,10 @@ impl<'source> Environment<'source> {
     /// the cost of the operation.  If statements and for loops for instance only
     /// increase the counter by 1, whereas template includes and macros might increase
     /// it to 10 or more.
+    ///
+    /// **Note on stack growth:** even if the stacker feature is enabled it does not
+    /// mean that in all cases stack can grow to the limits desired.  For instance in
+    /// WASM the maximum limits are additionally enforced by the runtime.
     pub fn set_recursion_limit(&mut self, level: usize) {
         #[cfg(not(feature = "stacker"))]
         {

--- a/minijinja/src/lib.rs
+++ b/minijinja/src/lib.rs
@@ -173,6 +173,9 @@
 //!
 //! Performance and memory related features:
 //!
+//! - `stacker`: enables automatic stack growth which permits much larger levels of recursion
+//!   at runtime.  This does not affect the maximum recursion at parsing time which is always
+//!   limited.
 //! - `speedups`: enables all speedups, in particular it turns on the `v_htmlescape` dependency
 //!   for faster HTML escapling.
 //! - `key_interning`: if this feature is enabled the automatic string interning in

--- a/minijinja/src/template.rs
+++ b/minijinja/src/template.rs
@@ -15,7 +15,7 @@ use crate::error::{attach_basic_debug_info, Error};
 use crate::output::{Output, WriteWrapper};
 use crate::utils::AutoEscape;
 use crate::value::{self, Value};
-use crate::vm::{prepare_blocks, State, Vm};
+use crate::vm::{prepare_blocks, Context, State, Vm};
 
 /// Represents a handle to a template.
 ///
@@ -254,7 +254,7 @@ impl<'env, 'source> Template<'env, 'source> {
     pub fn new_state(&self) -> State<'_, 'env> {
         State::new(
             self.env,
-            Default::default(),
+            Context::new(self.env.recursion_limit()),
             self.initial_auto_escape,
             &self.compiled.instructions,
             prepare_blocks(&self.compiled.blocks),

--- a/minijinja/src/vm/state.rs
+++ b/minijinja/src/vm/state.rs
@@ -97,7 +97,7 @@ impl<'template, 'env> State<'template, 'env> {
     pub(crate) fn new_for_env(env: &'env Environment) -> State<'env, 'env> {
         State::new(
             env,
-            Context::default(),
+            Context::new(env.recursion_limit()),
             AutoEscape::None,
             &crate::compiler::instructions::EMPTY_INSTRUCTIONS,
             BTreeMap::new(),

--- a/scripts/wasmtime-wrapper.sh
+++ b/scripts/wasmtime-wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR/..
-wasmtime run --env INSTA_WORKSPACE_ROOT=/ --mapdir "/::$(pwd)" -- "$@"
+wasmtime run -Wmax-wasm-stack=1048576 --env INSTA_WORKSPACE_ROOT=/ --mapdir "/::$(pwd)" -- "$@"

--- a/scripts/wasmtime-wrapper.sh
+++ b/scripts/wasmtime-wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR/..
-wasmtime run -W max-wasm-stack=1048576 --env INSTA_WORKSPACE_ROOT=/ --mapdir "/::$(pwd)" -- "$@"
+wasmtime run --max-wasm-stack=1048576 --env INSTA_WORKSPACE_ROOT=/ --mapdir "/::$(pwd)" -- "$@"

--- a/scripts/wasmtime-wrapper.sh
+++ b/scripts/wasmtime-wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR/..
-wasmtime run -Wmax-wasm-stack=1048576 --env INSTA_WORKSPACE_ROOT=/ --mapdir "/::$(pwd)" -- "$@"
+wasmtime run -W max-wasm-stack=1048576 --env INSTA_WORKSPACE_ROOT=/ --mapdir "/::$(pwd)" -- "$@"


### PR DESCRIPTION
There are templates out there which require excessive amounts of recursion.  This adds an optional `stacker` feature that allows raising of the max recursion limit to effectively unlimited by automatically growing the stack as needed.  Note that this only raises the runtime limit. The parser still enforces a maximum recursion while parsing.