### PR TITLE
Emit UnknownMethod instead of InvalidOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to MiniJinja are documented here.
 
+## 1.0.15
+
+- Fixed an incorrect error case in `call_method`.  Now `UnknownMethod`
+  is returned instead of `InvalidOperation` correctly. #439
+
 ## 1.0.14
 
 - Fixed a bug with broken closure handling when working with nested

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -1176,7 +1176,7 @@ impl Value {
             _ => {}
         }
         Err(Error::new(
-            ErrorKind::InvalidOperation,
+            ErrorKind::UnknownMethod,
             format!("object has no method named {name}"),
         ))
     }


### PR DESCRIPTION
The fallthrough of `call_method` in `Value` incorrectly returned the wrong error.