### PR TITLE
Pass arguments by reference when useful and fix an undefined bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to MiniJinja are documented here.
 - Added `truncate` filter to `minijinja-contrib`.  #647
 - Added `wordcount` filter to `minijinja-contrib`.  #649
 - Added `wordwrap` filter to `minijinja-contrib`.  #651
+- Some tests and filters now pass borrowed values for performance reasons
+  and a bug was fixed that caused undefined values in strict undefined
+  mode not to work with tests.  #657
 
 ## 2.5.0
 

--- a/minijinja/src/tests.rs
+++ b/minijinja/src/tests.rs
@@ -202,7 +202,7 @@ impl BoxedTest {
 /// ```jinja
 /// {{ 42 is undefined }} -> false
 /// ```
-pub fn is_undefined(v: Value) -> bool {
+pub fn is_undefined(v: &Value) -> bool {
     v.is_undefined()
 }
 
@@ -211,7 +211,7 @@ pub fn is_undefined(v: Value) -> bool {
 /// ```jinja
 /// {{ 42 is defined }} -> true
 /// ```
-pub fn is_defined(v: Value) -> bool {
+pub fn is_defined(v: &Value) -> bool {
     !v.is_undefined()
 }
 
@@ -220,7 +220,7 @@ pub fn is_defined(v: Value) -> bool {
 /// ```jinja
 /// {{ none is none }} -> true
 /// ```
-pub fn is_none(v: Value) -> bool {
+pub fn is_none(v: &Value) -> bool {
     v.is_none()
 }
 
@@ -231,7 +231,7 @@ pub fn is_none(v: Value) -> bool {
 /// ```
 ///
 /// This filter is also registered with the `escaped` alias.
-pub fn is_safe(v: Value) -> bool {
+pub fn is_safe(v: &Value) -> bool {
     v.is_safe()
 }
 
@@ -250,7 +250,7 @@ mod builtins {
     /// {{ true is boolean }} -> true
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_boolean(v: Value) -> bool {
+    pub fn is_boolean(v: &Value) -> bool {
         v.kind() == ValueKind::Bool
     }
 
@@ -280,8 +280,8 @@ mod builtins {
     /// {{ 42 is divisibleby(2) }} -> true
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_divisibleby(v: Value, other: Value) -> bool {
-        match coerce(&v, &other, false) {
+    pub fn is_divisibleby(v: &Value, other: &Value) -> bool {
+        match coerce(v, other, false) {
             Some(CoerceResult::I128(a, b)) => (a % b) == 0,
             Some(CoerceResult::F64(a, b)) => (a % b) == 0.0,
             _ => false,
@@ -295,7 +295,7 @@ mod builtins {
     /// {{ "42" is number }} -> false
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_number(v: Value) -> bool {
+    pub fn is_number(v: &Value) -> bool {
         matches!(v.kind(), ValueKind::Number)
     }
 
@@ -306,7 +306,7 @@ mod builtins {
     /// {{ 42.0 is integer }} -> false
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_integer(v: Value) -> bool {
+    pub fn is_integer(v: &Value) -> bool {
         v.is_integer()
     }
 
@@ -317,7 +317,7 @@ mod builtins {
     /// {{ 42.0 is float }} -> true
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_float(v: Value) -> bool {
+    pub fn is_float(v: &Value) -> bool {
         matches!(v.0, crate::value::ValueRepr::F64(_))
     }
 
@@ -328,7 +328,7 @@ mod builtins {
     /// {{ 42 is string }} -> false
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_string(v: Value) -> bool {
+    pub fn is_string(v: &Value) -> bool {
         matches!(v.kind(), ValueKind::String)
     }
 
@@ -339,7 +339,7 @@ mod builtins {
     /// {{ 42 is sequence }} -> false
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_sequence(v: Value) -> bool {
+    pub fn is_sequence(v: &Value) -> bool {
         matches!(v.kind(), ValueKind::Seq)
     }
 
@@ -350,7 +350,7 @@ mod builtins {
     /// {{ 42 is iterable }} -> false
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_iterable(v: Value) -> bool {
+    pub fn is_iterable(v: &Value) -> bool {
         v.try_iter().is_ok()
     }
 
@@ -361,7 +361,7 @@ mod builtins {
     /// {{ [1, 2, 3] is mapping }} -> false
     /// ```
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
-    pub fn is_mapping(v: Value) -> bool {
+    pub fn is_mapping(v: &Value) -> bool {
         matches!(v.kind(), ValueKind::Map)
     }
 
@@ -494,7 +494,7 @@ mod builtins {
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
     #[cfg(feature = "builtins")]
     pub fn is_in(state: &State, value: &Value, other: &Value) -> Result<bool, Error> {
-        ok!(state.undefined_behavior().assert_iterable(value));
+        ok!(state.undefined_behavior().assert_iterable(other));
         Ok(crate::value::ops::contains(other, value)
             .map(|value| value.is_true())
             .unwrap_or(false))

--- a/minijinja/tests/test_environment.rs
+++ b/minijinja/tests/test_environment.rs
@@ -161,7 +161,7 @@ fn test_unknown_method_callback() {
     env.set_unknown_method_callback(|_state, value, method, args| {
         if value.kind() == ValueKind::Map && method == "items" {
             from_args::<()>(args)?;
-            minijinja::filters::items(value.clone())
+            minijinja::filters::items(value)
         } else {
             Err(Error::from(ErrorKind::UnknownMethod))
         }

--- a/minijinja/tests/test_undefined.rs
+++ b/minijinja/tests/test_undefined.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "builtins")]
 use std::collections::HashMap;
 
-use minijinja::{context, render, Environment, ErrorKind, State, UndefinedBehavior, Value};
+use minijinja::{context, render, Environment, ErrorKind, State, UndefinedBehavior};
 
 use similar_asserts::assert_eq;
 
@@ -42,12 +42,6 @@ fn test_lenient_undefined() {
 fn test_strict_undefined() {
     let mut env = Environment::new();
     env.set_undefined_behavior(UndefinedBehavior::Strict);
-    env.add_filter("test", |_state: &State, _value: String| -> String {
-        panic!("filter must not be called");
-    });
-    env.add_filter("test2", |_state: &State, _value: Value| -> String {
-        "WAS CALLED".into()
-    });
 
     assert_eq!(
         env.render_str("{{ true.missing_attribute }}", ())
@@ -97,13 +91,6 @@ fn test_strict_undefined() {
             .kind(),
         ErrorKind::InvalidOperation
     );
-    assert_eq!(
-        env.render_str("{{ undefined|test }}", ())
-            .unwrap_err()
-            .kind(),
-        ErrorKind::UndefinedError
-    );
-    assert_eq!(render!(in env, "{{ undefined|test2 }}"), "WAS CALLED");
     assert_eq!(
         env.render_str("{{ 42 in undefined }}", ())
             .unwrap_err()


### PR DESCRIPTION
This is technically a behavior change but the current behavior clearly does not make sense and is in violation with Jinja2.

For the difference in behavior see $656.  After this change, there is no difference between `Value` and `&Value` as parameter other than the borrow difference.

Fixes #656