### PR TITLE
Typo n clippy

### DIFF
--- a/minijinja-py/src/typeconv.rs
+++ b/minijinja-py/src/typeconv.rs
@@ -257,7 +257,7 @@ pub fn to_python_args<'py>(
 
     if callback
         .getattr("__minijinja_pass_state__")
-        .map_or(false, |x| x.is_truthy().unwrap_or(false))
+        .is_ok_and(|x| x.is_truthy().unwrap_or(false))
     {
         py_args.push(Bound::new(py, StateRef)?.to_object(py));
     }

--- a/minijinja/src/compiler/lexer.rs
+++ b/minijinja/src/compiler/lexer.rs
@@ -87,10 +87,7 @@ fn find_start_marker_memchr(a: &str) -> Option<(usize, StartMarker, usize, White
     let bytes = a.as_bytes();
     let mut offset = 0;
     loop {
-        let idx = match memchr(&bytes[offset..], b'{') {
-            Some(idx) => idx,
-            None => return None,
-        };
+        let idx = memchr(&bytes[offset..], b'{')?;
         let marker = match bytes.get(offset + idx + 1).copied() {
             Some(b'{') => StartMarker::Variable,
             Some(b'%') => StartMarker::Block,
@@ -530,10 +527,7 @@ impl<'s> Tokenizer<'s> {
         let s = self.advance(str_len + 2);
         Ok(if has_escapes {
             (
-                Token::String(match unescape(&s[1..s.len() - 1]) {
-                    Ok(unescaped) => unescaped,
-                    Err(err) => return Err(err),
-                }),
+                Token::String(unescape(&s[1..s.len() - 1])?),
                 self.span(old_loc),
             )
         } else {

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -390,7 +390,7 @@ impl<T: Copy> Clone for Packed<T> {
 
 /// Max size of a small str.
 ///
-/// Logic: Value is 24 bytes. 1 byte is for the disciminant. One byte is
+/// Logic: Value is 24 bytes. 1 byte is for the discriminant. One byte is
 /// needed for the small str length.
 const SMALL_STR_CAP: usize = 22;
 

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -539,7 +539,7 @@ impl PartialEq for Value {
                                 if !a.try_iter_pairs().map_or(false, |mut ak| {
                                     ak.all(|(k, v1)| {
                                         a_count += 1;
-                                        b.get_value(&k).map_or(false, |v2| v1 == v2)
+                                        b.get_value(&k) == Some(v1)
                                     })
                                 }) {
                                     return false;


### PR DESCRIPTION
Interestingly, "disciminant" was missed by typos...

Also applied [clippy::question_mark](https://rust-lang.github.io/rust-clippy/master/index.html#question_mark) and [clippy::unnecessary_map_or](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or).
