### PR TITLE
Make Kwargs fail string conversions in ArgType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to MiniJinja are documented here.
 - Updated version of `minijinja-cli` with support for better documentation,
   config file and environment variable support.  #602
 - Made the c-bindings compatible with wasm compilation.  #603
+- `String`/`Cow<str>` argument types will no longer implicitly convert
+  keyword arguments to string form.  This was an unintended foot gun.  #605
 
 ## 2.3.1
 

--- a/minijinja/src/value/deserialize.rs
+++ b/minijinja/src/value/deserialize.rs
@@ -117,7 +117,15 @@ impl<'a, T: Deserialize<'a>> ArgType<'a> for ViaDeserialize<T> {
 
     fn from_value(value: Option<&'a Value>) -> Result<Self, Error> {
         match value {
-            Some(value) => T::deserialize(value).map(ViaDeserialize),
+            Some(value) => {
+                if value.is_kwargs() {
+                    return Err(Error::new(
+                        ErrorKind::InvalidOperation,
+                        "cannot deserialize from kwargs",
+                    ));
+                }
+                T::deserialize(value).map(ViaDeserialize)
+            }
             None => Err(Error::from(ErrorKind::MissingArgument)),
         }
     }


### PR DESCRIPTION
A complete fix is not really possible without breaking backwards compatibility, but these conversions are easy to guard.

Refs #596