### PR TITLE
Flush local filter and test cache when processing `parent_instructions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to MiniJinja are documented here.
 
+## Unreleased
+
+- Flush filter and test cache when processing extended template.  #551
+
 ## 2.1.1
 
 - Added `indent` parameter to `tojson` filter.  #546

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 All notable changes to MiniJinja are documented here.
 
-## Unreleased
+## 2.1.2
 
-- Flush filter and test cache when processing extended template.  #551
+- Flush filter and test cache when processing extended template.
+  This fixes a bug that caused the wrong filters to be used in some
+  cases. #551
 
 ## 2.1.1
 

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -231,6 +231,11 @@ impl<'env> Vm<'env> {
                     };
                     out.end_capture(AutoEscape::None);
                     pc = 0;
+                    // flush cached filters and tests, as the local_id could be different.
+                    for i in 0..MAX_LOCALS {
+                        loaded_filters[i] = None;
+                        loaded_tests[i] = None;
+                    }
                     continue;
                 }
             };

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -211,7 +211,7 @@ impl<'env> Vm<'env> {
             }};
         }
 
-        // looks nicer nice way
+        // looks nicer this way
         #[allow(clippy::while_let_loop)]
         loop {
             let instr = match state.instructions.get(pc) {
@@ -231,11 +231,11 @@ impl<'env> Vm<'env> {
                     };
                     out.end_capture(AutoEscape::None);
                     pc = 0;
-                    // flush cached filters and tests, as the local_id could be different.
-                    for i in 0..MAX_LOCALS {
-                        loaded_filters[i] = None;
-                        loaded_tests[i] = None;
-                    }
+                    // because we swap out the instructions we also need to unload all
+                    // the filters and tests to ensure that we are not accidentally
+                    // reusing the local_ids for completely different filters.
+                    loaded_filters = [None; MAX_LOCALS];
+                    loaded_tests = [None; MAX_LOCALS];
                     continue;
                 }
             };

--- a/minijinja/tests/test_templates.rs
+++ b/minijinja/tests/test_templates.rs
@@ -629,3 +629,32 @@ fn test_multiple_extended_includes_in_loop() {
     let rv = env.get_template("main.txt").unwrap().render(()).unwrap();
     assert_eq!(rv, "012");
 }
+
+/// See https://github.com/mitsuhiko/minijinja/issues/551
+#[test]
+fn test_filter_caching() {
+    let mut env = Environment::new();
+    env.add_template("parent.txt", "{{ 'Hello Foo' | lower }}")
+        .unwrap();
+    env.add_template(
+        "child.txt",
+        "{% extends 'parent.txt' %}{% set dummy = 'a' | upper %}",
+    )
+    .unwrap();
+    let rv = env.get_template("child.txt").unwrap().render(()).unwrap();
+    assert_eq!(rv, "hello foo");
+}
+
+/// See https://github.com/mitsuhiko/minijinja/issues/551
+#[test]
+fn test_test_caching() {
+    let mut env = Environment::new();
+    env.add_template("parent.txt", "{{ 42 is odd }}").unwrap();
+    env.add_template(
+        "child.txt",
+        "{% extends 'parent.txt' %}{% set dummy = 23 is even %}",
+    )
+    .unwrap();
+    let rv = env.get_template("child.txt").unwrap().render(()).unwrap();
+    assert_eq!(rv, "false");
+}


### PR DESCRIPTION
This resolves #551 . Please let me know if you want any changes made. This fix is the least disruptive one I could find. There may be a slight performance hit until the filters/tests are re-cached.