### PR TITLE
Do not apply lstrip_blocks to expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to MiniJinja are documented here.
 
+## 1.0.21
+
+- Fixed an issue where `lstrip_blocks` unintentionally also applied to
+  variable expression blocks.  #502
+
 ## 1.0.20
 
 - Added support for implicit string concatenation for Jinja2 compatibility.  #489

--- a/minijinja/src/compiler/lexer.rs
+++ b/minijinja/src/compiler/lexer.rs
@@ -491,6 +491,7 @@ impl<'s> Tokenizer<'s> {
         }
     }
 
+    syntax_token_getter!(variable_start, "{{");
     syntax_token_getter!(variable_end, "}}");
     syntax_token_getter!(block_start, "{%");
     syntax_token_getter!(block_end, "%}");
@@ -506,7 +507,11 @@ impl<'s> Tokenizer<'s> {
         }
         let old_loc = self.loc();
         let (lead, span) = match find_start_marker(self.rest, &self.syntax_config) {
-            Some((start, Whitespace::Default)) if self.ws_config.lstrip_blocks => {
+            Some((start, Whitespace::Default))
+                if self.ws_config.lstrip_blocks
+                    && self.rest.get(start..start + self.variable_start().len())
+                        != Some(self.variable_start()) =>
+            {
                 let peeked = &self.rest[..start];
                 let trimmed = lstrip_block(peeked);
                 let lead = self.advance(trimmed.len());

--- a/minijinja/tests/snapshots/test_lexer__lexer@lstrip-blocks-preserve.txt.snap
+++ b/minijinja/tests/snapshots/test_lexer__lexer@lstrip-blocks-preserve.txt.snap
@@ -47,8 +47,8 @@ Ident("seq")
   "seq"
 BlockEnd
   "+%}"
-TemplateData("\n")
-  "\n"
+TemplateData("\n    ")
+  "\n    "
 VariableStart
   "{{"
 Ident("item")
@@ -65,4 +65,3 @@ BlockEnd
   "+%}"
 TemplateData("\n</ul>")
   "\n</ul>"
-

--- a/minijinja/tests/snapshots/test_lexer__lexer@lstrip-blocks.txt.snap
+++ b/minijinja/tests/snapshots/test_lexer__lexer@lstrip-blocks.txt.snap
@@ -47,6 +47,8 @@ Ident("seq")
   "seq"
 BlockEnd
   "%}"
+TemplateData("    ")
+  "    "
 VariableStart
   "{{"
 Ident("item")
@@ -63,4 +65,3 @@ BlockEnd
   "%}"
 TemplateData("</ul>")
   "</ul>"
-


### PR DESCRIPTION
The implementation of `lstrip_blocks` accidentally also applied to variable expressions.

Fixes #496