### PR TITLE
Enable all features by default in minijinja-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to MiniJinja are documented here.
   rendering.  #627
 - Syntax errors caused by the lexer now include the correct position of
   the error.  #630
+- `minijinja-cli` now has all features enabled by default as documented
+  (that means also shell completion and ini).  #633
+- `minijinja-cli` now does not convert INI files to lowercase anymore.  This was
+  an unintended behavior.  #633
 
 ## 2.4.0
 

--- a/minijinja-cli/Cargo.toml
+++ b/minijinja-cli/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 rust-version = "1.65"
 
 [features]
-default = ["toml", "yaml", "querystring", "cbor", "datetime", "json5", "repl", "unicode", "contrib", "preserve_order"]
+default = ["toml", "yaml", "querystring", "cbor", "datetime", "json5", "repl", "completions", "unicode", "ini", "contrib", "preserve_order"]
 yaml = ["serde_yml"]
 querystring = ["serde_qs"]
 cbor = ["ciborium"]

--- a/minijinja-cli/README.md
+++ b/minijinja-cli/README.md
@@ -85,7 +85,7 @@ The following formats are supported:
 - `toml` (`*.toml`): TOML
 - `cbor` (`*.cbor`): CBOR
 - `querystring` (`*.qs`): URL encoded query strings
-- `ini` (`*.ini`, `*.config`, `*.properties`): text only INI files
+- `ini` (`*.ini`, `*.conf`, `*.config`, `*.properties`): text only INI files
 
 For most formats there is a pretty straightforward mapping into the template
 context.  The only exception to this is currently INI files where sections are
@@ -93,7 +93,7 @@ effectively mandatory.  If keys are placed in the unnamed section, the second
 is renamed to `default`.  You can use `--select` to make a section be implied:
 
 ```
-minijinja-cli template.j2 input.ini --section default
+minijinja-cli template.j2 input.ini --select default
 ```
 
 Note that not all formats support all input types.  For instance querystring

--- a/minijinja-cli/src/cli.rs
+++ b/minijinja-cli/src/cli.rs
@@ -112,7 +112,7 @@ fn load_data(
         #[cfg(feature = "ini")]
         "ini" => {
             let contents = String::from_utf8(contents).context("invalid utf-8")?;
-            let mut config = configparser::ini::Ini::new();
+            let mut config = configparser::ini::Ini::new_cs();
             config
                 .read(contents)
                 .map_err(|msg| anyhow::anyhow!("could not load ini: {}", msg))?;

--- a/minijinja-cli/src/command.rs
+++ b/minijinja-cli/src/command.rs
@@ -15,7 +15,11 @@ pub static SUPPORTED_FORMATS: &[(&str, &str, &[&str])] = &[
     #[cfg(feature = "cbor")]
     ("cbor", "CBOR", &["cbor"]),
     #[cfg(feature = "ini")]
-    ("ini", "INI / Config", &["ini", "conf", "config", "properties"]),
+    (
+        "ini",
+        "INI / Config",
+        &["ini", "conf", "config", "properties"],
+    ),
     #[cfg(not(feature = "json5"))]
     ("json", "JSON", &["json"]),
     #[cfg(feature = "json5")]

--- a/minijinja-cli/src/command.rs
+++ b/minijinja-cli/src/command.rs
@@ -15,7 +15,7 @@ pub static SUPPORTED_FORMATS: &[(&str, &str, &[&str])] = &[
     #[cfg(feature = "cbor")]
     ("cbor", "CBOR", &["cbor"]),
     #[cfg(feature = "ini")]
-    ("ini", "INI / Config", &["ini", "config", "properties"]),
+    ("ini", "INI / Config", &["ini", "conf", "config", "properties"]),
     #[cfg(not(feature = "json5"))]
     ("json", "JSON", &["json"]),
     #[cfg(feature = "json5")]
@@ -79,15 +79,17 @@ pub(super) fn make_command() -> Command {
                     [env var: MINIJINJA_FORMAT]"))
                 .value_parser([
                     "auto",
+                    #[cfg(feature = "cbor")]
+                    "cbor",
+                    #[cfg(feature = "ini")]
+                    "ini",
                     "json",
                     #[cfg(feature = "querystring")]
                     "querystring",
-                    #[cfg(feature = "yaml")]
-                    "yaml",
                     #[cfg(feature = "toml")]
                     "toml",
-                    #[cfg(feature = "cbor")]
-                    "cbor",
+                    #[cfg(feature = "yaml")]
+                    "yaml",
                 ]),
             arg!(-a --autoescape <MODE> "Reconfigures autoescape behavior")
                 .long_help("\

--- a/minijinja-cli/tests/snapshots/test_basic__long_help.snap
+++ b/minijinja-cli/tests/snapshots/test_basic__long_help.snap
@@ -44,6 +44,9 @@ Arguments:
           defaults to '-' which means the template is loaded from stdin.  When the format is set to
           'auto' which is the default, the extension of the filename is used to detect the format.
           
+          This argument can be set to an empty string when --template is provided to allow a data
+          file to be supplied.
+          
           [default: -]
 
   [DATA_FILE]
@@ -70,7 +73,7 @@ Options:
           
           - auto
           - cbor (CBOR): *.cbor
-          - ini (INI / Config): *.ini, *.config, *.properties
+          - ini (INI / Config): *.ini, *.conf, *.config, *.properties
           - json (JSON / JSON5): *.json, *.json5
           - querystring (Query String / Form Encoded): *.qs
           - toml (TOML): *.toml
@@ -84,7 +87,7 @@ Options:
           
           [env var: MINIJINJA_FORMAT]
           
-          [possible values: auto, json, querystring, yaml, toml, cbor]
+          [possible values: auto, cbor, ini, json, querystring, toml, yaml]
 
   -D, --define <EXPR>
           This defines an input variable for the template.  This is used in addition to the input

--- a/minijinja-cli/tests/snapshots/test_basic__short_help.snap
+++ b/minijinja-cli/tests/snapshots/test_basic__short_help.snap
@@ -20,8 +20,8 @@ Arguments:
 
 Options:
       --config-file <PATH>          Alternative path to the config file.
-  -f, --format <FORMAT>             The format of the input data [possible values: auto, json,
-                                    querystring, yaml, toml, cbor]
+  -f, --format <FORMAT>             The format of the input data [possible values: auto, cbor, ini,
+                                    json, querystring, toml, yaml]
   -D, --define <EXPR>               Defines an input variable (key=value / key:=json_value)
   -t, --template <TEMPLATE_STRING>  Render a string template
   -o, --output <FILENAME>           Path to the output file [default: -]


### PR DESCRIPTION
The doc says that all features are enabled by default, but it's not true: by default (and in the release binaries too) ini format support and shell completion aren't enabled + ini format is actually partially broken even when enabled (can't be specified in the command line).

This PR fixes the issue.