### PR TITLE
docs: Fix rustdoc::redundant_explicit_links warnings.

### DIFF
--- a/minijinja-stack-ref/src/lib.rs
+++ b/minijinja-stack-ref/src/lib.rs
@@ -13,9 +13,8 @@
 //! This crate provides a solution to this issue by moving lifetime checks to the
 //! runtime for MiniJinja objects.  One first needs to create a [`Scope`] with
 //! the [`scope`] function.  It invokes a callback to which a scope is passed
-//! which in turn then provides functionality to create
-//! [`Value`](minijinja::value::Value)s to those borrowed values such as the
-//! [`object_ref`](crate::Scope::object_ref) method.
+//! which in turn then provides functionality to create [`Value`]s to those
+//! borrowed values such as the [`object_ref`](crate::Scope::object_ref) method.
 //!
 //! # Example
 //!

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -48,9 +48,8 @@
 //! # Accessing State
 //!
 //! In some cases it can be necessary to access the execution [`State`].  Since a borrowed
-//! state implements [`ArgType`](crate::value::ArgType) it's possible to add a
-//! parameter that holds the state.  For instance the following filter appends
-//! the current template name to the string:
+//! state implements [`ArgType`] it's possible to add a parameter that holds the state.
+//! For instance the following filter appends the current template name to the string:
 //!
 //! ```
 //! # use minijinja::Environment;
@@ -105,7 +104,7 @@ pub(crate) struct BoxedFilter(Arc<FilterFunc>);
 /// applied to and up to 4 extra parameters.  The extra parameters can be
 /// marked optional by using `Option<T>`.  The last argument can also use
 /// [`Rest<T>`](crate::value::Rest) to capture the remaining arguments.  All
-/// types are supported for which [`ArgType`](crate::value::ArgType) is implemented.
+/// types are supported for which [`ArgType`] is implemented.
 ///
 /// For a list of built-in filters see [`filters`](crate::filters).
 ///

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -95,7 +95,7 @@ pub(crate) struct BoxedFunction(Arc<FuncFunc>, #[cfg(feature = "debug")] &'stati
 /// The parameters can be marked optional by using `Option<T>`.  The last
 /// argument can also use [`Rest<T>`](crate::value::Rest) to capture the
 /// remaining arguments.  All types are supported for which
-/// [`ArgType`](crate::value::ArgType) is implemented.
+/// [`ArgType`] is implemented.
 ///
 /// For a list of built-in functions see [`functions`](crate::functions).
 ///
@@ -103,8 +103,7 @@ pub(crate) struct BoxedFunction(Arc<FuncFunc>, #[cfg(feature = "debug")] &'stati
 /// functionality of [`add_function`](crate::Environment::add_function)
 /// and [`from_function`](crate::value::Value::from_function).  If you want
 /// to implement a custom callable, you can directly implement
-/// [`Object::call`](crate::value::Object::call) which is what the engine
-/// actually uses internally.
+/// [`Object::call`] which is what the engine actually uses internally.
 ///
 /// # Basic Example
 ///

--- a/minijinja/src/lib.rs
+++ b/minijinja/src/lib.rs
@@ -155,8 +155,8 @@
 //!   - `debug`: if this feature is removed some debug functionality of the engine is
 //!     removed as well.  This mainly affects the quality of error reporting.
 //!   - `deserialization`: when removed this disables deserialization support for
-//!     the [`Value`](crate::value::Value) type, removes the `ViaDeserialize`
-//!     type and the error type no longer implements `serde::de::Error`.
+//!     the [`Value`] type, removes the `ViaDeserialize` type and the error type
+//!     no longer implements `serde::de::Error`.
 //!
 //! There are some additional features that provide extra functionality:
 //!

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -1070,7 +1070,7 @@ impl Value {
     /// have to use [`call_method`](Self::call_method).
     ///
     /// The `args` slice is for the arguments of the function call.  To pass
-    /// keyword arguments use the [`Kwargs`](crate::value::Kwargs) type.
+    /// keyword arguments use the [`Kwargs`] type.
     ///
     /// Usually the state is already available when it's useful to call this method,
     /// but when it's not available you can get a fresh template state straight


### PR DESCRIPTION
These are described at: https://doc.rust-lang.org/rustdoc/lints.html#redundant_explicit_links