### PR TITLE
 Add benchmarks for `sailfish`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,7 @@ dependencies = [
  "liquid",
  "minijinja",
  "rinja",
+ "sailfish",
  "serde",
  "serde_json",
  "tera",
@@ -1135,14 +1136,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
- "windows-sys 0.42.0",
+ "libredox",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1599,6 +1600,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "itoap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9028f49264629065d057f340a86acb84867925865f73bbf8d47b4d149a7e88b8"
+
+[[package]]
 name = "jobserver"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +1676,17 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.4.0",
+ "libc",
+ "redox_syscall 0.5.7",
+]
 
 [[package]]
 name = "libyml"
@@ -1936,7 +1954,7 @@ dependencies = [
  "serde_qs",
  "serde_yml",
  "tempfile",
- "toml",
+ "toml 0.7.6",
 ]
 
 [[package]]
@@ -2147,7 +2165,7 @@ checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.42.0",
 ]
@@ -2551,6 +2569,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags 2.4.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,6 +2760,44 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "sailfish"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d5cd6d4f24f3ab107e949ab424738cf55b03deddce3b184c46985d7b1394ef"
+dependencies = [
+ "itoap",
+ "ryu",
+ "sailfish-macros",
+ "version_check",
+]
+
+[[package]]
+name = "sailfish-compiler"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7254ec7b3651f7f723a9073153f5dcddc1f2bf1bf8d1b23ac71c236ef6360d2b"
+dependencies = [
+ "filetime",
+ "home",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.71",
+ "toml 0.8.2",
+]
+
+[[package]]
+name = "sailfish-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00812289fe1891c191cc2d9db461352fc410619e07ec2bb748faaa06412619d0"
+dependencies = [
+ "proc-macro2",
+ "sailfish-compiler",
+]
 
 [[package]]
 name = "same-file"
@@ -3281,7 +3346,19 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.14",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -3298,6 +3375,19 @@ name = "toml_edit"
 version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -3636,6 +3726,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
-name = "benchmarks"
-version = "0.1.0"
 edition = "2018"
+name    = "benchmarks"
+version = "0.1.0"
 
 [features]
 speedups = ["minijinja/speedups"]
 
 [dependencies]
+askama = "0.12.1"
 handlebars = "5.1.2"
 liquid = "0.26.1"
 minijinja = { path = "../minijinja", default-features = false, features = [
@@ -14,19 +15,19 @@ minijinja = { path = "../minijinja", default-features = false, features = [
     "multi_template",
     "builtins",
 ] }
+rinja = "0.3.4"
+sailfish = "0.9.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 tera = "1.17.1"
-askama = "0.12.1"
-rinja = "0.3.4"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [[bench]]
-name = "templates"
 harness = false
+name    = "templates"
 
 [[bench]]
-name = "comparison"
 harness = false
+name    = "comparison"

--- a/benchmarks/benches/comparison.rs
+++ b/benchmarks/benches/comparison.rs
@@ -42,6 +42,14 @@ struct RinjaContext {
     title: &'static str,
 }
 
+#[derive(Serialize, Debug, sailfish::Template)]
+#[template(path = "comparison/askama.html")]
+struct SailFishContext {
+    items: Vec<String>,
+    site: Site,
+    title: &'static str,
+}
+
 macro_rules! default_context {
     ($($ty:ident),+) => {
         $(impl Default for $ty {
@@ -87,7 +95,7 @@ macro_rules! default_context {
     }
 }
 
-default_context!(Context, RinjaContext);
+default_context!(Context, RinjaContext, SailFishContext);
 
 pub fn bench_compare_compile(c: &mut Criterion) {
     let mut g = c.benchmark_group("cmp_compile");
@@ -224,6 +232,13 @@ pub fn bench_compare_render(c: &mut Criterion) {
         b.iter(|| {
             let context = black_box(Context::default());
             askama::Template::render(&context).unwrap();
+        });
+    });
+
+    g.bench_function("sailfish", |b| {
+        b.iter(|| {
+            let context = black_box(SailFishContext::default());
+            sailfish::Template::render(&context).unwrap();
         });
     });
 }

--- a/benchmarks/sailfish.toml
+++ b/benchmarks/sailfish.toml
@@ -1,0 +1,4 @@
+template_dirs = ["inputs"]
+
+[optimizations]
+rm_whitespace = false


### PR DESCRIPTION
[`sailfish`](https://github.com/rust-sailfish/sailfish) was a fork of `askama`, fourish years ago, that was designed to be more performant.

Here is the results of running `cargo bench` on my computer

| benchmark | min (µs) | median (µs) | max (µs) |
| :--- | :--- | :--- | :--- |
| cmp_render/sailfish     | 0.10779 | 0.10785  | 0.10795 |
| cmp_render/rinja        | 1.1630 | 1.1684 | 1.1756 |
| cmp_render/askama       | 1.6060 | 1.6113 | 1.6177 |
| cmp_render/minijinja    | 6.3485 | 6.3723 | 6.4054 |
| cmp_render/handlebars   | 8.5822 | 8.6305 | 8.6821 |
| cmp_render/tera         | 9.3394 | 9.3517  |9.3644 |
| cmp_render/liquid       | 14.788 | 14.868 | 14.952 |
| cmp_compile/minijinja | 6.3218 | 6.3254 | 6.3293 |
| cmp_compile/tera      | 111.98 | 113.16  |114.72 |
| cmp_compile/liquid    | 93.847 | 94.009 | 94.210 |
| cmp_compile/handlebars | 65.498 | 65.687 | 65.928 |
