### PR TITLE
Add support for unknown_method_callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to MiniJinja are documented here.
 - Fixed an incorrect error case in `call_method`.  Now `UnknownMethod`
   is returned instead of `InvalidOperation` correctly. #439
 
+- Added `Environment::set_unknown_method_callback` which allows a user
+  to intercept method calls on primitives.  The motivation here is that
+  this can be used to implement python like methods to improve the
+  compatibility with Jinja2 Python templates.  #441
+
 ## 1.0.14
 
 - Fixed a bug with broken closure handling when working with nested

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -46,7 +46,8 @@ pub trait Object: fmt::Display + fmt::Debug + Any + Sync + Send {
     /// Called when the engine tries to call a method on the object.
     ///
     /// It's the responsibility of the implementer to ensure that an
-    /// error is generated if an invalid method is invoked.
+    /// error is generated if an invalid method is invoked.  If the method
+    /// is not known an [`ErrorKind::UnknownMethod`] error must be returned.
     ///
     /// To convert the arguments into arguments use the
     /// [`from_args`](crate::value::from_args) function.


### PR DESCRIPTION
This allows a user to implement methods that are otherwise not available on objects:

```rust
use minijinja::value::{ValueKind, from_args};
use minijinja::{Error, ErrorKind};

env.set_unknown_method_callback(|state, value, method, args| {
    if value.kind() == ValueKind::Map && method == "items" {
        let _: () = from_args(args)?;
        state.apply_filter("items", &[value.clone()])
    } else {
        Err(Error::new(
            ErrorKind::UnknownMethod,
            "object has no method named {name}",
        ))
    }
});
```

Fixes #438