### PR TITLE
Remove ExactSizeIterator dependency

### DIFF
--- a/minijinja/src/vm/loop_object.rs
+++ b/minijinja/src/vm/loop_object.rs
@@ -7,7 +7,7 @@ use crate::value::{Object, ObjectKind, StructObject, Value};
 use crate::vm::state::State;
 
 pub(crate) struct Loop {
-    pub len: usize,
+    pub len: Option<usize>,
     pub idx: AtomicUsize,
     pub depth: usize,
     #[cfg(feature = "adjacent_loop_items")]
@@ -92,15 +92,23 @@ impl StructObject for Loop {
         if idx == !0 {
             return Some(Value::UNDEFINED);
         }
-        let len = self.len as u64;
+        let len = self.len.map(|x| x as u64);
         match name {
             "index0" => Some(Value::from(idx)),
             "index" => Some(Value::from(idx + 1)),
-            "length" => Some(Value::from(len)),
-            "revindex" => Some(Value::from(len.saturating_sub(idx))),
-            "revindex0" => Some(Value::from(len.saturating_sub(idx).saturating_sub(1))),
+            "length" => Some(len.map(Value::from).unwrap_or(Value::UNDEFINED)),
+            "revindex" => Some(
+                len.map(|len| Value::from(len.saturating_sub(idx)))
+                    .unwrap_or(Value::UNDEFINED),
+            ),
+            "revindex0" => Some(
+                len.map(|len| Value::from(len.saturating_sub(idx).saturating_sub(1)))
+                    .unwrap_or(Value::UNDEFINED),
+            ),
             "first" => Some(Value::from(idx == 0)),
-            "last" => Some(Value::from(len == 0 || idx == len - 1)),
+            "last" => Some(len.map_or(Value::from(false), |len| {
+                Value::from(len == 0 || idx == len - 1)
+            })),
             "depth" => Some(Value::from(self.depth + 1)),
             "depth0" => Some(Value::from(self.depth)),
             #[cfg(feature = "adjacent_loop_items")]
@@ -132,7 +140,10 @@ impl fmt::Display for Loop {
             f,
             "<loop {}/{}>",
             self.idx.load(Ordering::Relaxed),
-            self.len
+            match self.len {
+                Some(ref len) => len as &dyn fmt::Display,
+                None => &"?" as &dyn fmt::Display,
+            },
         )
     }
 }


### PR DESCRIPTION
This changes the internal iteration code so that `ExactSizeIterator` is no longer necessary. It does not yet remove the bounds however as this would be backwards incompatible.