### PR TITLE
Store short strings inline in Value

### DIFF
--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -623,12 +623,9 @@ mod builtins {
                     ))
                 }
             }
-            ValueRepr::String(s, _) => s
-                .parse::<i128>()
-                .map(Value::from)
-                .map_err(|err| Error::new(ErrorKind::InvalidOperation, err.to_string())),
-            ValueRepr::SmallStr(s) => s
+            ValueRepr::String(..) | ValueRepr::SmallStr(_) => value
                 .as_str()
+                .unwrap()
                 .parse::<i128>()
                 .map(Value::from)
                 .map_err(|err| Error::new(ErrorKind::InvalidOperation, err.to_string())),
@@ -653,12 +650,9 @@ mod builtins {
         match &value.0 {
             ValueRepr::Undefined | ValueRepr::None => Ok(Value::from(0.0)),
             ValueRepr::Bool(x) => Ok(Value::from(*x as u64 as f64)),
-            ValueRepr::String(s, _) => s
-                .parse::<f64>()
-                .map(Value::from)
-                .map_err(|err| Error::new(ErrorKind::InvalidOperation, err.to_string())),
-            ValueRepr::SmallStr(s) => s
+            ValueRepr::String(..) | ValueRepr::SmallStr(_) => value
                 .as_str()
+                .unwrap()
                 .parse::<f64>()
                 .map(Value::from)
                 .map_err(|err| Error::new(ErrorKind::InvalidOperation, err.to_string())),
@@ -1099,12 +1093,9 @@ mod builtins {
             match &value.0 {
                 ValueRepr::None | ValueRepr::Undefined => Ok("".into()),
                 ValueRepr::Bytes(b) => Ok(percent_encoding::percent_encode(b, SET).to_string()),
-                ValueRepr::String(s, _) => {
-                    Ok(percent_encoding::utf8_percent_encode(s, SET).to_string())
-                }
-                ValueRepr::SmallStr(s) => {
-                    Ok(percent_encoding::utf8_percent_encode(s.as_str(), SET).to_string())
-                }
+                ValueRepr::String(..) | ValueRepr::SmallStr(_) => Ok(
+                    percent_encoding::utf8_percent_encode(value.as_str().unwrap(), SET).to_string(),
+                ),
                 _ => Ok(percent_encoding::utf8_percent_encode(&value.to_string(), SET).to_string()),
             }
         }

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -627,6 +627,11 @@ mod builtins {
                 .parse::<i128>()
                 .map(Value::from)
                 .map_err(|err| Error::new(ErrorKind::InvalidOperation, err.to_string())),
+            ValueRepr::SmallStr(s) => s
+                .as_str()
+                .parse::<i128>()
+                .map(Value::from)
+                .map_err(|err| Error::new(ErrorKind::InvalidOperation, err.to_string())),
             ValueRepr::Bytes(_) | ValueRepr::Object(_) => Err(Error::new(
                 ErrorKind::InvalidOperation,
                 format!("cannot convert {} to integer", value.kind()),
@@ -649,6 +654,11 @@ mod builtins {
             ValueRepr::Undefined | ValueRepr::None => Ok(Value::from(0.0)),
             ValueRepr::Bool(x) => Ok(Value::from(*x as u64 as f64)),
             ValueRepr::String(s, _) => s
+                .parse::<f64>()
+                .map(Value::from)
+                .map_err(|err| Error::new(ErrorKind::InvalidOperation, err.to_string())),
+            ValueRepr::SmallStr(s) => s
+                .as_str()
                 .parse::<f64>()
                 .map(Value::from)
                 .map_err(|err| Error::new(ErrorKind::InvalidOperation, err.to_string())),
@@ -1091,6 +1101,9 @@ mod builtins {
                 ValueRepr::Bytes(b) => Ok(percent_encoding::percent_encode(b, SET).to_string()),
                 ValueRepr::String(s, _) => {
                     Ok(percent_encoding::utf8_percent_encode(s, SET).to_string())
+                }
+                ValueRepr::SmallStr(s) => {
+                    Ok(percent_encoding::utf8_percent_encode(s.as_str(), SET).to_string())
                 }
                 _ => Ok(percent_encoding::utf8_percent_encode(&value.to_string(), SET).to_string()),
             }

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -330,7 +330,7 @@ impl<F: FnOnce()> Drop for OnDrop<F> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct InlineStr {
     len: u8,
     buf: [u8; 22],

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -330,6 +330,35 @@ impl<F: FnOnce()> Drop for OnDrop<F> {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct InlineStr {
+    len: u8,
+    buf: [u8; 22],
+}
+
+impl InlineStr {
+    pub fn new(s: &str) -> Option<InlineStr> {
+        if s.len() <= 22 {
+            let mut rv = InlineStr {
+                len: s.len() as u8,
+                buf: Default::default(),
+            };
+            rv.buf[..s.len()].copy_from_slice(s.as_bytes());
+            Some(rv)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        unsafe { std::str::from_utf8_unchecked(&self.buf[..self.len as usize]) }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -330,35 +330,6 @@ impl<F: FnOnce()> Drop for OnDrop<F> {
     }
 }
 
-#[derive(Clone)]
-pub struct InlineStr {
-    len: u8,
-    buf: [u8; 22],
-}
-
-impl InlineStr {
-    pub fn new(s: &str) -> Option<InlineStr> {
-        if s.len() <= 22 {
-            let mut rv = InlineStr {
-                len: s.len() as u8,
-                buf: Default::default(),
-            };
-            rv.buf[..s.len()].copy_from_slice(s.as_bytes());
-            Some(rv)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_str(&self) -> &str {
-        unsafe { std::str::from_utf8_unchecked(&self.buf[..self.len as usize]) }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len == 0
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/minijinja/src/value/argtypes.rs
+++ b/minijinja/src/value/argtypes.rs
@@ -5,7 +5,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use crate::error::{Error, ErrorKind};
-use crate::utils::UndefinedBehavior;
+use crate::utils::{InlineStr, UndefinedBehavior};
 use crate::value::{
     DynObject, ObjectRepr, Packed, StringType, Value, ValueKind, ValueMap, ValueRepr,
 };
@@ -271,14 +271,18 @@ impl<'a> From<&'a [u8]> for Value {
 impl<'a> From<&'a str> for Value {
     #[inline(always)]
     fn from(val: &'a str) -> Self {
-        ValueRepr::String(Arc::from(val.to_string()), StringType::Normal).into()
+        InlineStr::new(val)
+            .map(|small_str| Value(ValueRepr::SmallStr(small_str)))
+            .unwrap_or_else(|| {
+                ValueRepr::String(Arc::from(val.to_string()), StringType::Normal).into()
+            })
     }
 }
 
 impl<'a> From<&'a String> for Value {
     #[inline(always)]
     fn from(val: &'a String) -> Self {
-        ValueRepr::String(Arc::from(val.to_string()), StringType::Normal).into()
+        Value::from(val.as_str())
     }
 }
 
@@ -376,7 +380,8 @@ impl From<u128> for Value {
 impl From<char> for Value {
     #[inline(always)]
     fn from(val: char) -> Self {
-        ValueRepr::String(Arc::from(val.to_string()), StringType::Normal).into()
+        let mut buf = [0u8; 4];
+        ValueRepr::SmallStr(InlineStr::new(val.encode_utf8(&mut buf)).unwrap()).into()
     }
 }
 
@@ -468,6 +473,12 @@ primitive_try_from!(char, {
             unsupported_conversion(ValueKind::String, "non single character string")
         }))
     },
+    ValueRepr::SmallStr(ref val) => {
+        let mut char_iter = val.as_str().chars();
+        ok!(char_iter.next().filter(|_| char_iter.next().is_none()).ok_or_else(|| {
+            unsupported_conversion(ValueKind::String, "non single character string")
+        }))
+    },
 });
 primitive_try_from!(f32, {
     ValueRepr::U64(val) => val as f32,
@@ -503,6 +514,7 @@ impl TryFrom<Value> for Arc<str> {
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         match value.0 {
             ValueRepr::String(x, _) => Ok(x),
+            ValueRepr::SmallStr(x) => Ok(Arc::from(x.as_str())),
             _ => Err(Error::new(
                 ErrorKind::InvalidOperation,
                 "value is not a string",
@@ -568,6 +580,7 @@ impl<'a> ArgType<'a> for Cow<'_, str> {
         match value {
             Some(value) => Ok(match value.0 {
                 ValueRepr::String(ref s, _) => Cow::Borrowed(s as &str),
+                ValueRepr::SmallStr(ref s) => Cow::Borrowed(s.as_str()),
                 _ => Cow::Owned(value.to_string()),
             }),
             None => Err(Error::from(ErrorKind::MissingArgument)),

--- a/minijinja/src/value/deserialize.rs
+++ b/minijinja/src/value/deserialize.rs
@@ -177,6 +177,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer {
             ValueRepr::U128(v) => visitor.visit_u128(v.0),
             ValueRepr::F64(v) => visitor.visit_f64(v),
             ValueRepr::String(ref v, _) => visitor.visit_str(v),
+            ValueRepr::SmallStr(v) => visitor.visit_str(v.as_str()),
             ValueRepr::Undefined | ValueRepr::None => visitor.visit_unit(),
             ValueRepr::Bytes(ref v) => visitor.visit_bytes(v),
             ValueRepr::Object(o) => match o.repr() {
@@ -445,6 +446,7 @@ fn value_to_unexpected(value: &Value) -> de::Unexpected {
             }
         }
         ValueRepr::String(ref s, _) => de::Unexpected::Str(s),
+        ValueRepr::SmallStr(ref s) => de::Unexpected::Str(s.as_str()),
         ValueRepr::Bytes(ref b) => de::Unexpected::Bytes(b),
         ValueRepr::Object(..) => de::Unexpected::Other("<dynamic value>"),
     }

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -384,6 +384,7 @@ impl PartialEq for Value {
             (ValueRepr::None, ValueRepr::None) => true,
             (ValueRepr::Undefined, ValueRepr::Undefined) => true,
             (ValueRepr::String(ref a, _), ValueRepr::String(ref b, _)) => a == b,
+            (ValueRepr::SmallStr(a), ValueRepr::SmallStr(b)) => a.as_str() == b.as_str(),
             (ValueRepr::Bytes(a), ValueRepr::Bytes(b)) => a == b,
             _ => match ops::coerce(self, other) {
                 Some(ops::CoerceResult::F64(a, b)) => a == b,
@@ -432,6 +433,7 @@ impl Ord for Value {
             (ValueRepr::None, ValueRepr::None) => Ordering::Equal,
             (ValueRepr::Undefined, ValueRepr::Undefined) => Ordering::Equal,
             (ValueRepr::String(ref a, _), ValueRepr::String(ref b, _)) => a.cmp(b),
+            (ValueRepr::SmallStr(a), ValueRepr::SmallStr(b)) => a.as_str().cmp(b.as_str()),
             (ValueRepr::Bytes(a), ValueRepr::Bytes(b)) => a.cmp(b),
             _ => match ops::coerce(self, other) {
                 Some(ops::CoerceResult::F64(a, b)) => f64_total_cmp(a, b),
@@ -1024,6 +1026,7 @@ impl Value {
             ValueRepr::Undefined | ValueRepr::None => Some(self.clone()),
             ValueRepr::String(ref s, _) => Some(Value::from(s.chars().rev().collect::<String>())),
             ValueRepr::SmallStr(ref s) => {
+                // TODO: add small str optimization here
                 Some(Value::from(s.as_str().chars().rev().collect::<String>()))
             }
             ValueRepr::Bytes(ref b) => {

--- a/minijinja/src/value/ops.rs
+++ b/minijinja/src/value/ops.rs
@@ -29,6 +29,11 @@ pub fn coerce<'x>(a: &'x Value, b: &'x Value) -> Option<CoerceResult<'x>> {
             Some(CoerceResult::I128(a.0 as i128, b.0 as i128))
         }
         (ValueRepr::String(a, _), ValueRepr::String(b, _)) => Some(CoerceResult::Str(a, b)),
+        (ValueRepr::SmallStr(a), ValueRepr::String(b, _)) => Some(CoerceResult::Str(a.as_str(), b)),
+        (ValueRepr::SmallStr(a), ValueRepr::SmallStr(b)) => {
+            Some(CoerceResult::Str(a.as_str(), b.as_str()))
+        }
+        (ValueRepr::String(a, _), ValueRepr::SmallStr(b)) => Some(CoerceResult::Str(a, b.as_str())),
         (ValueRepr::I64(a), ValueRepr::I64(b)) => Some(CoerceResult::I128(*a as i128, *b as i128)),
         (ValueRepr::I128(a), ValueRepr::I128(b)) => Some(CoerceResult::I128(a.0, b.0)),
         (ValueRepr::F64(a), ValueRepr::F64(b)) => Some(CoerceResult::F64(*a, *b)),
@@ -101,7 +106,7 @@ pub fn slice(value: Value, start: Value, stop: Value, step: Value) -> Result<Val
     ));
 
     match value.0 {
-        ValueRepr::String(..) => {
+        ValueRepr::String(..) | ValueRepr::SmallStr(_) => {
             let s = value.as_str().unwrap();
             let (start, len) = get_offset_and_len(start, stop, || s.chars().count());
             Ok(Value::from(

--- a/minijinja/src/value/ops.rs
+++ b/minijinja/src/value/ops.rs
@@ -29,10 +29,10 @@ pub fn coerce<'x>(a: &'x Value, b: &'x Value) -> Option<CoerceResult<'x>> {
             Some(CoerceResult::I128(a.0 as i128, b.0 as i128))
         }
         (ValueRepr::String(a, _), ValueRepr::String(b, _)) => Some(CoerceResult::Str(a, b)),
-        (ValueRepr::SmallStr(a), ValueRepr::String(b, _)) => Some(CoerceResult::Str(a.as_str(), b)),
         (ValueRepr::SmallStr(a), ValueRepr::SmallStr(b)) => {
             Some(CoerceResult::Str(a.as_str(), b.as_str()))
         }
+        (ValueRepr::SmallStr(a), ValueRepr::String(b, _)) => Some(CoerceResult::Str(a.as_str(), b)),
         (ValueRepr::String(a, _), ValueRepr::SmallStr(b)) => Some(CoerceResult::Str(a, b.as_str())),
         (ValueRepr::I64(a), ValueRepr::I64(b)) => Some(CoerceResult::I128(*a as i128, *b as i128)),
         (ValueRepr::I128(a), ValueRepr::I128(b)) => Some(CoerceResult::I128(a.0, b.0)),

--- a/minijinja/src/value/serialize.rs
+++ b/minijinja/src/value/serialize.rs
@@ -5,7 +5,7 @@ use serde::{ser, Serialize, Serializer};
 
 use crate::utils::untrusted_size_hint;
 use crate::value::{
-    value_map_with_capacity, Arc, Packed, StringType, Value, ValueMap, ValueRepr, VALUE_HANDLES,
+    value_map_with_capacity, Arc, Packed, Value, ValueMap, ValueRepr, VALUE_HANDLES,
     VALUE_HANDLE_MARKER,
 };
 
@@ -107,7 +107,7 @@ impl Serializer for ValueSerializer {
     }
 
     fn serialize_char(self, v: char) -> Result<Value, InvalidValue> {
-        Ok(ValueRepr::String(Arc::from(v.to_string()), StringType::Normal).into())
+        Ok(Value::from(v))
     }
 
     fn serialize_str(self, value: &str) -> Result<Value, InvalidValue> {

--- a/minijinja/src/value/serialize.rs
+++ b/minijinja/src/value/serialize.rs
@@ -111,7 +111,7 @@ impl Serializer for ValueSerializer {
     }
 
     fn serialize_str(self, value: &str) -> Result<Value, InvalidValue> {
-        Ok(ValueRepr::String(Arc::from(value.to_owned()), StringType::Normal).into())
+        Ok(Value::from(value))
     }
 
     fn serialize_bytes(self, value: &[u8]) -> Result<Value, InvalidValue> {

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -994,23 +994,12 @@ impl<'env> Vm<'env> {
     ) {
         use crate::{compiler::instructions::MACRO_CALLER, vm::macro_object::Macro};
 
-        let arg_spec = match stack.pop().0 {
-            ValueRepr::Object(args) => args
-                .try_iter()
-                .unwrap()
-                .map(|value| match &value.0 {
-                    ValueRepr::String(arg, _) => arg.clone(),
-                    ValueRepr::SmallStr(arg) => Arc::from(arg.as_str()),
-                    _ => unreachable!(),
-                })
-                .collect(),
-            _ => unreachable!(),
-        };
+        let arg_spec = stack.pop().try_iter().unwrap().collect();
         let closure = stack.pop();
         let macro_ref_id = state.macros.len();
         Arc::make_mut(&mut state.macros).push((state.instructions, offset));
         stack.push(Value::from_object(Macro {
-            name: Arc::from(name.to_string()),
+            name: Value::from(name),
             arg_spec,
             macro_ref_id,
             state_id: state.id,

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -1000,6 +1000,7 @@ impl<'env> Vm<'env> {
                 .unwrap()
                 .map(|value| match &value.0 {
                     ValueRepr::String(arg, _) => arg.clone(),
+                    ValueRepr::SmallStr(arg) => Arc::from(arg.as_str()),
                     _ => unreachable!(),
                 })
                 .collect(),


### PR DESCRIPTION
Now that the object interface is based on `Value` objects everywhere, the small string optimization is meaningful as it cuts down on a lot of allocations for attribute and variable lookups.

Fixes #477