### PR TITLE
Implement enumerators

### DIFF
--- a/examples/dynamic-context/src/main.rs
+++ b/examples/dynamic-context/src/main.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::env;
 use std::sync::Arc;
 
-use minijinja::value::{Enumeration, Object, Value};
+use minijinja::value::{Enumerator, Object, Value};
 use minijinja::Environment;
 
 #[derive(Debug)]
@@ -25,8 +25,8 @@ impl Object for DynamicContext {
     /// This implementation is not needed for the example.  However
     /// returning known keys here has the benefit that `{{ debug() }}`
     /// can show the context.
-    fn enumeration(self: &Arc<Self>) -> Enumeration {
-        Enumeration::Static(&["pid", "cwd", "env"])
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
+        Enumerator::Str(&["pid", "cwd", "env"])
     }
 }
 

--- a/examples/dynamic-objects/src/main.rs
+++ b/examples/dynamic-objects/src/main.rs
@@ -71,7 +71,7 @@ impl Object for SimpleDynamicSeq {
     }
 
     fn enumerate(self: &Arc<Self>) -> Enumerator {
-        Enumerator::Sequential(4)
+        Enumerator::Seq(4)
     }
 }
 

--- a/examples/dynamic-objects/src/main.rs
+++ b/examples/dynamic-objects/src/main.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use minijinja::value::{from_args, Enumeration, Object, ObjectRepr, Value};
+use minijinja::value::{from_args, Enumerator, Object, ObjectRepr, Value};
 use minijinja::{Environment, Error, State};
 
 #[derive(Debug)]
@@ -70,8 +70,8 @@ impl Object for SimpleDynamicSeq {
         ['a', 'b', 'c', 'd'].get(idx).copied().map(Value::from)
     }
 
-    fn enumeration(self: &Arc<Self>) -> Enumeration {
-        Enumeration::Sized(4)
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
+        Enumerator::Sequential(4)
     }
 }
 

--- a/examples/self-referential-context/src/main.rs
+++ b/examples/self-referential-context/src/main.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use minijinja::value::{Enumeration, Object, Value, ValueKind};
+use minijinja::value::{Enumerator, Object, Value, ValueKind};
 use minijinja::{context, Environment};
 
 #[derive(Debug)]
@@ -16,13 +16,13 @@ impl Object for SelfReferentialContext {
         self.ctx.get_item(name).ok().filter(|x| !x.is_undefined())
     }
 
-    fn enumeration(self: &Arc<Self>) -> Enumeration {
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
         if self.ctx.kind() == ValueKind::Map {
             if let Ok(keys) = self.ctx.try_iter() {
-                return Enumeration::Values(keys.collect());
+                return Enumerator::Values(keys.collect());
             }
         }
-        Enumeration::Sized(0)
+        Enumerator::Sequential(0)
     }
 }
 

--- a/examples/self-referential-context/src/main.rs
+++ b/examples/self-referential-context/src/main.rs
@@ -22,7 +22,7 @@ impl Object for SelfReferentialContext {
                 return Enumerator::Values(keys.collect());
             }
         }
-        Enumerator::Sequential(0)
+        Enumerator::Seq(0)
     }
 }
 

--- a/examples/undefined-tracking/src/main.rs
+++ b/examples/undefined-tracking/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
-use minijinja::value::{Enumeration, Object, Value, ValueKind};
+use minijinja::value::{Enumerator, Object, Value, ValueKind};
 use minijinja::{context, Environment};
 
 #[derive(Debug)]
@@ -33,13 +33,13 @@ impl Object for TrackedContext {
         }
     }
 
-    fn enumeration(self: &Arc<Self>) -> Enumeration {
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
         if self.enclosed.kind() == ValueKind::Map {
             if let Ok(keys) = self.enclosed.try_iter() {
-                return Enumeration::Values(keys.collect());
+                return Enumerator::Values(keys.collect());
             }
         }
-        Enumeration::Sized(0)
+        Enumerator::Sequential(0)
     }
 }
 

--- a/examples/undefined-tracking/src/main.rs
+++ b/examples/undefined-tracking/src/main.rs
@@ -39,7 +39,7 @@ impl Object for TrackedContext {
                 return Enumerator::Values(keys.collect());
             }
         }
-        Enumerator::Sequential(0)
+        Enumerator::Seq(0)
     }
 }
 

--- a/examples/value-tracking/src/main.rs
+++ b/examples/value-tracking/src/main.rs
@@ -32,7 +32,7 @@ impl Object for TrackedContext {
                 return Enumerator::Values(keys.collect());
             }
         }
-        Enumerator::Sequential(0)
+        Enumerator::Seq(0)
     }
 }
 

--- a/examples/value-tracking/src/main.rs
+++ b/examples/value-tracking/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
-use minijinja::value::{Enumeration, Object, Value, ValueKind};
+use minijinja::value::{Enumerator, Object, Value, ValueKind};
 use minijinja::{context, Environment};
 
 #[derive(Debug)]
@@ -26,13 +26,13 @@ impl Object for TrackedContext {
         }
     }
 
-    fn enumeration(self: &Arc<Self>) -> Enumeration {
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
         if self.enclosed.kind() == ValueKind::Map {
             if let Ok(keys) = self.enclosed.try_iter() {
-                return Enumeration::Values(keys.collect());
+                return Enumerator::Values(keys.collect());
             }
         }
-        Enumeration::Sized(0)
+        Enumerator::Sequential(0)
     }
 }
 

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -764,7 +764,7 @@ mod builtins {
             .as_object()
             .filter(|x| matches!(x.repr(), ObjectRepr::Seq))
         {
-            Ok(match obj.enumeration().len() {
+            Ok(match obj.len() {
                 Some(0) | None => None,
                 Some(idx) => obj.get_value(&Value::from(idx - 1)),
             }

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -101,7 +101,7 @@ use std::sync::Arc;
 
 use crate::error::Error;
 use crate::utils::SealedMarker;
-use crate::value::{ArgType, Enumerator, FunctionArgs, FunctionResult, Object, ObjectRepr, Value};
+use crate::value::{ArgType, FunctionArgs, FunctionResult, Object, ObjectRepr, Value};
 use crate::vm::State;
 
 type FuncFunc = dyn Fn(&State, &[Value]) -> Result<Value, Error> + Sync + Send + 'static;
@@ -250,10 +250,6 @@ impl fmt::Debug for BoxedFunction {
 impl Object for BoxedFunction {
     fn repr(self: &Arc<Self>) -> ObjectRepr {
         ObjectRepr::Plain
-    }
-
-    fn enumerate(self: &Arc<Self>) -> Enumerator {
-        Enumerator::NonEnumerable
     }
 
     fn call(self: &Arc<Self>, state: &State, args: &[Value]) -> Result<Value, Error> {

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -101,7 +101,7 @@ use std::sync::Arc;
 
 use crate::error::Error;
 use crate::utils::SealedMarker;
-use crate::value::{ArgType, Enumeration, FunctionArgs, FunctionResult, Object, ObjectRepr, Value};
+use crate::value::{ArgType, Enumerator, FunctionArgs, FunctionResult, Object, ObjectRepr, Value};
 use crate::vm::State;
 
 type FuncFunc = dyn Fn(&State, &[Value]) -> Result<Value, Error> + Sync + Send + 'static;
@@ -252,8 +252,8 @@ impl Object for BoxedFunction {
         ObjectRepr::Plain
     }
 
-    fn enumeration(self: &Arc<Self>) -> Enumeration {
-        Enumeration::NonEnumerable
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
+        Enumerator::NonEnumerable
     }
 
     fn call(self: &Arc<Self>, state: &State, args: &[Value]) -> Result<Value, Error> {

--- a/minijinja/src/value/argtypes.rs
+++ b/minijinja/src/value/argtypes.rs
@@ -11,7 +11,7 @@ use crate::value::{
 };
 use crate::vm::State;
 
-use super::{Enumeration, Object};
+use super::{Enumerator, Object};
 
 /// A utility trait that represents the return value of functions and filters.
 ///
@@ -751,8 +751,8 @@ impl Object for KwargsValues {
         self.as_value_map().get_value(key)
     }
 
-    fn enumeration(self: &Arc<Self>) -> Enumeration {
-        self.as_value_map().enumeration()
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
+        self.as_value_map().enumerate()
     }
 }
 

--- a/minijinja/src/value/deserialize.rs
+++ b/minijinja/src/value/deserialize.rs
@@ -181,7 +181,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer {
             ValueRepr::Bytes(ref v) => visitor.visit_bytes(v),
             ValueRepr::Object(o) => match o.repr() {
                 ObjectRepr::Plain => Err(de::Error::custom("cannot deserialize plain objects")),
-                ObjectRepr::Seq | ObjectRepr::Iterator => {
+                ObjectRepr::Seq | ObjectRepr::Iterable => {
                     visitor.visit_seq(de::value::SeqDeserializer::new(
                         o.try_iter()
                             .into_iter()

--- a/minijinja/src/value/merge_object.rs
+++ b/minijinja/src/value/merge_object.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use crate::value::{Enumeration, Object, ObjectExt, Value};
+use crate::value::{Enumerator, Object, ObjectExt, Value};
 
 /// Utility struct used by [`context!`](crate::context) to merge
 /// multiple values.
@@ -20,8 +20,8 @@ impl Object for MergeObject {
         None
     }
 
-    fn enumeration(self: &Arc<Self>) -> Enumeration {
-        self.mapped_enumeration(|this| {
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
+        self.map_enumerator(|this| {
             let mut seen = BTreeSet::new();
             let iter = this
                 .0

--- a/minijinja/src/value/merge_object.rs
+++ b/minijinja/src/value/merge_object.rs
@@ -21,7 +21,7 @@ impl Object for MergeObject {
     }
 
     fn enumerate(self: &Arc<Self>) -> Enumerator {
-        self.map_enumerator(|this| {
+        self.mapped_enumerator(|this| {
             let mut seen = BTreeSet::new();
             let iter = this
                 .0

--- a/minijinja/src/value/namespace_object.rs
+++ b/minijinja/src/value/namespace_object.rs
@@ -15,7 +15,7 @@ pub(crate) struct Namespace {
 
 impl Object for Namespace {
     fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
-        self.data.lock().unwrap().get(key.as_str()?).cloned()
+        self.data.lock().unwrap().get(some!(key.as_str())).cloned()
     }
 
     fn enumerate(self: &Arc<Self>) -> Enumerator {

--- a/minijinja/src/value/namespace_object.rs
+++ b/minijinja/src/value/namespace_object.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
-use crate::value::{Enumeration, Object, Value};
+use crate::value::{Enumerator, Object, Value};
 
 /// This object exists for the `namespace` function.
 ///
@@ -18,10 +18,10 @@ impl Object for Namespace {
         self.data.lock().unwrap().get(key.as_str()?).cloned()
     }
 
-    fn enumeration(self: &Arc<Self>) -> Enumeration {
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
         let data = self.data.lock().unwrap();
         let keys = data.keys().cloned().map(Value::from);
-        Enumeration::Values(keys.collect())
+        Enumerator::Values(keys.collect())
     }
 }
 

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -268,17 +268,27 @@ impl<T: Object + Send + Sync + 'static> ObjectExt for T {}
 /// Utility type to enumerate an object.
 #[non_exhaustive]
 pub enum Enumerator {
-    /// A non enumerable enumeration.  This fails iteration.
+    /// A non enumerable enumeration.
+    ///
+    /// This fails iteration and the object has no known length.
     NonEnumerable,
-    /// The empty enumeration
+    /// The empty enumeration.  It yields no elements.
+    ///
+    /// It has a known length of 0.
     Empty,
     /// A slice of static string keys.
+    ///
+    /// This has a known length which is the length of the slice.
     Str(&'static [&'static str]),
-    /// A dynamic iterator over keys.
+    /// A dynamic iterator over keys.  Length is known if the size hint has matching lower and upper bounds.
     Iter(Box<dyn Iterator<Item = Value> + Send + Sync>),
     /// Instructs the engine to yield values by calling `get_value` from 0 to `usize`.
+    ///
+    /// This has a known legth of `usize`.
     Sequential(usize),
     /// A vector of known values to iterate over.
+    ///
+    /// This has a known length which is the length of the vector.
     Values(Vec<Value>),
 }
 

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -392,7 +392,7 @@ impl<T: Into<Value> + Clone + Send + Sync + fmt::Debug> Object for Vec<T> {
     }
 
     fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
-        self.get(key.as_usize()?).cloned().map(|v| v.into())
+        self.get(some!(key.as_usize())).cloned().map(|v| v.into())
     }
 
     fn enumerate(self: &Arc<Self>) -> Enumerator {
@@ -425,7 +425,7 @@ where
     V: Into<Value> + Clone + Send + Sync + fmt::Debug + 'static,
 {
     fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
-        self.get(key.as_str()?).cloned().map(|v| v.into())
+        self.get(some!(key.as_str())).cloned().map(|v| v.into())
     }
 
     fn enumerate(self: &Arc<Self>) -> Enumerator {

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -26,7 +26,7 @@ use crate::vm::State;
 /// struct Point(f32, f32, f32);
 ///
 /// impl Object for Point {
-///     fn get_value(self: &Arc<self>, key: &Value) -> Option<Value> {
+///     fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
 ///         match key.as_str()? {
 ///             "x" => Some(Value::from(self.0)),
 ///             "y" => Some(Value::from(self.1)),
@@ -60,11 +60,11 @@ use crate::vm::State;
 /// struct Point(f32, f32, f32);
 ///
 /// impl Object for Point {
-///     fn repr(self: &Arc<self>) -> ObjectRepr {
+///     fn repr(self: &Arc<Self>) -> ObjectRepr {
 ///         ObjectRepr::Seq
 ///     }
 ///
-///     fn get_value(self: &Arc<self>, key: &Value) -> Option<Value> {
+///     fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
 ///         match key.as_usize()? {
 ///             0 => Some(Value::from(self.0)),
 ///             1 => Some(Value::from(self.1)),

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -234,8 +234,8 @@ macro_rules! impl_object_helpers {
 
 /// Provides utility methods for working with objects.
 pub trait ObjectExt: Object + Send + Sync + 'static {
-    /// Creates a new iterator enumeration that projects into the given object.
-    fn map_enumerator<F>(self: &Arc<Self>, maker: F) -> Enumerator
+    /// Creates a new enumeration that projects into the given object.
+    fn mapped_enumerator<F>(self: &Arc<Self>, maker: F) -> Enumerator
     where
         F: for<'a> FnOnce(&'a Self) -> Box<dyn Iterator<Item = Value> + Send + Sync + 'a>
             + Send
@@ -406,7 +406,7 @@ impl Object for ValueMap {
     }
 
     fn enumerate(self: &Arc<Self>) -> Enumerator {
-        self.map_enumerator(|this| Box::new(this.keys().cloned()))
+        self.mapped_enumerator(|this| Box::new(this.keys().cloned()))
     }
 }
 
@@ -429,7 +429,7 @@ where
     }
 
     fn enumerate(self: &Arc<Self>) -> Enumerator {
-        self.map_enumerator(|this| {
+        self.mapped_enumerator(|this| {
             Box::new(this.keys().map(|k| intern(k.as_ref())).map(Value::from))
         })
     }

--- a/minijinja/src/value/ops.rs
+++ b/minijinja/src/value/ops.rs
@@ -114,7 +114,7 @@ pub fn slice(value: Value, start: Value, stop: Value, step: Value) -> Result<Val
         }
         ValueRepr::Undefined | ValueRepr::None => Ok(Value::from(Vec::<Value>::new())),
         ValueRepr::Object(obj) if obj.repr() == ObjectRepr::Seq => {
-            let len = obj.enumeration().len().unwrap_or_default();
+            let len = obj.len().unwrap_or_default();
             let (start, len) = get_offset_and_len(start, stop, || len);
             Ok(Value::from_iter(
                 obj.try_iter()
@@ -273,7 +273,7 @@ pub fn contains(container: &Value, value: &Value) -> Result<Value, Error> {
         match obj.repr() {
             ObjectRepr::Plain => false,
             ObjectRepr::Map => obj.get_value(value).is_some(),
-            ObjectRepr::Seq | ObjectRepr::Iterator => {
+            ObjectRepr::Seq | ObjectRepr::Iterable => {
                 obj.try_iter().into_iter().flatten().any(|v| &v == value)
             }
         }

--- a/minijinja/src/vm/closure_object.rs
+++ b/minijinja/src/vm/closure_object.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
-use crate::value::{Enumeration, Object, Value};
+use crate::value::{Enumerator, Object, Value};
 
 /// Closure cycle breaker utility.
 ///
@@ -65,9 +65,9 @@ impl Object for Closure {
         self.values.lock().unwrap().get(key.as_str()?).cloned()
     }
 
-    fn enumeration(self: &Arc<Self>) -> Enumeration {
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
         let values = self.values.lock().unwrap();
         let keys = values.keys().cloned().map(Value::from);
-        Enumeration::Values(keys.collect())
+        Enumerator::Values(keys.collect())
     }
 }

--- a/minijinja/src/vm/loop_object.rs
+++ b/minijinja/src/vm/loop_object.rs
@@ -140,7 +140,7 @@ impl Object for Loop {
     }
 
     fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
-        self.get(key.as_str()?)
+        self.get(some!(key.as_str()))
     }
 
     fn render(self: &Arc<Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/minijinja/src/vm/loop_object.rs
+++ b/minijinja/src/vm/loop_object.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::error::{Error, ErrorKind};
-use crate::value::{Enumeration, Object, Value};
+use crate::value::{Enumerator, Object, Value};
 use crate::vm::state::State;
 
 pub(crate) struct Loop {
@@ -135,8 +135,8 @@ impl Object for Loop {
         }
     }
 
-    fn enumeration(self: &Arc<Self>) -> Enumeration {
-        Enumeration::Static(self.keys())
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
+        Enumerator::Str(self.keys())
     }
 
     fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {

--- a/minijinja/src/vm/macro_object.rs
+++ b/minijinja/src/vm/macro_object.rs
@@ -34,14 +34,12 @@ impl Object for Macro {
     }
 
     fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
-        match key.as_str()? {
-            "name" => Some(Value::from(self.name.clone())),
-            "arguments" => Some(Value::from_iter(
-                self.arg_spec.iter().cloned().map(Value::from),
-            )),
-            "caller" => Some(Value::from(self.caller_reference)),
-            _ => None,
-        }
+        Some(match some!(key.as_str()) {
+            "name" => Value::from(self.name.clone()),
+            "arguments" => Value::from_iter(self.arg_spec.iter().cloned().map(Value::from)),
+            "caller" => Value::from(self.caller_reference),
+            _ => return None,
+        })
     }
 
     fn call(self: &Arc<Self>, state: &State<'_, '_>, args: &[Value]) -> Result<Value, Error> {

--- a/minijinja/src/vm/macro_object.rs
+++ b/minijinja/src/vm/macro_object.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::error::{Error, ErrorKind};
 use crate::output::Output;
 use crate::utils::AutoEscape;
-use crate::value::{Enumeration, Object, Value, ValueRepr};
+use crate::value::{Enumerator, Object, Value, ValueRepr};
 use crate::vm::state::State;
 use crate::vm::Vm;
 
@@ -29,8 +29,8 @@ impl fmt::Debug for Macro {
 }
 
 impl Object for Macro {
-    fn enumeration(self: &Arc<Self>) -> Enumeration {
-        Enumeration::Static(&["name", "arguments", "caller"])
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
+        Enumerator::Str(&["name", "arguments", "caller"])
     }
 
     fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {

--- a/minijinja/tests/test_deserialization.rs
+++ b/minijinja/tests/test_deserialization.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use serde::{Deserialize, Serialize};
 use similar_asserts::assert_eq;
 
-use minijinja::value::{Enumeration, Object, ObjectRepr, Value};
+use minijinja::value::{Enumerator, Object, ObjectRepr, Value};
 
 #[test]
 fn test_seq() {
@@ -31,8 +31,8 @@ fn test_seq_object() {
             }
         }
 
-        fn enumeration(self: &Arc<Self>) -> Enumeration {
-            Enumeration::Sized(3)
+        fn enumerate(self: &Arc<Self>) -> Enumerator {
+            Enumerator::Sequential(3)
         }
     }
 
@@ -67,8 +67,8 @@ fn test_struct_object() {
             }
         }
 
-        fn enumeration(self: &Arc<Self>) -> Enumeration {
-            Enumeration::Static(&["a", "b"])
+        fn enumerate(self: &Arc<Self>) -> Enumerator {
+            Enumerator::Str(&["a", "b"])
         }
     }
 

--- a/minijinja/tests/test_deserialization.rs
+++ b/minijinja/tests/test_deserialization.rs
@@ -32,7 +32,7 @@ fn test_seq_object() {
         }
 
         fn enumerate(self: &Arc<Self>) -> Enumerator {
-            Enumerator::Sequential(3)
+            Enumerator::Seq(3)
         }
     }
 

--- a/minijinja/tests/test_templates.rs
+++ b/minijinja/tests/test_templates.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::{env, fs};
 
 use insta::assert_snapshot;
-use minijinja::value::{Enumeration, Object, Value};
+use minijinja::value::{Enumerator, Object, Value};
 use minijinja::{context, render, Environment, Error, State};
 
 use similar_asserts::assert_eq;
@@ -181,8 +181,8 @@ fn test_items_and_dictsort_with_structs() {
             }
         }
 
-        fn enumeration(self: &Arc<Self>) -> Enumeration {
-            Enumeration::Static(&["b", "a"])
+        fn enumerate(self: &Arc<Self>) -> Enumerator {
+            Enumerator::Str(&["b", "a"])
         }
     }
 
@@ -210,8 +210,8 @@ fn test_urlencode_with_struct() {
             }
         }
 
-        fn enumeration(self: &Arc<Self>) -> Enumeration {
-            Enumeration::Static(&["a", "b"])
+        fn enumerate(self: &Arc<Self>) -> Enumerator {
+            Enumerator::Str(&["a", "b"])
         }
     }
 

--- a/minijinja/tests/test_value.rs
+++ b/minijinja/tests/test_value.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use insta::assert_snapshot;
 use similar_asserts::assert_eq;
 
-use minijinja::value::{DynObject, Enumeration, Kwargs, Object, ObjectRepr, Rest, Value};
+use minijinja::value::{DynObject, Enumerator, Kwargs, Object, ObjectRepr, Rest, Value};
 use minijinja::{args, render, Environment, Error};
 
 #[test]
@@ -179,8 +179,8 @@ fn test_map_object_iteration_and_indexing() {
             }
         }
 
-        fn enumeration(self: &Arc<Self>) -> Enumeration {
-            Enumeration::Static(&["x", "y", "z"])
+        fn enumerate(self: &Arc<Self>) -> Enumerator {
+            Enumerator::Str(&["x", "y", "z"])
         }
     }
 
@@ -220,8 +220,8 @@ fn test_seq_object_iteration_and_indexing() {
             }
         }
 
-        fn enumeration(self: &Arc<Self>) -> Enumeration {
-            Enumeration::Sized(3)
+        fn enumerate(self: &Arc<Self>) -> Enumerator {
+            Enumerator::Sequential(3)
         }
     }
 
@@ -261,7 +261,7 @@ fn test_builtin_seq_objects() {
 fn test_value_object_interface() {
     let val = Value::from_object(vec![1u32, 2, 3, 4]);
     let obj = val.as_object().unwrap();
-    assert_eq!(obj.enumeration().len(), Some(4));
+    assert_eq!(obj.len(), Some(4));
     assert_eq!(obj.to_string(), "[1, 2, 3, 4]");
 }
 
@@ -297,8 +297,8 @@ fn test_seq_object_downcast() {
             }
         }
 
-        fn enumeration(self: &Arc<Self>) -> Enumeration {
-            Enumeration::Sized(3)
+        fn enumerate(self: &Arc<Self>) -> Enumerator {
+            Enumerator::Sequential(3)
         }
     }
 
@@ -580,8 +580,8 @@ fn test_seq_custom_iter() {
             ObjectRepr::Seq
         }
 
-        fn enumeration(self: &Arc<Self>) -> Enumeration {
-            Enumeration::NonEnumerable
+        fn enumerate(self: &Arc<Self>) -> Enumerator {
+            Enumerator::Iter(Box::new(('a'..='b').map(Value::from)))
         }
 
         fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
@@ -590,10 +590,6 @@ fn test_seq_custom_iter() {
                 Some(1) => Some(Value::from(false)),
                 _ => None,
             }
-        }
-
-        fn custom_iter(self: &Arc<Self>) -> Option<Box<dyn Iterator<Item = Value> + Send + Sync>> {
-            Some(Box::new(('a'..='b').map(Value::from)))
         }
     }
 
@@ -625,8 +621,8 @@ fn test_map_custom_iter() {
             ObjectRepr::Map
         }
 
-        fn enumeration(self: &Arc<Self>) -> Enumeration {
-            Enumeration::NonEnumerable
+        fn enumerate(self: &Arc<Self>) -> Enumerator {
+            Enumerator::Iter(Box::new(('a'..='b').map(Value::from)))
         }
 
         fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
@@ -635,10 +631,6 @@ fn test_map_custom_iter() {
                 Some("b") => Some(Value::from(false)),
                 _ => None,
             }
-        }
-
-        fn custom_iter(self: &Arc<Self>) -> Option<Box<dyn Iterator<Item = Value> + Send + Sync>> {
-            Some(Box::new(('a'..='b').map(Value::from)))
         }
     }
 

--- a/minijinja/tests/test_value.rs
+++ b/minijinja/tests/test_value.rs
@@ -221,7 +221,7 @@ fn test_seq_object_iteration_and_indexing() {
         }
 
         fn enumerate(self: &Arc<Self>) -> Enumerator {
-            Enumerator::Sequential(3)
+            Enumerator::Seq(3)
         }
     }
 
@@ -298,7 +298,7 @@ fn test_seq_object_downcast() {
         }
 
         fn enumerate(self: &Arc<Self>) -> Enumerator {
-            Enumerator::Sequential(3)
+            Enumerator::Seq(3)
         }
     }
 


### PR DESCRIPTION
This implements the concept of an `Enumerator` as an alternative to the current `Enumeration` system as outlined in https://github.com/mitsuhiko/minijinja/issues/456#issuecomment-2030630560.

It's mostly what's there with some minor differences that I ran into during implementation:

* `iter` -> `try_iter` as an extension method
* I ended up adding `Enumerator::NonEnumerable` which I believe fits nicer
* `Enumerator::Seq` instead of `Enumerator::Sequential`

Personally I quite like this, but I would like to play with this in practice more first.

It still retains `Value::from_iterator` which I think can be seen as a mistake but I want to fix this later.  It also renames `mapped_enumeration` to `mapped_enumerator`.