### PR TITLE
Refactor lexer and update for better jinja2 compatibility

### DIFF
--- a/minijinja/src/compiler/parser.rs
+++ b/minijinja/src/compiler/parser.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use std::fmt;
 
 use crate::compiler::ast::{self, Spanned};
-use crate::compiler::lexer::{tokenize, SyntaxConfig};
+use crate::compiler::lexer::{SyntaxConfig, Tokenizer, WhitespaceConfig};
 use crate::compiler::tokens::{Span, Token};
 use crate::error::{Error, ErrorKind};
 use crate::value::Value;
@@ -93,19 +93,23 @@ enum SetParseResult<'a> {
 }
 
 struct TokenStream<'a> {
-    iter: Box<dyn Iterator<Item = Result<(Token<'a>, Span), Error>> + 'a>,
+    tokenizer: Tokenizer<'a>,
     current: Option<Result<(Token<'a>, Span), Error>>,
     last_span: Span,
 }
 
 impl<'a> TokenStream<'a> {
     /// Tokenize a template
-    pub fn new(source: &'a str, in_expr: bool, syntax_config: SyntaxConfig) -> TokenStream<'a> {
-        let mut iter =
-            Box::new(tokenize(source, in_expr, syntax_config)) as Box<dyn Iterator<Item = _>>;
-        let current = iter.next();
+    pub fn new(
+        source: &'a str,
+        in_expr: bool,
+        syntax_config: SyntaxConfig,
+        whitespace_config: WhitespaceConfig,
+    ) -> TokenStream<'a> {
+        let mut tokenizer = Tokenizer::new(source, in_expr, syntax_config, whitespace_config);
+        let current = tokenizer.next_token().transpose();
         TokenStream {
-            iter,
+            tokenizer,
             current,
             last_span: Span::default(),
         }
@@ -114,7 +118,7 @@ impl<'a> TokenStream<'a> {
     /// Advance the stream.
     pub fn next(&mut self) -> Result<Option<(Token<'a>, Span)>, Error> {
         let rv = self.current.take();
-        self.current = self.iter.next();
+        self.current = self.tokenizer.next_token().transpose();
         if let Some(Ok((_, span))) = rv {
             self.last_span = span;
         }
@@ -222,9 +226,14 @@ macro_rules! with_recursion_guard {
 }
 
 impl<'a> Parser<'a> {
-    pub fn new(source: &'a str, in_expr: bool, syntax_config: SyntaxConfig) -> Parser<'a> {
+    pub fn new(
+        source: &'a str,
+        in_expr: bool,
+        syntax_config: SyntaxConfig,
+        whitespace_config: WhitespaceConfig,
+    ) -> Parser<'a> {
         Parser {
-            stream: TokenStream::new(source, in_expr, syntax_config),
+            stream: TokenStream::new(source, in_expr, syntax_config, whitespace_config),
             in_macro: false,
             blocks: BTreeSet::new(),
             depth: 0,
@@ -1120,7 +1129,7 @@ impl<'a> Parser<'a> {
 /// Parses a template
 #[cfg(feature = "unstable_machinery")]
 pub fn parse<'source>(source: &'source str, filename: &str) -> Result<ast::Stmt<'source>, Error> {
-    parse_with_syntax(source, filename, Default::default(), false)
+    parse_with_syntax(source, filename, Default::default(), Default::default())
 }
 
 /// Parses a template with a specific syntax
@@ -1128,14 +1137,16 @@ pub fn parse_with_syntax<'source>(
     source: &'source str,
     filename: &str,
     syntax_config: SyntaxConfig,
-    keep_trailing_newline: bool,
+    whitespace_config: WhitespaceConfig,
 ) -> Result<ast::Stmt<'source>, Error> {
     // we want to chop off a single newline at the end.  This means that a template
     // by default does not end in a newline which is a useful property to allow
     // inline templates to work.  If someone wants a trailing newline the expectation
     // is that the user adds it themselves for achieve consistency.
+    //
+    // TODO: move into lexer
     let mut source = source;
-    if !keep_trailing_newline {
+    if !whitespace_config.keep_trailing_newline {
         if source.ends_with('\n') {
             source = &source[..source.len() - 1];
         }
@@ -1144,7 +1155,7 @@ pub fn parse_with_syntax<'source>(
         }
     }
 
-    let mut parser = Parser::new(source, false, syntax_config);
+    let mut parser = Parser::new(source, false, syntax_config, whitespace_config);
     parser.parse().map_err(|mut err| {
         if err.line().is_none() {
             err.set_filename_and_span(filename, parser.stream.last_span())
@@ -1154,8 +1165,12 @@ pub fn parse_with_syntax<'source>(
 }
 
 /// Parses an expression
-pub fn parse_expr(source: &str, syntax_config: SyntaxConfig) -> Result<ast::Expr<'_>, Error> {
-    let mut parser = Parser::new(source, true, syntax_config);
+pub fn parse_expr(
+    source: &str,
+    syntax_config: SyntaxConfig,
+    whitespace_config: WhitespaceConfig,
+) -> Result<ast::Expr<'_>, Error> {
+    let mut parser = Parser::new(source, true, syntax_config, whitespace_config);
     parser
         .parse_expr()
         .and_then(|result| {

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -219,12 +219,50 @@ impl<'source> Environment<'source> {
     /// This setting is used whenever a template is loaded into the environment.
     /// Changing it at a later point only affects future templates loaded.
     pub fn set_keep_trailing_newline(&mut self, yes: bool) {
-        self.templates.template_config.keep_trailing_newline = yes;
+        self.templates
+            .template_config
+            .whitespace_config
+            .keep_trailing_newline = yes;
     }
 
     /// Returns the value of the trailing newline preservation flag.
     pub fn keep_trailing_newline(&self) -> bool {
-        self.templates.template_config.keep_trailing_newline
+        self.templates
+            .template_config
+            .whitespace_config
+            .keep_trailing_newline
+    }
+
+    /// Remove the first newline after a block.
+    ///
+    /// If this is set to `true` then the first newline after a block is removed
+    /// (block, not variable tag!). Defaults to `false`.
+    pub fn set_trim_blocks(&mut self, yes: bool) {
+        self.templates.template_config.whitespace_config.trim_blocks = yes;
+    }
+
+    /// Returns the value of the trim blocks flag.
+    pub fn trim_blocks(&self) -> bool {
+        self.templates.template_config.whitespace_config.trim_blocks
+    }
+
+    /// Remove leading spaces and tabs from the start of a line to a block.
+    ///
+    /// If this is set to `true` then leading spaces and tabs from the start of a line
+    /// to the block tag are removed.
+    pub fn set_lstrip_blocks(&mut self, yes: bool) {
+        self.templates
+            .template_config
+            .whitespace_config
+            .lstrip_blocks = yes;
+    }
+
+    /// Returns the value of the lstrip blocks flag.
+    pub fn lstrip_blocks(&self) -> bool {
+        self.templates
+            .template_config
+            .whitespace_config
+            .lstrip_blocks
     }
 
     /// Removes a template by name.
@@ -627,7 +665,12 @@ impl<'source> Environment<'source> {
 
     fn _compile_expression<'expr>(&self, expr: &'expr str) -> Result<Instructions<'expr>, Error> {
         attach_basic_debug_info(
-            parse_expr(expr, self._syntax_config().clone()).map(|ast| {
+            parse_expr(
+                expr,
+                self._syntax_config().clone(),
+                self.templates.template_config.whitespace_config,
+            )
+            .map(|ast| {
                 let mut gen = CodeGenerator::new("<expression>", expr);
                 gen.compile_expr(&ast);
                 gen.finish().0

--- a/minijinja/src/expression.rs
+++ b/minijinja/src/expression.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use crate::compiler::ast;
 use crate::compiler::instructions::Instructions;
-use crate::compiler::lexer::SyntaxConfig;
+use crate::compiler::lexer::{SyntaxConfig, WhitespaceConfig};
 use crate::compiler::meta::find_undeclared;
 use crate::compiler::parser::parse_expr;
 use crate::environment::Environment;
@@ -97,7 +97,11 @@ impl<'env, 'source> Expression<'env, 'source> {
     /// This works the same as
     /// [`Template::undeclared_variables`](crate::Template::undeclared_variables).
     pub fn undeclared_variables(&self, nested: bool) -> HashSet<String> {
-        match parse_expr(self.instructions().source(), SyntaxConfig::default()) {
+        match parse_expr(
+            self.instructions().source(),
+            SyntaxConfig::default(),
+            WhitespaceConfig::default(),
+        ) {
             Ok(expr) => find_undeclared(
                 &ast::Stmt::EmitExpr(ast::Spanned::new(
                     ast::EmitExpr { expr },

--- a/minijinja/src/lib.rs
+++ b/minijinja/src/lib.rs
@@ -260,7 +260,7 @@ pub mod machinery {
     pub use crate::compiler::ast;
     pub use crate::compiler::codegen::CodeGenerator;
     pub use crate::compiler::instructions::{Instruction, Instructions};
-    pub use crate::compiler::lexer::{tokenize, SyntaxConfig};
+    pub use crate::compiler::lexer::{SyntaxConfig, Tokenizer, WhitespaceConfig};
     pub use crate::compiler::parser::{parse, parse_with_syntax};
     pub use crate::compiler::tokens::{Span, Token};
     pub use crate::template::{CompiledTemplate, TemplateConfig};

--- a/minijinja/tests/test_lexer.rs
+++ b/minijinja/tests/test_lexer.rs
@@ -1,27 +1,73 @@
 #![cfg(feature = "unstable_machinery")]
-use minijinja::machinery::tokenize;
+use minijinja::machinery::{Span, SyntaxConfig, Token, Tokenizer, WhitespaceConfig};
+use minijinja::Error;
 
 use std::fmt::Write;
+
+pub fn tokenize(
+    input: &str,
+    syntax_config: SyntaxConfig,
+    whitespace_config: WhitespaceConfig,
+) -> Result<Vec<(Token<'_>, Span)>, Error> {
+    let mut tokenizer = Tokenizer::new(input, false, syntax_config, whitespace_config);
+    std::iter::from_fn(move || tokenizer.next_token().transpose()).collect()
+}
+
+fn stringify_tokens(tokens: Vec<(Token<'_>, Span)>, contents: &str) -> String {
+    let mut stringified = String::new();
+    for (token, span) in tokens {
+        let token_source = contents
+            .get(span.start_offset as usize..span.end_offset as usize)
+            .unwrap();
+        writeln!(stringified, "{token:?}").unwrap();
+        writeln!(stringified, "  {token_source:?}").unwrap();
+    }
+    stringified
+}
 
 #[test]
 fn test_lexer() {
     insta::glob!("lexer-inputs/*.txt", |path| {
         let contents = std::fs::read_to_string(path).unwrap();
-
-        let tokens: Result<Vec<_>, _> = tokenize(&contents, false, Default::default()).collect();
+        let tokens = tokenize(&contents, Default::default(), Default::default());
         insta::with_settings!({
             description => contents.trim_end(),
             omit_expression => true
         }, {
-            let mut stringified = String::new();
-            for (token, span) in tokens.unwrap() {
-                let token_source = contents
-                    .get(span.start_offset as usize..span.end_offset as usize)
-                    .unwrap();
-                writeln!(stringified, "{token:?}").unwrap();
-                writeln!(stringified, "  {token_source:?}").unwrap();
-            }
+            let stringified = stringify_tokens(tokens.unwrap(), &contents);
             insta::assert_snapshot!(&stringified);
         });
     });
+}
+
+#[test]
+fn test_trim_blocks() {
+    let input = "{% block foo %}\nbar{% endblock %}";
+    let tokens = tokenize(
+        input,
+        Default::default(),
+        WhitespaceConfig {
+            trim_blocks: true,
+            ..Default::default()
+        },
+    );
+    let stringified = stringify_tokens(tokens.unwrap(), input);
+    insta::assert_snapshot!(&stringified, @r###"
+    BlockStart
+      "{%"
+    Ident("block")
+      "block"
+    Ident("foo")
+      "foo"
+    BlockEnd
+      "%}"
+    TemplateData("bar")
+      "bar"
+    BlockStart
+      "{%"
+    Ident("endblock")
+      "endblock"
+    BlockEnd
+      "%}"
+    "###);
 }


### PR DESCRIPTION
This is a larger update to the lexer to bring it more in line with Jinja2. When this is done the goal is to have compatibility with `trim_blocks` and `lstrip_blocks`.

Refs #446 