### PR TITLE
Make clippy and rustc happy for rust 1.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to MiniJinja are documented here.
 
+## 1.0.15
+
+- Resolved a compiler warning for Rust 1.77.  #440
+
 ## 1.0.14
 
 - Fixed a bug with broken closure handling when working with nested

--- a/minijinja-py/src/environment.rs
+++ b/minijinja-py/src/environment.rs
@@ -17,7 +17,7 @@ use crate::typeconv::{
 };
 
 thread_local! {
-    static CURRENT_ENV: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
+    static CURRENT_ENV: AtomicPtr<c_void> = const { AtomicPtr::new(std::ptr::null_mut()) };
 }
 
 macro_rules! syntax_setter {

--- a/minijinja-py/src/error_support.rs
+++ b/minijinja-py/src/error_support.rs
@@ -9,7 +9,7 @@ use pyo3::types::PyTuple;
 static TEMPLATE_ERROR: OnceCell<Py<PyAny>> = OnceCell::new();
 
 thread_local! {
-    static STASHED_ERROR: RefCell<Option<PyErr>> = RefCell::new(None);
+    static STASHED_ERROR: RefCell<Option<PyErr>> = const { RefCell::new(None) };
 }
 
 /// Provides information about a template error from the runtime.

--- a/minijinja-py/src/state.rs
+++ b/minijinja-py/src/state.rs
@@ -8,7 +8,7 @@ use crate::environment::{with_environment, Environment};
 use crate::typeconv::to_python_value;
 
 thread_local! {
-    static CURRENT_STATE: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
+    static CURRENT_STATE: AtomicPtr<c_void> = const { AtomicPtr::new(std::ptr::null_mut()) };
 }
 
 /// A reference to the current state.

--- a/minijinja-stack-ref/src/lib.rs
+++ b/minijinja-stack-ref/src/lib.rs
@@ -139,7 +139,7 @@ static STACK_SCOPE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 thread_local! {
     static STACK_SCOPE_IS_VALID: RefCell<HashSet<u64>> = RefCell::default();
-    static CURRENT_HANDLE: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
+    static CURRENT_HANDLE: AtomicPtr<c_void> = const { AtomicPtr::new(std::ptr::null_mut()) };
 }
 
 /// A handle to an enclosed value.

--- a/minijinja/src/output.rs
+++ b/minijinja/src/output.rs
@@ -1,3 +1,4 @@
+use std::ptr::addr_of_mut;
 use std::{fmt, io};
 
 use crate::error::{Error, ErrorKind};
@@ -124,7 +125,7 @@ impl NullWriter {
     pub fn get_mut() -> &'static mut NullWriter {
         static mut NULL_WRITER: NullWriter = NullWriter;
         // SAFETY: this is safe as the null writer is a ZST
-        unsafe { &mut NULL_WRITER }
+        unsafe { &mut *addr_of_mut!(NULL_WRITER) }
     }
 }
 

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -198,11 +198,11 @@ pub(crate) fn value_map_with_capacity(capacity: usize) -> ValueMap {
 }
 
 thread_local! {
-    static INTERNAL_SERIALIZATION: Cell<bool> = Cell::new(false);
+    static INTERNAL_SERIALIZATION: Cell<bool> = const { Cell::new(false) };
 
     // This should be an AtomicU64 but sadly 32bit targets do not necessarily have
     // AtomicU64 available.
-    static LAST_VALUE_HANDLE: Cell<u32> = Cell::new(0);
+    static LAST_VALUE_HANDLE: Cell<u32> = const { Cell::new(0) };
     static VALUE_HANDLES: RefCell<BTreeMap<u32, Value>> = RefCell::new(BTreeMap::new());
 }
 


### PR DESCRIPTION
Fixes some clippy lints and a warning introduced in 1.77.

Refs https://github.com/rust-lang/rust/issues/114447