### PR TITLE
Add benchmarks for `rinja`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "handlebars",
  "liquid",
  "minijinja",
+ "rinja",
  "serde",
  "serde_json",
  "tera",
@@ -1333,6 +1334,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2112,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "once_map"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed29bb6f7d6ac14023acb332a356f3891265d780e254057c866dbe7a909d2d2d"
+dependencies = [
+ "ahash",
+ "hashbrown 0.15.0",
+ "parking_lot",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,6 +2609,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rinja"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28580fecce391f3c0e65a692e5f2b5db258ba2346ee04f355ae56473ab973dc"
+dependencies = [
+ "humansize 2.1.3",
+ "itoa",
+ "num-traits",
+ "percent-encoding",
+ "rinja_derive",
+]
+
+[[package]]
+name = "rinja_derive"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f1ae91455a4c82892d9513fcfa1ac8faff6c523602d0041536341882714aede"
+dependencies = [
+ "basic-toml",
+ "memchr",
+ "mime",
+ "mime_guess",
+ "once_map",
+ "proc-macro2",
+ "quote",
+ "rinja_parser",
+ "rustc-hash",
+ "serde",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "rinja_parser"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea17639e1f35032e1c67539856e498c04cd65fe2a45f55ec437ec55e4be941"
+dependencies = [
+ "memchr",
+ "nom",
+ "serde",
+]
+
+[[package]]
 name = "roff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,6 +2662,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
@@ -2909,6 +2977,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stacker"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ These are related template engines for Rust:
 
 * [Askama](https://crates.io/crates/askama): Jinja inspired, type-safe, requires template
   precompilation. Has significant divergence from Jinja syntax in parts.
+* [Rinja](https://crates.io/crates/rinja): Jinja inspired, type-safe, requires template
+  precompilation. Has significant divergence from Jinja syntax in parts.
 * [Tera](https://crates.io/crates/tera): Jinja inspired, dynamic, has divergences from Jinja.
 * [TinyTemplate](https://crates.io/crates/tinytemplate): minimal footprint template engine
   with syntax that takes lose inspiration from Jinja and handlebars.

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 tera = "1.17.1"
 askama = "0.12.1"
+rinja = "0.3.4"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/benchmarks/rinja.toml
+++ b/benchmarks/rinja.toml
@@ -1,0 +1,2 @@
+[general]
+dirs = ["inputs"]


### PR DESCRIPTION
`rinja` is a `askama` fork made by me and another `askama` maintainer. More information about why and the main differences can be found [here](https://blog.guillaume-gomez.fr/articles/2024-07-31+docs.rs+switching+jinja+template+framework+from+tera+to+rinja).

Since `rinja` diverged "enough", I think it's worth adding it to the benchmarks list. By running it locally, I got:

```
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high mild

cmp_render/minijinja    time:   [9.1311 µs 9.1745 µs 9.2243 µs]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
cmp_render/tera         time:   [11.926 µs 11.945 µs 11.967 µs]
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
cmp_render/liquid       time:   [17.181 µs 17.301 µs 17.432 µs]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
cmp_render/handlebars   time:   [10.564 µs 10.622 µs 10.700 µs]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
cmp_render/rinja        time:   [1.7499 µs 1.7508 µs 1.7520 µs]
Found 20 outliers among 100 measurements (20.00%)
  20 (20.00%) high mild
cmp_render/askama       time:   [2.1653 µs 2.1697 µs 2.1747 µs]
```

I didn't add the numbers in the PR though but I can update them with mine. Not sure how you prefer to do it.

In any case, thanks for maintaining this project and this bench comparison list!