### PR TITLE
Added merging functionality to dict function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to MiniJinja are documented here.
 ## 1.0.12
 
 - The `urlencode` filter now correctly skips over none and undefined.  #394
+- The `dict` function now supports merging in of extra arguments.
 
 ## 1.0.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to MiniJinja are documented here.
 ## 1.0.12
 
 - The `urlencode` filter now correctly skips over none and undefined.  #394
-- The `dict` function now supports merging in of extra arguments.
+- The `dict` function now supports merging in of extra arguments.  #395
 
 ## 1.0.11
 

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -231,10 +231,8 @@ impl Object for BoxedFunction {
 mod builtins {
     use super::*;
 
-    use std::collections::BTreeMap;
-
     use crate::error::ErrorKind;
-    use crate::value::{MapType, Rest, ValueRepr};
+    use crate::value::{MapType, ObjectKind, Rest, ValueMap, ValueRepr};
 
     /// Returns a range.
     ///
@@ -294,13 +292,47 @@ mod builtins {
     ///   API_URL_PREFIX="/api"
     /// )|tojson }};</script>
     /// ```
+    ///
+    /// Additionally this can be used to merge objects by passing extra keyword
+    /// arguments:
+    ///
+    /// ```jinja
+    /// {% set new_dict = dict(old_dict, extra_value=2) %}
+    /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn dict(value: Value) -> Result<Value, Error> {
-        match value.0 {
-            ValueRepr::Undefined => Ok(Value::from(BTreeMap::<bool, Value>::new())),
-            ValueRepr::Map(map, _) => Ok(Value(ValueRepr::Map(map, MapType::Normal))),
-            _ => Err(Error::from(ErrorKind::InvalidOperation)),
+    pub fn dict(value: Option<Value>, update_with: crate::value::Kwargs) -> Result<Value, Error> {
+        let mut rv = match value {
+            None => Arc::new(ValueMap::default()),
+            Some(value) => match value.0 {
+                ValueRepr::Undefined => Arc::new(ValueMap::default()),
+                ValueRepr::Map(map, _) => map,
+                ValueRepr::Dynamic(ref dynamic) => match dynamic.kind() {
+                    ObjectKind::Plain => Arc::new(ValueMap::default()),
+                    ObjectKind::Seq(_) => return Err(Error::from(ErrorKind::InvalidOperation)),
+                    ObjectKind::Struct(s) => {
+                        let mut rv = ValueMap::default();
+                        for field in s.fields() {
+                            if let Some(value) = s.get_field(&field) {
+                                rv.insert(crate::value::KeyRef::Value(Value::from(field)), value);
+                            }
+                        }
+                        Arc::new(rv)
+                    }
+                },
+                _ => return Err(Error::from(ErrorKind::InvalidOperation)),
+            },
+        };
+
+        if !update_with.values.is_empty() {
+            Arc::make_mut(&mut rv).extend(
+                update_with
+                    .values
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone())),
+            );
         }
+
+        Ok(Value(ValueRepr::Map(rv, MapType::Normal)))
     }
 
     /// Outputs the current context or the arguments stringified.

--- a/minijinja/src/value/argtypes.rs
+++ b/minijinja/src/value/argtypes.rs
@@ -737,7 +737,7 @@ impl<'a, T: ArgType<'a, Output = T>> ArgType<'a> for Rest<T> {
 /// ```
 #[derive(Debug, Clone)]
 pub struct Kwargs {
-    values: Arc<ValueMap>,
+    pub(crate) values: Arc<ValueMap>,
     used: RefCell<HashSet<String>>,
 }
 

--- a/minijinja/tests/inputs/dict.txt
+++ b/minijinja/tests/inputs/dict.txt
@@ -1,0 +1,8 @@
+{
+  "d": {"a": 1, "b": 2}
+}
+---
+{{ dict(d) }}
+{{ dict(x=1, y=2) }}
+{{ dict(d, c=3)}}
+{% for _ in [1] %}{{ dict(loop, extra=2) }}{% endfor %}

--- a/minijinja/tests/inputs/dict.txt
+++ b/minijinja/tests/inputs/dict.txt
@@ -5,4 +5,4 @@
 {{ dict(d) }}
 {{ dict(x=1, y=2) }}
 {{ dict(d, c=3)}}
-{% for _ in [1] %}{{ dict(loop, extra=2) }}{% endfor %}
+{% for _ in [1] %}{{ dict(loop, extra=2)|dictsort }}{% endfor %}

--- a/minijinja/tests/snapshots/test_templates__vm@dict.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@dict.txt.snap
@@ -1,6 +1,6 @@
 ---
 source: minijinja/tests/test_templates.rs
-description: "{{ dict(d) }}\n{{ dict(x=1, y=2) }}\n{{ dict(d, c=3)}}\n{% for _ in [1] %}{{ dict(loop, extra=2) }}{% endfor %}"
+description: "{{ dict(d) }}\n{{ dict(x=1, y=2) }}\n{{ dict(d, c=3)}}\n{% for _ in [1] %}{{ dict(loop, extra=2)|dictsort }}{% endfor %}"
 info:
   d:
     a: 1
@@ -10,5 +10,5 @@ input_file: minijinja/tests/inputs/dict.txt
 {"a": 1, "b": 2}
 {"x": 1, "y": 2}
 {"a": 1, "b": 2, "c": 3}
-{"index0": 0, "index": 1, "length": 1, "revindex": 1, "revindex0": 0, "first": true, "last": true, "depth": 1, "depth0": 0, "previtem": undefined, "nextitem": undefined, "extra": 2}
+[["depth", 1], ["depth0", 0], ["extra", 2], ["first", true], ["index", 1], ["index0", 0], ["last", true], ["length", 1], ["nextitem", undefined], ["previtem", undefined], ["revindex", 1], ["revindex0", 0]]
 

--- a/minijinja/tests/snapshots/test_templates__vm@dict.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@dict.txt.snap
@@ -1,0 +1,14 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{{ dict(d) }}\n{{ dict(x=1, y=2) }}\n{{ dict(d, c=3)}}\n{% for _ in [1] %}{{ dict(loop, extra=2) }}{% endfor %}"
+info:
+  d:
+    a: 1
+    b: 2
+input_file: minijinja/tests/inputs/dict.txt
+---
+{"a": 1, "b": 2}
+{"x": 1, "y": 2}
+{"a": 1, "b": 2, "c": 3}
+{"index0": 0, "index": 1, "length": 1, "revindex": 1, "revindex0": 0, "first": true, "last": true, "depth": 1, "depth0": 0, "previtem": undefined, "nextitem": undefined, "extra": 2}
+


### PR DESCRIPTION
This lets the `dict()` call merge in the keyword arguments. It also makes the function work with non native dict objects.