### PR TITLE
Fix custom delimiters in Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to MiniJinja are documented here.
 
+## 2.0.1
+
+- Fixed an issue that caused custom delimiters to not work in the Python binding.
+
 ## 2.0.0
 
 This is a major update to MiniJinja that changes a lot of core internals and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to MiniJinja are documented here.
 
 ## 2.0.1
 
-- Fixed an issue that caused custom delimiters to not work in the Python binding.
+- Fixed an issue that caused custom delimiters to not work in the Python
+  binding.  #506
 
 ## 2.0.0
 

--- a/minijinja-py/python/minijinja/__init__.py
+++ b/minijinja-py/python/minijinja/__init__.py
@@ -41,6 +41,8 @@ class Environment(_lowlevel.Environment):
         variable_end_string="}}",
         comment_start_string="{#",
         comment_end_string="#}",
+        line_statement_prefix=None,
+        line_comment_prefix=None,
     ):
         super().__init__()
         if loader is not None:
@@ -85,6 +87,8 @@ class Environment(_lowlevel.Environment):
         self.variable_end_string = variable_end_string
         self.comment_start_string = comment_start_string
         self.comment_end_string = comment_end_string
+        self.line_statement_prefix = line_statement_prefix
+        self.line_comment_prefix = line_comment_prefix
 
 
 DEFAULT_ENVIRONMENT = Environment()

--- a/minijinja-py/src/environment.rs
+++ b/minijinja-py/src/environment.rs
@@ -28,6 +28,8 @@ struct Syntax {
     variable_end: String,
     comment_start: String,
     comment_end: String,
+    line_statement_prefix: String,
+    line_comment_prefix: String,
 }
 
 impl Default for Syntax {
@@ -37,8 +39,10 @@ impl Default for Syntax {
             block_end: "%}".into(),
             variable_start: "{{".into(),
             variable_end: "}}".into(),
-            comment_start: "{%".into(),
-            comment_end: "%}".into(),
+            comment_start: "{#".into(),
+            comment_end: "#}".into(),
+            line_statement_prefix: "".into(),
+            line_comment_prefix: "".into(),
         }
     }
 }
@@ -48,6 +52,8 @@ impl Syntax {
             .block_delimiters(self.block_start.clone(), self.block_end.clone())
             .variable_delimiters(self.variable_start.clone(), self.variable_end.clone())
             .comment_delimiters(self.comment_start.clone(), self.comment_end.clone())
+            .line_statement_prefix(self.line_statement_prefix.clone())
+            .line_comment_prefix(self.line_comment_prefix.clone())
             .build()
     }
 }
@@ -534,6 +540,28 @@ impl Environment {
     #[getter]
     pub fn get_comment_end_string(&self) -> String {
         syntax_getter!(self, comment_end, "#}")
+    }
+
+    #[setter]
+    pub fn set_line_statement_prefix(&self, value: Option<String>) -> PyResult<()> {
+        syntax_setter!(self, value.unwrap_or_default(), line_statement_prefix, "")
+    }
+
+    #[getter]
+    pub fn get_line_statement_prefix(&self) -> Option<String> {
+        let rv: String = syntax_getter!(self, line_statement_prefix, "");
+        (!rv.is_empty()).then_some(rv)
+    }
+
+    #[setter]
+    pub fn set_line_comment_prefix(&self, value: Option<String>) -> PyResult<()> {
+        syntax_setter!(self, value.unwrap_or_default(), line_comment_prefix, "")
+    }
+
+    #[getter]
+    pub fn get_line_comment_prefix(&self) -> Option<String> {
+        let rv: String = syntax_getter!(self, line_comment_prefix, "");
+        (!rv.is_empty()).then_some(rv)
     }
 
     /// Configures the trailing newline trimming feature.

--- a/minijinja-py/tests/test_basic.py
+++ b/minijinja-py/tests/test_basic.py
@@ -315,3 +315,29 @@ def test_trim_and_lstrip_blocks():
     assert env.render_str("  {% if true %}\nfoo{% endif %}") == "  \nfoo"
     env = Environment(lstrip_blocks=True, trim_blocks=True)
     assert env.render_str("  {% if true %}\nfoo{% endif %}") == "foo"
+
+
+def test_line_statements():
+    env = Environment()
+    assert env.line_statement_prefix is None
+    assert env.line_comment_prefix is None
+
+    env = Environment(line_statement_prefix="#", line_comment_prefix="##")
+    assert env.line_statement_prefix == "#"
+    assert env.line_comment_prefix == "##"
+
+    rv = env.render_str("# for x in range(3)\n{{ x }}\n# endfor")
+    assert rv == "0\n1\n2\n"
+
+
+def test_custom_delimiters():
+    env = Environment(
+        variable_start_string="${",
+        variable_end_string="}",
+        block_start_string="<%",
+        block_end_string="%>",
+        comment_start_string="<!--",
+        comment_end_string="-->",
+    )
+    rv = env.render_str('<% if true %>${ value }<% endif %><!-- nothing -->', value=42)
+    assert rv == '42'

--- a/minijinja/src/syntax.rs
+++ b/minijinja/src/syntax.rs
@@ -939,7 +939,6 @@ mod imp {
                         return Err(ErrorKind::InvalidDelimiter.into());
                     }
                 } else if delims.contains(&delim) {
-                    dbg!(&delims, delim);
                     return Err(ErrorKind::InvalidDelimiter.into());
                 } else {
                     delims.push(delim);

--- a/minijinja/src/syntax.rs
+++ b/minijinja/src/syntax.rs
@@ -939,6 +939,7 @@ mod imp {
                         return Err(ErrorKind::InvalidDelimiter.into());
                     }
                 } else if delims.contains(&delim) {
+                    dbg!(&delims, delim);
                     return Err(ErrorKind::InvalidDelimiter.into());
                 } else {
                     delims.push(delim);


### PR DESCRIPTION
Fixes two missing cases and a bug in reconfiguring custom syntax.