### PR TITLE
Expose Value::from(error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ For upgrade instructions read the [UPDATING](UPDATING.md) guide.
 - The CLI now enables unicode support by default.
 - `Value::from_serializable` is now `Value::from_serialize`.
 - Ranges are now iterables and no longer sequences. #493
+- `Value::from` is now implemented for `Error` as public API to create invalid values.
+  Previously this behavior was hidden internally in the serde support.
 
 ## 1.0.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ For upgrade instructions read the [UPDATING](UPDATING.md) guide.
 - `Value::from_serializable` is now `Value::from_serialize`.
 - Ranges are now iterables and no longer sequences. #493
 - `Value::from` is now implemented for `Error` as public API to create invalid values.
-  Previously this behavior was hidden internally in the serde support.
+  Previously this behavior was hidden internally in the serde support. #495
 
 ## 1.0.20
 

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -633,10 +633,7 @@ mod builtins {
                 ErrorKind::InvalidOperation,
                 format!("cannot convert {} to integer", value.kind()),
             )),
-            ValueRepr::Invalid(ref x) => Err(Error::new(
-                ErrorKind::InvalidOperation,
-                format!("invalid value: {}", x),
-            )),
+            ValueRepr::Invalid(_) => value.validate(),
         }
     }
 
@@ -656,10 +653,7 @@ mod builtins {
                 .parse::<f64>()
                 .map(Value::from)
                 .map_err(|err| Error::new(ErrorKind::InvalidOperation, err.to_string())),
-            ValueRepr::Invalid(ref x) => Err(Error::new(
-                ErrorKind::InvalidOperation,
-                format!("invalid value: {}", x),
-            )),
+            ValueRepr::Invalid(_) => value.validate(),
             _ => as_f64(&value).map(Value::from).ok_or_else(|| {
                 Error::new(
                     ErrorKind::InvalidOperation,

--- a/minijinja/src/lib.rs
+++ b/minijinja/src/lib.rs
@@ -158,7 +158,7 @@
 //!   - `deserialization`: when removed this disables deserialization support for
 //!     the [`Value`] type, removes the `ViaDeserialize` type and the error type
 //!     no longer implements `serde::de::Error`.
-//!   - `std_collections`: if this feature is removed some [`Object`](create::value::Object)
+//!   - `std_collections`: if this feature is removed some [`Object`](crate::value::Object)
 //!     implementations for standard library collections are removed.  Only the
 //!     ones needed for the engine to function itself are retained.
 //!

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -111,6 +111,11 @@ use crate::vm::State;
 /// let value = Value::from_object(Range10);
 /// ```
 ///
+/// Iteration is encouraged to fail immediately (object is not iterable) or not at
+/// all.  However this is not always possible, but the iteration interface itself
+/// does not support fallible iteration.  It is however possible to accomplish the
+/// same thing by creating an [invalid value](index.html#invalid-values).
+///
 /// # Map As Context
 ///
 /// Map can also be used as template rendering context.  This has a lot of

--- a/minijinja/src/vm/context.rs
+++ b/minijinja/src/vm/context.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use crate::environment::Environment;
 use crate::error::{Error, ErrorKind};
-use crate::value::{Value, ValueIter, ValueRepr};
+use crate::value::{Value, ValueIter};
 use crate::vm::loop_object::Loop;
 
 #[cfg(feature = "macros")]
@@ -58,11 +58,7 @@ impl<'env> Frame<'env> {
 
     /// Creates a new frame with the given context and validates the value is not invalid
     pub fn new_checked(root: Value) -> Result<Frame<'env>, Error> {
-        if let ValueRepr::Invalid(ref err) = root.0 {
-            Err(Error::new(ErrorKind::BadSerialization, err.to_string()))
-        } else {
-            Ok(Frame::new(root))
-        }
+        Ok(Frame::new(ok!(root.validate())))
     }
 }
 

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -11,7 +11,7 @@ use crate::error::{Error, ErrorKind};
 use crate::output::{CaptureMode, Output};
 use crate::utils::{untrusted_size_hint, AutoEscape, UndefinedBehavior};
 use crate::value::namespace_object::Namespace;
-use crate::value::{ops, value_map_with_capacity, value_optimization, Kwargs, Value, ValueRepr};
+use crate::value::{ops, value_map_with_capacity, value_optimization, Kwargs, Value};
 use crate::vm::context::{Frame, LoopState, Stack};
 use crate::vm::loop_object::Loop;
 use crate::vm::state::BlockStack;
@@ -277,10 +277,10 @@ impl<'env> Vm<'env> {
             macro_rules! assert_valid {
                 ($expr:expr) => {{
                     let val = $expr;
-                    if let ValueRepr::Invalid(ref err) = val.0 {
-                        bail!(Error::new(ErrorKind::BadSerialization, err.to_string()));
+                    match val.validate() {
+                        Ok(val) => val,
+                        Err(err) => bail!(err),
                     }
-                    val
                 }};
             }
 

--- a/minijinja/tests/test_deserialization.rs
+++ b/minijinja/tests/test_deserialization.rs
@@ -121,8 +121,14 @@ fn test_invalid() {
     }
 
     let v = Value::from_serialize(X);
-    assert_eq!(v.to_string(), "<invalid value: meh>");
+    assert_eq!(
+        v.to_string(),
+        "<invalid value: could not serialize to value: meh>"
+    );
 
     let err = bool::deserialize(v).unwrap_err();
-    assert_eq!(err.to_string(), "cannot deserialize: meh");
+    assert_eq!(
+        err.to_string(),
+        "cannot deserialize: could not serialize to value: meh"
+    );
 }


### PR DESCRIPTION
This makes a previously internal functionality public.

Fixes #494 