### PR TITLE
example: nit

### DIFF
--- a/examples/generate-yaml/src/main.rs
+++ b/examples/generate-yaml/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
         SyntaxConfig::builder()
             .block_delimiters("{%", "%}")
             .variable_delimiters("${{", "}}")
-            .block_delimiters("{#", "#}")
+            .comment_delimiters("{#", "#}")
             .build()
             .unwrap(),
     );


### PR DESCRIPTION
Hi,

Currently, the "generate-yaml" example fails with:
```
thread 'main' panicked at examples/generate-yaml/src/main.rs:16:14:
called `Result::unwrap()` on an `Err` value: Error { kind: InvalidDelimiter }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Here is a simple fix.