### PR TITLE
Fix linking error in minijinja-cabi example on Debian GNU/Linux 11

### DIFF
--- a/minijinja-cabi/example/Makefile
+++ b/minijinja-cabi/example/Makefile
@@ -1,2 +1,2 @@
 hello: hello.c
-	cc -I../include -lminijinja_cabi -L../../target/release ./hello.c -o hello
+	cc -I../include ./hello.c -L../../target/release -lminijinja_cabi -o hello


### PR DESCRIPTION
Fixes #612

Update the linking order in `minijinja-cabi/example/Makefile` to fix compilation errors on affected configurations.

* Change the linking order to place the source file `hello.c` before the library flag `-lminijinja_cabi`.
* Update the `cc` command to `cc -I../include ./hello.c -L../../target/release -lminijinja_cabi -o hello`.

