### PR TITLE
Add --safe-path to restrict template loading from unsafe paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to MiniJinja are documented here.
 - `minijinja-cli` now supports an `-o` or `--output` parameter to write
   into a target file.  #405
 
+- `minijinja-cli` now accepts the `--safe-path` parameter to disallow
+  includes or extends from paths not explicitly allowlisted.  #432
+
 - Added support for `Error::display_debug_info` which displays just the
   debug info, same way as alternative display on the error does.  #420
 

--- a/minijinja-cli/src/cli.rs
+++ b/minijinja-cli/src/cli.rs
@@ -27,6 +27,9 @@ pub(super) fn make_command() -> Command {
             arg!(--strict "disallow undefined variables in templates"),
             arg!(--"no-include" "Disallow includes and extending"),
             arg!(--"no-newline" "Do not output a newline"),
+            arg!(--"safe-path" <PATH>... "Only allow includes from this path. Can be used multiple times.")
+                .conflicts_with("no-include")
+                .value_parser(value_parser!(PathBuf)),
             arg!(--env "Pass environment variables as ENV to the template"),
             arg!(-E --expr <EXPR> "Evaluates an expression instead"),
             arg!(--"expr-out" <MODE> "Sets the expression output mode")


### PR DESCRIPTION
This adds a way to restrict template includes to a given path. Can be supplied multiple times.

Fixes #431