### PR TITLE
Route incref via vtable to avoid alignment issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3090,9 +3090,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/minijinja-contrib/Cargo.toml
+++ b/minijinja-contrib/Cargo.toml
@@ -23,7 +23,7 @@ timezone = ["time-tz"]
 [dependencies]
 minijinja = { version = "2.0.1", path = "../minijinja", default-features = false }
 serde = "1.0.164"
-time = { version = "0.3.22", optional = true, features = ["serde", "formatting", "parsing"] }
+time = { version = "0.3.25", optional = true, features = ["serde", "formatting", "parsing"] }
 time-tz = { version = "1.0.3", features = ["db"], optional = true }
 
 [dev-dependencies]

--- a/minijinja-contrib/Cargo.toml
+++ b/minijinja-contrib/Cargo.toml
@@ -23,7 +23,7 @@ timezone = ["time-tz"]
 [dependencies]
 minijinja = { version = "2.0.1", path = "../minijinja", default-features = false }
 serde = "1.0.164"
-time = { version = "0.3.25", optional = true, features = ["serde", "formatting", "parsing"] }
+time = { version = "0.3.35", optional = true, features = ["serde", "formatting", "parsing"] }
 time-tz = { version = "1.0.3", features = ["db"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This method was previously not sound when the alignment of the type was larger than the necessary alignment for the atomic counters.