### PR TITLE
Add support for indexing into iterables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to MiniJinja are documented here.
 - Added `filesizeformat` to minijinja-contrib.  #556
 - Added support for the `loop_controls` feature which adds
   `{% break %}` and `{% continue %}`.  #558
+- Iterables can now be indexed into.  It was already possible previously
+  to slice them.  This improves support for Jinja2 compatibility as Jinja2
+  is more likely to create temporary lists when slicing lists.  #565
 
 ## 2.1.2
 

--- a/minijinja/tests/inputs/slicing.txt
+++ b/minijinja/tests/inputs/slicing.txt
@@ -15,3 +15,5 @@
 {{ intrange[::2] }}
 {{ intrange[2:10] }}
 {{ intrange[2:10:2] }}
+{{ intrange[2:10][0] }}
+{{ intrange[2:10][2:][0] }}

--- a/minijinja/tests/snapshots/test_templates__vm@slicing.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@slicing.txt.snap
@@ -1,6 +1,6 @@
 ---
 source: minijinja/tests/test_templates.rs
-description: "{{ hello[:] }}\n{{ hello[1:] }}\n{{ hello[1:-1] }}\n{{ hello[::2] }}\n{{ hello[2:10] }}\n{{ hello[2:10:2] }}\n{{ intrange[:] }}\n{{ intrange[1:] }}\n{{ intrange[1:-1] }}\n{{ intrange[::2] }}\n{{ intrange[2:10] }}\n{{ intrange[2:10:2] }}"
+description: "{{ hello[:] }}\n{{ hello[1:] }}\n{{ hello[1:-1] }}\n{{ hello[::2] }}\n{{ hello[2:10] }}\n{{ hello[2:10:2] }}\n{{ intrange[:] }}\n{{ intrange[1:] }}\n{{ intrange[1:-1] }}\n{{ intrange[::2] }}\n{{ intrange[2:10] }}\n{{ intrange[2:10:2] }}\n{{ intrange[2:10][0] }}\n{{ intrange[2:10][2:][0] }}"
 info:
   hello: Hällo Wörld
   intrange:
@@ -28,4 +28,5 @@ loWr
 [0, 2, 4, 6, 8]
 [2, 3, 4, 5, 6, 7, 8, 9]
 [2, 4, 6, 8]
-
+2
+4


### PR DESCRIPTION
This makes any iterable indexable.  They were already sliceable.

Fixes #564