### PR TITLE
Update state::lookup documentation to reflect updated capture behaviour

### DIFF
--- a/minijinja/src/vm/state.rs
+++ b/minijinja/src/vm/state.rs
@@ -143,8 +143,9 @@ impl<'template, 'env> State<'template, 'env> {
     ///
     /// Macros and call blocks analyze which variables are referenced and
     /// create closures for them.  This means that unless a variable is defined
-    /// as a [global](Environment::add_global) in the environment or it was
-    /// referenced by a macro, this method won't be able to find it.
+    /// as a [global](Environment::add_global) in the environment, was passed in the
+    /// initial render context, or was referenced by a macro, this method won't be 
+    /// able to find it.
     #[inline(always)]
     pub fn lookup(&self, name: &str) -> Option<Value> {
         self.ctx.load(self.env, name)


### PR DESCRIPTION
This comment is slightly misleading, as it implies that the initial template context is not passed through to State inside macros which if true, would prevent some patterns (including the example date time filter in the filters documentation: https://docs.rs/minijinja/latest/minijinja/filters/index.html#filter-configuration, which relies on a TIME_FORMAT variable passed in in the render context).

Since https://github.com/mitsuhiko/minijinja/issues/535 (released in v2.1.0), this is no longer how this works.

This updates the `State::lookup` docs to clarify the initial render context is also always available.