### PR TITLE
New iterator interface

### DIFF
--- a/examples/dynamic-objects/src/main.rs
+++ b/examples/dynamic-objects/src/main.rs
@@ -80,8 +80,7 @@ fn main() {
     env.add_function("cycler", make_cycler);
     env.add_global("magic", Value::from_object(Magic));
     env.add_global("seq", Value::from_object(SimpleDynamicSeq));
-    // TODO: add this back
-    //env.add_global("real_iter", Value::from_iterator((0..10).chain(20..30)));
+    env.add_global("real_iter", Value::from_iterator((0..10).chain(20..30)));
     env.add_template("template.html", include_str!("template.html"))
         .unwrap();
 

--- a/examples/self-referential-context/src/main.rs
+++ b/examples/self-referential-context/src/main.rs
@@ -22,7 +22,7 @@ impl Object for SelfReferentialContext {
                 return Enumeration::Values(keys.collect());
             }
         }
-        Enumeration::Empty
+        Enumeration::Sized(0)
     }
 }
 

--- a/examples/undefined-tracking/src/main.rs
+++ b/examples/undefined-tracking/src/main.rs
@@ -39,7 +39,7 @@ impl Object for TrackedContext {
                 return Enumeration::Values(keys.collect());
             }
         }
-        Enumeration::Empty
+        Enumeration::Sized(0)
     }
 }
 

--- a/examples/value-tracking/src/main.rs
+++ b/examples/value-tracking/src/main.rs
@@ -32,7 +32,7 @@ impl Object for TrackedContext {
                 return Enumeration::Values(keys.collect());
             }
         }
-        Enumeration::Empty
+        Enumeration::Sized(0)
     }
 }
 

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -101,7 +101,7 @@ use std::sync::Arc;
 
 use crate::error::Error;
 use crate::utils::SealedMarker;
-use crate::value::{ArgType, FunctionArgs, FunctionResult, Object, Value};
+use crate::value::{ArgType, Enumeration, FunctionArgs, FunctionResult, Object, ObjectRepr, Value};
 use crate::vm::State;
 
 type FuncFunc = dyn Fn(&State, &[Value]) -> Result<Value, Error> + Sync + Send + 'static;
@@ -248,12 +248,16 @@ impl fmt::Debug for BoxedFunction {
 }
 
 impl Object for BoxedFunction {
-    fn call(self: &Arc<Self>, state: &State, args: &[Value]) -> Result<Value, Error> {
-        self.invoke(state, args)
+    fn repr(self: &Arc<Self>) -> ObjectRepr {
+        ObjectRepr::Plain
     }
 
-    fn render(self: &Arc<Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
+    fn enumeration(self: &Arc<Self>) -> Enumeration {
+        Enumeration::NonEnumerable
+    }
+
+    fn call(self: &Arc<Self>, state: &State, args: &[Value]) -> Result<Value, Error> {
+        self.invoke(state, args)
     }
 }
 

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -99,7 +99,7 @@ env.add_function("is_adult", is_adult);
 use std::fmt;
 use std::sync::Arc;
 
-use crate::error::{Error, ErrorKind};
+use crate::error::Error;
 use crate::utils::SealedMarker;
 use crate::value::{ArgType, FunctionArgs, FunctionResult, Object, Value};
 use crate::vm::State;
@@ -261,6 +261,7 @@ impl Object for BoxedFunction {
 mod builtins {
     use super::*;
 
+    use crate::error::ErrorKind;
     use crate::value::{ObjectRepr, Rest, ValueMap, ValueRepr};
 
     /// Returns a range.

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -5,7 +5,7 @@ use std::iter::{once, repeat};
 use std::str::Chars;
 
 use crate::error::{Error, ErrorKind};
-use crate::value::{OwnedValueIterator, StringType, Value, ValueKind, ValueRepr};
+use crate::value::{StringType, Value, ValueIter, ValueKind, ValueRepr};
 use crate::Output;
 
 /// internal marker to seal up some trait methods
@@ -161,9 +161,8 @@ impl UndefinedBehavior {
     /// If the value is undefined, then iteration fails if the behavior is set to strict,
     /// otherwise it succeeds with an empty iteration.  This is also internally used in the
     /// engine to convert values to lists.
-    pub(crate) fn try_iter(self, value: Value) -> Result<OwnedValueIterator, Error> {
-        self.assert_iterable(&value)
-            .and_then(|_| value.try_iter_owned())
+    pub(crate) fn try_iter(self, value: Value) -> Result<ValueIter, Error> {
+        self.assert_iterable(&value).and_then(|_| value.try_iter())
     }
 
     /// Are we strict on iteration?

--- a/minijinja/src/value/deserialize.rs
+++ b/minijinja/src/value/deserialize.rs
@@ -181,12 +181,14 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer {
             ValueRepr::Bytes(ref v) => visitor.visit_bytes(v),
             ValueRepr::Object(o) => match o.repr() {
                 ObjectRepr::Plain => Err(de::Error::custom("cannot deserialize plain objects")),
-                ObjectRepr::Seq => visitor.visit_seq(de::value::SeqDeserializer::new(
-                    o.try_iter()
-                        .into_iter()
-                        .flatten()
-                        .map(ValueDeserializer::new),
-                )),
+                ObjectRepr::Seq | ObjectRepr::Iterator => {
+                    visitor.visit_seq(de::value::SeqDeserializer::new(
+                        o.try_iter()
+                            .into_iter()
+                            .flatten()
+                            .map(ValueDeserializer::new),
+                    ))
+                }
                 ObjectRepr::Map => visitor.visit_map(de::value::MapDeserializer::new(
                     o.try_iter_pairs()
                         .into_iter()

--- a/minijinja/src/value/deserialize.rs
+++ b/minijinja/src/value/deserialize.rs
@@ -180,6 +180,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer {
             ValueRepr::Undefined | ValueRepr::None => visitor.visit_unit(),
             ValueRepr::Bytes(ref v) => visitor.visit_bytes(v),
             ValueRepr::Object(o) => match o.repr() {
+                ObjectRepr::Plain => Err(de::Error::custom("cannot deserialize plain objects")),
                 ObjectRepr::Seq => visitor.visit_seq(de::value::SeqDeserializer::new(
                     o.try_iter()
                         .into_iter()

--- a/minijinja/src/value/ops.rs
+++ b/minijinja/src/value/ops.rs
@@ -275,7 +275,9 @@ pub fn contains(container: &Value, value: &Value) -> Result<Value, Error> {
         match obj.repr() {
             ObjectRepr::Plain => false,
             ObjectRepr::Map => obj.get_value(value).is_some(),
-            ObjectRepr::Seq => obj.try_iter().into_iter().flatten().any(|v| &v == value),
+            ObjectRepr::Seq | ObjectRepr::Iterator => {
+                obj.try_iter().into_iter().flatten().any(|v| &v == value)
+            }
         }
     } else {
         return Err(Error::new(

--- a/minijinja/src/value/ops.rs
+++ b/minijinja/src/value/ops.rs
@@ -116,16 +116,14 @@ pub fn slice(value: Value, start: Value, stop: Value, step: Value) -> Result<Val
         ValueRepr::Object(obj) if obj.repr() == ObjectRepr::Seq => {
             let len = obj.enumeration().len().unwrap_or_default();
             let (start, len) = get_offset_and_len(start, stop, || len);
-            Ok(Value::from_object_iter(obj.clone(), move |this| {
-                Box::new(
-                    this.try_iter()
-                        .into_iter()
-                        .flatten()
-                        .skip(start)
-                        .take(len)
-                        .step_by(step),
-                )
-            }))
+            Ok(Value::from_iter(
+                obj.try_iter()
+                    .into_iter()
+                    .flatten()
+                    .skip(start)
+                    .take(len)
+                    .step_by(step),
+            ))
         }
         _ => error,
     }

--- a/minijinja/src/value/ops.rs
+++ b/minijinja/src/value/ops.rs
@@ -273,6 +273,7 @@ pub fn contains(container: &Value, value: &Value) -> Result<Value, Error> {
         }
     } else if let ValueRepr::Object(ref obj) = container.0 {
         match obj.repr() {
+            ObjectRepr::Plain => false,
             ObjectRepr::Map => obj.get_value(value).is_some(),
             ObjectRepr::Seq => obj.try_iter().into_iter().flatten().any(|v| &v == value),
         }

--- a/minijinja/src/vm/context.rs
+++ b/minijinja/src/vm/context.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use crate::environment::Environment;
 use crate::error::{Error, ErrorKind};
-use crate::value::{OwnedValueIterator, Value, ValueRepr};
+use crate::value::{Value, ValueIter, ValueRepr};
 use crate::vm::loop_object::Loop;
 
 #[cfg(feature = "macros")]
@@ -20,7 +20,7 @@ pub(crate) struct LoopState {
     // first item is the target jump instruction, the second argument
     // tells us if we need to end capturing.
     pub(crate) current_recursion_jump: Option<(usize, bool)>,
-    pub(crate) iterator: OwnedValueIterator,
+    pub(crate) iterator: ValueIter,
     pub(crate) object: Arc<Loop>,
 }
 

--- a/minijinja/src/vm/context.rs
+++ b/minijinja/src/vm/context.rs
@@ -108,6 +108,11 @@ impl Stack {
         self.values.pop().unwrap()
     }
 
+    pub fn reverse_top(&mut self, n: usize) {
+        let start = self.values.len() - n;
+        self.values[start..].reverse();
+    }
+
     pub fn slice_top(&mut self, n: usize) -> &[Value] {
         &self.values[self.values.len() - n..]
     }

--- a/minijinja/src/vm/macro_object.rs
+++ b/minijinja/src/vm/macro_object.rs
@@ -36,9 +36,9 @@ impl Object for Macro {
     fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
         match key.as_str()? {
             "name" => Some(Value::from(self.name.clone())),
-            "arguments" => Some(Value::from_object_iter(self.clone(), |this| {
-                Box::new(this.arg_spec.iter().cloned().map(Value::from))
-            })),
+            "arguments" => Some(Value::from_iter(
+                self.arg_spec.iter().cloned().map(Value::from),
+            )),
             "caller" => Some(Value::from(self.caller_reference)),
             _ => None,
         }

--- a/minijinja/tests/snapshots/test_templates__vm@loop_bad_unpacking.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@loop_bad_unpacking.txt.snap
@@ -12,12 +12,12 @@ input_file: minijinja/tests/inputs/loop_bad_unpacking.txt
 
 Error {
     kind: CannotUnpack,
-    detail: "not a sequence",
+    detail: "value is not iterable",
     name: "loop_bad_unpacking.txt",
     line: 2,
 }
 
-cannot unpack: not a sequence (in loop_bad_unpacking.txt:2)
+cannot unpack: value is not iterable (in loop_bad_unpacking.txt:2)
 --------------------------- loop_bad_unpacking.txt ----------------------------
    1 | <ul>
    2 > {% for a, b in seq %}
@@ -47,4 +47,3 @@ Referenced variables: {
     ],
 }
 -------------------------------------------------------------------------------
-

--- a/minijinja/tests/test_environment.rs
+++ b/minijinja/tests/test_environment.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use insta::assert_snapshot;
 use similar_asserts::assert_eq;
 
-use minijinja::value::{from_args, Value, ValueKind};
-use minijinja::{Environment, Error, ErrorKind};
+use minijinja::Environment;
+use minijinja::Value;
 
 #[test]
 fn test_basic() {
@@ -152,7 +152,11 @@ fn test_keep_trailing_newlines() {
 }
 
 #[test]
+#[cfg(feature = "builtins")]
 fn test_unknown_method_callback() {
+    use minijinja::value::{from_args, ValueKind};
+    use minijinja::{Error, ErrorKind};
+
     let mut env = Environment::new();
     env.set_unknown_method_callback(|_state, value, method, args| {
         if value.kind() == ValueKind::Map && method == "items" {

--- a/minijinja/tests/test_value.rs
+++ b/minijinja/tests/test_value.rs
@@ -456,7 +456,7 @@ fn test_values_in_vec() {
 fn test_seq_object_borrow() {
     fn connect(values: DynObject) -> String {
         let mut rv = String::new();
-        for item in values.values() {
+        for item in values.try_iter().into_iter().flatten() {
             rv.push_str(&item.to_string())
         }
         rv

--- a/minijinja/tests/test_value.rs
+++ b/minijinja/tests/test_value.rs
@@ -517,7 +517,6 @@ fn test_complex_key() {
         (Value::from_iter([0u32, 0u32]), "origin"),
         (Value::from_iter([0u32, 1u32]), "right"),
     ]);
-
     assert_eq!(
         value.get_item(&Value::from_iter([0, 0])).ok(),
         Some(Value::from("origin"))

--- a/minijinja/tests/test_value.rs
+++ b/minijinja/tests/test_value.rs
@@ -4,7 +4,7 @@ use insta::assert_snapshot;
 use similar_asserts::assert_eq;
 
 use minijinja::value::{DynObject, Enumeration, Kwargs, Object, ObjectRepr, Rest, Value};
-use minijinja::{args, Environment, Error};
+use minijinja::{args, render, Environment, Error};
 
 #[test]
 fn test_sort() {
@@ -476,40 +476,40 @@ fn test_seq_object_borrow() {
     );
 }
 
-// #[test]
-// fn test_iterator() {
-//     let value = Value::from_iterator(0..10);
-//     assert_eq!(value.to_string(), "<iterator>");
-//     let rv = render!(
-//         "{% for item in iter %}[{{ item }}]{% endfor %}",
-//         iter => value
-//     );
-//     assert_snapshot!(rv, @"[0][1][2][3][4][5][6][7][8][9]");
-//
-//     let rv = render!(
-//         "{% for item in iter %}- {{ item }}: {{ loop.index }} / {{ loop.length }}\n{% endfor %}",
-//         iter => Value::from_iterator('a'..'f')
-//     );
-//     assert_snapshot!(rv, @r###"
-//     - a: 1 / 5
-//     - b: 2 / 5
-//     - c: 3 / 5
-//     - d: 4 / 5
-//     - e: 5 / 5
-//     "###);
-//
-//     let rv = render!(
-//         "{% for item in iter %}- {{ item }}: {{ loop.index }} / {{ loop.length|default('?') }}\n{% endfor %}",
-//      iter => Value::from_iterator((0..10).filter(|x| x % 2 == 0))
-//     );
-//     assert_snapshot!(rv, @r###"
-//     - 0: 1 / ?
-//     - 2: 2 / ?
-//     - 4: 3 / ?
-//     - 6: 4 / ?
-//     - 8: 5 / ?
-//     "###);
-// }
+#[test]
+fn test_iterator() {
+    let value = Value::from_iterator(0..10);
+    assert_eq!(value.to_string(), "<iterator>");
+    let rv = render!(
+        "{% for item in iter %}[{{ item }}]{% endfor %}",
+        iter => value
+    );
+    assert_snapshot!(rv, @"[0][1][2][3][4][5][6][7][8][9]");
+
+    let rv = render!(
+        "{% for item in iter %}- {{ item }}: {{ loop.index }} / {{ loop.length }}\n{% endfor %}",
+        iter => Value::from_iterator('a'..'f')
+    );
+    assert_snapshot!(rv, @r###"
+    - a: 1 / 5
+    - b: 2 / 5
+    - c: 3 / 5
+    - d: 4 / 5
+    - e: 5 / 5
+    "###);
+
+    let rv = render!(
+        "{% for item in iter %}- {{ item }}: {{ loop.index }} / {{ loop.length|default('?') }}\n{% endfor %}",
+     iter => Value::from_iterator((0..10).filter(|x| x % 2 == 0))
+    );
+    assert_snapshot!(rv, @r###"
+    - 0: 1 / ?
+    - 2: 2 / ?
+    - 4: 3 / ?
+    - 6: 4 / ?
+    - 8: 5 / ?
+    "###);
+}
 
 #[test]
 fn test_complex_key() {


### PR DESCRIPTION
This is a work in progress PR for the changes mentioned in #456.

It changes the object protocol so that custom iterators are possible. There is still a lot of duplication and some of the code paths are pretty gnarly. In particular I think it might be better to try to implement `Object::from_iterator` again (#457) with some proper tests to ensure that all code paths behave as intended.

TODO:

* [x] Replace `Value::try_iter` with the internal `Value::try_iter_owned` in the public interface
* [x] Implement `Value::from_iterator`
* [x] Validate the behavior of `custom_iter` for both `try_iter` and `try_iter_pairs` for custom sequences
* [x] Validate the behavior of `custom_iter` for both `try_iter` and `try_iter_pairs` for custom maps
* [x] Fix temporary allocation in `unpack_list` for reversing

Follow up for later:

* This changes the system to buffer for `|reverse` which seems suboptional
* Is there a way to get rid of the `Box<dyn Iterator>` for a concrete type?

Fixes #453
Fixes #455
Fixes #456
Fixes #454
Fixes #459