### PR TITLE
Allow the CLI to override the syntax config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ For upgrade instructions read the [UPDATING](UPDATING.md) guide.
   Previously this behavior was hidden internally in the serde support. #495
 - `UndefinedBehavior::Strict` now acts more delayed.  This means that now `value.key is defined`
 - Added support for line statements and comments.  #503 
+- The CLI now accepts `--syntax` to reconfigure syntax flags such as delimiters.  #504
 
 ## 1.0.21
 

--- a/minijinja-cli/Cargo.toml
+++ b/minijinja-cli/Cargo.toml
@@ -39,6 +39,7 @@ minijinja = { version = "=2.0.0-alpha.0", path = "../minijinja", features = [
     "urlencode",
     "fuel",
     "unstable_machinery",
+    "custom_syntax",
 ] }
 minijinja-contrib = { version = "=2.0.0-alpha.0", path = "../minijinja-contrib" }
 rustyline = { version = "12.0.0", optional = true }

--- a/minijinja-cli/README.md
+++ b/minijinja-cli/README.md
@@ -71,6 +71,16 @@ can be set to stdin at once.
     enables strict mode.  Undefined variables will then error upon rendering.
 - `--no-include`:
     disallows including or extending of templates from the file system.
+- `--no-newline`:
+    Do not output a trailing newline
+- `--trim-blocks`:
+    Enable the trim_blocks flag
+- `--lstrip-blocks`:
+    Enable the lstrip_blocks flag
+- `-s`, `--syntax <PAIR>`:
+    Changes a syntax feature (feature=value) [possible features: `block-start`, `block-end`, `variable-start`, `variable-end`, `comment-start`, `comment-end`, `line-statement-prefix`, `line-statement-comment`]
+- `--safe-path <PATH>`:
+    Only allow includes from this path. Can be used multiple times.
 - `--env`:
     passes the environment variables to the template in the variable `ENV`
 - `-E`, `--expr` `<EXPR>`:

--- a/minijinja-cli/src/cli.rs
+++ b/minijinja-cli/src/cli.rs
@@ -26,9 +26,13 @@ pub(super) fn make_command() -> Command {
                 .action(ArgAction::Append),
             arg!(--strict "disallow undefined variables in templates"),
             arg!(--"no-include" "Disallow includes and extending"),
-            arg!(--"no-newline" "Do not output a newline"),
+            arg!(--"no-newline" "Do not output a trailing newline"),
             arg!(--"trim-blocks" "Enable the trim_blocks flag"),
             arg!(--"lstrip-blocks" "Enable the lstrip_blocks flag"),
+            arg!(-s --syntax <PAIR>... "Changes a syntax feature (feature=value) \
+                [possible features: block-start, block-end, variable-start, variable-end, \
+                comment-start, comment-end, line-statement-prefix, \
+                line-statement-comment]"),
             arg!(--"safe-path" <PATH>... "Only allow includes from this path. Can be used multiple times.")
                 .conflicts_with("no-include")
                 .value_parser(value_parser!(PathBuf)),

--- a/minijinja-cli/tests/test_basic.rs
+++ b/minijinja-cli/tests/test_basic.rs
@@ -395,3 +395,26 @@ fn test_stdin_template() {
     ----- stderr -----
     "###);
 }
+
+#[test]
+fn test_line_statement() {
+    let tmpl = file_with_contents("# for item in seq\n  {{ item }}\n# endfor");
+    let input = file_with_contents_and_ext(r#"{"seq": [1, 2, 3]}"#, ".json");
+
+    assert_cmd_snapshot!(
+        cli()
+            .arg("-sline-statement-prefix=#")
+            .arg("--no-newline")
+            .arg(tmpl.path())
+            .arg(input.path()),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+      1
+      2
+      3
+
+    ----- stderr -----
+    "###);
+}


### PR DESCRIPTION
Adds a `--syntax` flag to override syntax features such as delimiters.