### PR TITLE
urlencode now correctly skips over none/undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to MiniJinja are documented here.
 
+## 1.0.12
+
+- The `urlencode` filter now correctly skips over none and undefined.
+
 ## 1.0.11
 
 - Added `Environment::compile_expression_owned` to allow compiled expressions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to MiniJinja are documented here.
 
 ## 1.0.12
 
-- The `urlencode` filter now correctly skips over none and undefined.
+- The `urlencode` filter now correctly skips over none and undefined.  #394
 
 ## 1.0.11
 

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -1040,11 +1040,14 @@ mod builtins {
 
         if value.kind() == ValueKind::Map {
             let mut rv = String::new();
-            for (idx, k) in ok!(value.try_iter()).enumerate() {
-                if idx > 0 {
+            for k in ok!(value.try_iter()) {
+                let v = ok!(value.get_item(&k));
+                if v.is_none() || v.is_undefined() {
+                    continue;
+                }
+                if !rv.is_empty() {
                     rv.push('&');
                 }
-                let v = ok!(value.get_item(&k));
                 write!(
                     rv,
                     "{}={}",

--- a/minijinja/tests/inputs/filters.txt
+++ b/minijinja/tests/inputs/filters.txt
@@ -73,7 +73,7 @@ json: {{ map|tojson }}
 json-pretty: {{ map|tojson(true) }}
 json-scary-html: {{ scary_html|tojson }}
 urlencode: {{ "hello world/foo-bar_baz.txt"|urlencode }}
-urlencode-kv: {{ dict(a="x y", b=2, c=3)|urlencode }}
+urlencode-kv: {{ dict(a="x y", b=2, c=3, d=None)|urlencode }}
 batch: {{ range(10)|batch(3) }}
 batch-fill: {{ range(10)|batch(3, '-') }}
 slice: {{ range(10)|slice(3) }}


### PR DESCRIPTION
This is a much more useful behavior.