### PR TITLE
Update minijinja-cabi to avoid depending on usize bit length

### DIFF
--- a/minijinja-cabi/src/value.rs
+++ b/minijinja-cabi/src/value.rs
@@ -398,7 +398,6 @@ mod tests {
 
     #[test]
     fn test_mj_value_size_and_alignment() {
-        // Compute sizes and alignments once and store them in variables
         let mj_size = mem::size_of::<mj_value>();
         let value_size = mem::size_of::<Value>();
         let mj_align = mem::align_of::<mj_value>();

--- a/minijinja-cabi/src/value.rs
+++ b/minijinja-cabi/src/value.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::ffi::{c_char, CStr, CString};
-use std::mem::{transmute, ManuallyDrop};
+use std::mem::{transmute, ManuallyDrop, size_of};
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -39,8 +39,10 @@ where
 /// Opaque value type.
 #[repr(C)]
 pub struct mj_value {
-    _opaque: [usize; 3],
+    _opaque: [u8; VALUE_SIZE],
 }
+
+const VALUE_SIZE: usize = size_of::<Value>();
 
 impl mj_value {
     pub(crate) fn into_value(self) -> Value {
@@ -51,7 +53,7 @@ impl mj_value {
 impl From<Value> for mj_value {
     fn from(value: Value) -> Self {
         mj_value {
-            _opaque: unsafe { transmute::<Value, [usize; 3]>(value) },
+            _opaque: unsafe { transmute::<Value, [u8; VALUE_SIZE]>(value) },
         }
     }
 }

--- a/minijinja-cabi/src/value.rs
+++ b/minijinja-cabi/src/value.rs
@@ -37,7 +37,7 @@ where
 }
 
 /// Opaque value type.
-#[repr(C)]
+#[repr(C, align(8))]
 pub struct mj_value {
     _opaque: [u8; VALUE_SIZE],
 }
@@ -388,5 +388,36 @@ ffi_fn! {
     /// Debug prints a value to stderr
     unsafe fn mj_value_dbg(_scope, value: mj_value) {
         eprintln!("{:?}", &value as &Value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem;
+
+    #[test]
+    fn test_mj_value_size_and_alignment() {
+        // Compute sizes and alignments once and store them in variables
+        let mj_size = mem::size_of::<mj_value>();
+        let value_size = mem::size_of::<Value>();
+        let mj_align = mem::align_of::<mj_value>();
+        let value_align = mem::align_of::<Value>();
+
+        // Check size
+        assert_eq!(
+            mj_size, value_size,
+            "Size of mj_value ({}) does not match size of Value ({})",
+            mj_size, value_size
+        );
+
+        // Check alignment
+        assert_eq!(
+            mj_align, value_align,
+            "Alignment of mj_value ({}) does not match alignment of Value ({})",
+            mj_align, value_align
+        );
+        // If the alignment requirements of `Value` evolve, the explicit alignment of
+        // `mj_value` should be updated to reflect it.
     }
 }


### PR DESCRIPTION
Hi! 

While trying to build minijinja-cabi for Wasm targets, I encountered an error due to a size mismatch on transmute operations, the reason is that `usize` is 32 bits on those targets which breaks existing assumption for usize to be 64 bits, this attempts to fix this by doing the following:

* Add `const VALUE_SIZE: usize = size_of::<Value>();`
* Change `_opaque: [usize; 3],` to `_opaque: [u8; VALUE_SIZE],` in the `mj_value` struct.
* Change `transmute::<Value, [usize; 3]>(value)` to `transmute::<Value, [u8; VALUE_SIZE]>(value)` in the `impl From<Value> for mj_value` block.

Does this look like the correct approach?

For reference here is the build error without those changes when running `cargo build -p minijinja-cabi --target wasm32-wasi`

> Compiling minijinja-cabi v2.3.1 (/workspaces/minijinja/minijinja-cabi)
> error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
>   --> minijinja-cabi/src/value.rs:47:18
>    |
> 47 |         unsafe { transmute(self._opaque) }
>    |                  ^^^^^^^^^
>    |
>    = note: source type: `[usize; 3]` (96 bits)
>    = note: target type: `Value` (192 bits)
> 
> error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
>   --> minijinja-cabi/src/value.rs:54:31
>    |
> 54 |             _opaque: unsafe { transmute::<Value, [usize; 3]>(value) },
>    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>    |
>    = note: source type: `Value` (192 bits)
>    = note: target type: `[usize; 3]` (96 bits)
> 
> error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
>    --> minijinja-cabi/src/value.rs:380:46
>     |
> 380 |         let mut value: ManuallyDrop<Value> = transmute((*value)._opaque);
>     |                                              ^^^^^^^^^
>     |
>     = note: source type: `[usize; 3]` (96 bits)
>     = note: target type: `ManuallyDrop<Value>` (192 bits)
> 
> For more information about this error, try `rustc --explain E0512`.
> warning: `minijinja-cabi` (lib) generated 1 warning (1 duplicate)
> error: could not compile `minijinja-cabi` (lib) due to 3 previous errors; 1 warning emitted