### PR TITLE
Fixed warnings in stack-ref lib.rs

### DIFF
--- a/minijinja-stack-ref/src/lib.rs
+++ b/minijinja-stack-ref/src/lib.rs
@@ -227,7 +227,7 @@ pub fn reborrow<T: ?Sized, R>(obj: &T, f: for<'a> fn(&'a T, &'a Scope) -> R) -> 
             }
         };
 
-        if handle.ptr != obj as *const T {
+        if !std::ptr::eq(handle.ptr, obj as *const T) {
             panic!(
                 "cannot reborrow &{} as it's not held in an active stack handle ({:?} != {:?})",
                 std::any::type_name::<T>(),
@@ -288,7 +288,7 @@ pub fn can_reborrow<T: ?Sized>(obj: &T) -> bool {
             None => return false,
         };
 
-        if handle.ptr != obj as *const T {
+        if !std::ptr::eq(handle.ptr, obj as *const T) {
             return false;
         }
 


### PR DESCRIPTION
This PR fixes a few warnings related to ambiguous pointer comparisons in the `minijinja-stack-ref/src/lib.rs` file.
It applies the suggested fix by the compiler.
All tests have passed.