### PR TITLE
Added Environment::compile_expression_owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to MiniJinja are documented here.
 
+## 1.0.11
+
+- Added `Environment::compile_expression_owned` to allow compiled expressions
+  to be held without requiring a reference.  #383
+
 ## 1.0.10
 
 - Added `int` and `float` filters.  #372

--- a/minijinja/src/loader.rs
+++ b/minijinja/src/loader.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use memo_map::MemoMap;
 use self_cell::self_cell;
 
+use crate::compiler::instructions::Instructions;
 use crate::compiler::lexer::SyntaxConfig;
 use crate::error::{Error, ErrorKind};
 use crate::template::CompiledTemplate;
@@ -51,6 +52,14 @@ self_cell! {
         owner: (Arc<str>, Box<str>),
         #[covariant]
         dependent: CompiledTemplate,
+    }
+}
+
+self_cell! {
+    pub(crate) struct OwnedInstructions {
+        owner: Box<str>,
+        #[covariant]
+        dependent: Instructions,
     }
 }
 

--- a/minijinja/tests/test_environment.rs
+++ b/minijinja/tests/test_environment.rs
@@ -28,6 +28,19 @@ fn test_expression() {
 }
 
 #[test]
+#[cfg(feature = "loader")]
+fn test_expression_owned() {
+    let env = Environment::new();
+    let expr: minijinja::Expression<'_, 'static> = env
+        .compile_expression_owned("foo + bar".to_string())
+        .unwrap();
+    let mut ctx = BTreeMap::new();
+    ctx.insert("foo", 42);
+    ctx.insert("bar", 23);
+    assert_eq!(expr.eval(&ctx).unwrap(), Value::from(65));
+}
+
+#[test]
 fn test_expression_bug() {
     let env = Environment::new();
     assert!(env.compile_expression("42.blahadsf()").is_err());


### PR DESCRIPTION
This allows expressions to be compiled without requiring a held lifetime.