### PR TITLE
Expose a display_debug_info method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to MiniJinja are documented here.
 - `minijinja-cli` now supports an `-o` or `--output` parameter to write
   into a target file.  #405
 
+- Added support for `Error::display_debug_info` which displays just the
+  debug info, same way as alternative display on the error does.  #420
+
 ## 1.0.12
 
 - The `urlencode` filter now correctly skips over none and undefined.  #394

--- a/minijinja-cli/src/main.rs
+++ b/minijinja-cli/src/main.rs
@@ -376,18 +376,16 @@ fn print_instructions(
 }
 
 pub fn print_error(err: &Error) {
+    eprintln!("error: {err}");
     if let Some(err) = err.downcast_ref::<MError>() {
-        eprintln!("template error: {err:#}");
-    } else {
-        eprintln!("error: {err}");
+        eprintln!("{}", err.display_debug_info());
     }
     let mut source_opt = err.source();
     while let Some(source) = source_opt {
         eprintln!();
+        eprintln!("caused by: {source}");
         if let Some(source) = source.downcast_ref::<MError>() {
-            eprintln!("caused by template error: {source:#}");
-        } else {
-            eprintln!("caused by: {source}");
+            eprintln!("{}", source.display_debug_info());
         }
         source_opt = source.source();
     }


### PR DESCRIPTION
Useful utility to quickly render the debug info as the error display does.