### PR TITLE
Ability to provide --no-newline option to skip newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to MiniJinja are documented here.
 - Added `integer` and `float` tests.  #373
 - Fixed an issue that caused the CLI not to run when the `repl` feature
   was disabled.  #374
+- Added `-n` / `--no-newline` option to CLI.  #375
 
 ## 1.0.9
 

--- a/minijinja-cli/src/main.rs
+++ b/minijinja-cli/src/main.rs
@@ -203,6 +203,7 @@ fn make_command() -> Command {
                 .action(ArgAction::Append),
             arg!(--strict "disallow undefined variables in templates"),
             arg!(--"no-include" "Disallow includes and extending"),
+            arg!(--"no-newline" "Do not output a newline"),
             arg!(--env "Pass environment variables as ENV to the template"),
             arg!(-E --expr <EXPR> "Evaluates an expression instead"),
             arg!(--"expr-out" <MODE> "Sets the expression output mode")
@@ -256,6 +257,8 @@ fn execute() -> Result<i32, Error> {
         None
     };
 
+    let no_newline = matches.get_flag("no-newline");
+
     let env = create_env(&matches, cwd, allowed_template, stdin_used);
 
     if let Some(expr) = matches.get_one::<String>("expr") {
@@ -305,7 +308,12 @@ fn execute() -> Result<i32, Error> {
             repl::run(env, ctx)?;
         }
     } else {
-        println!("{}", env.get_template(&template)?.render(ctx)?);
+        let result = env.get_template(&template)?.render(ctx)?;
+        if no_newline {
+            print!("{result}");
+        } else {
+            println!("{result}");
+        }
     }
 
     Ok(0)


### PR DESCRIPTION
At work, I had this requirement where I wanted the output to be produced without any newline. This is similar to how `echo` has the option `-n`.

Also, thanks for creating minijinja among other things. :-)