### PR TITLE
Document the missing support for {% continue %} and {% break %}

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -129,6 +129,15 @@ useful.
 
 `raw` has feature parity with Jinja2.
 
+### `{% continue %}`
+
+`continue` is not supported. You can, however, filter a sequence during
+iteration to skip items.
+
+### `{% break %}`
+
+`break` is not supported.
+
 ## Expressions
 
 Most expressions are supported from Jinja2.  The main difference for expressions


### PR DESCRIPTION
Jinja2 provides the [loop controls](https://jinja.palletsprojects.com/en/3.1.x/extensions/#loop-controls) extension, which adds support for the `{% continue %}` and `{% break %}` tags. However, these are currently not supported in minijinja.