### PR TITLE
Add context for more "strict undefined behavior" cases

### DIFF
--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -488,13 +488,13 @@ impl<'env> Vm<'env> {
                 }
                 Instruction::JumpIfFalse(jump_target) => {
                     a = stack.pop();
-                    if !ok!(undefined_behavior.is_true(&a)) {
+                    if !ctx_ok!(undefined_behavior.is_true(&a)) {
                         pc = *jump_target;
                         continue;
                     }
                 }
                 Instruction::JumpIfFalseOrPop(jump_target) => {
-                    if !ok!(undefined_behavior.is_true(stack.peek())) {
+                    if !ctx_ok!(undefined_behavior.is_true(stack.peek())) {
                         pc = *jump_target;
                         continue;
                     } else {
@@ -502,7 +502,7 @@ impl<'env> Vm<'env> {
                     }
                 }
                 Instruction::JumpIfTrueOrPop(jump_target) => {
-                    if ok!(undefined_behavior.is_true(stack.peek())) {
+                    if ctx_ok!(undefined_behavior.is_true(stack.peek())) {
                         pc = *jump_target;
                         continue;
                     } else {


### PR DESCRIPTION
...and make it hard to forget to add context again.

This hit us in https://github.com/axodotdev/cargo-dist when trying to enable strict undefined behavior.

The change I _do_ care about is using `ctx_ok!` in all branches of the vm evaluation.

I added a little trick where the `ok!` macro is shadowed, so if you accidentally use it again, rustc will yell at you:

![CleanShot 2024-10-31 at 17 09 49@2x](https://github.com/user-attachments/assets/d23e86d3-4409-4a35-bbca-9a978bde7c68)

Other ideas include.. shadowing `ok!` in the first place and changing every `ctx_ok!` invocation back to `ok!`, but eh, I had to pick one. Feel free to pick your favorite / take over this PR / do whatever it takes to get this merged, all I care is that our errors have debug info :) Thanks!