### PR TITLE
Fix flatten error condition for latest serde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to MiniJinja are documented here.
 - Fixed an error reporting issue for some syntax errors.  #655
 - Removed an `unsafe` code block from the `Kwargs` type internally
   which was probably unsafe.  #659
+- Fix a regression with latest serde that caused internals to leak
+  out when flattening on value handles is used.  #664
 
 ## 2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -384,7 +384,7 @@ For upgrade instructions read the [UPDATING](UPDATING.md) guide.
 
 - Added `json5` as file extension for JSON formatter.
 
-- The autoreload crate now supports fast reloading by just clearning the
+- The autoreload crate now supports fast reloading by just clearing the
   already templates.  This is enabled via `set_fast_reload` on the
   `Notifier`.
 

--- a/minijinja-cli/src/command.rs
+++ b/minijinja-cli/src/command.rs
@@ -252,7 +252,7 @@ pub(super) fn make_command() -> Command {
                     Example: minijinja-cli --template='Hello {{ name }}' -Dname=World"),
             arg!(-E --expr <EXPR> "Evaluates an template expression")
                 .long_help("\
-                    Evalues a template expression instead of rendering a template.\n\n\
+                    Evaluates a template expression instead of rendering a template.\n\n\
                     \
                     The value to the parameter is a template expression that is evaluated with the \
                     context of the template and the result is emitted according to --expr-out.  The \

--- a/minijinja-cli/tests/snapshots/test_basic__long_help.snap
+++ b/minijinja-cli/tests/snapshots/test_basic__long_help.snap
@@ -269,7 +269,7 @@ Security:
 
 Advanced:
   -E, --expr <EXPR>
-          Evalues a template expression instead of rendering a template.
+          Evaluates a template expression instead of rendering a template.
           
           The value to the parameter is a template expression that is evaluated with the context of
           the template and the result is emitted according to --expr-out.  The default output mode

--- a/minijinja/tests/test_templates.rs
+++ b/minijinja/tests/test_templates.rs
@@ -394,7 +394,7 @@ fn test_flattening_sub_item_bad_attr() {
     assert_eq!(err.kind(), ErrorKind::BadSerialization);
     assert_eq!(
         err.detail(),
-        Some("can only flatten structs and maps (got an enum)")
+        Some("can only flatten structs and maps (got a tuple struct)")
     );
 }
 
@@ -412,7 +412,7 @@ fn test_flattening_sub_item_shielded_print() {
     let value = env.render_str("{{ good }}", ctx).unwrap();
     assert_eq!(
         value,
-        r#"{"bad": <invalid value: could not serialize to value: can only flatten structs and maps (got an enum)>}"#
+        r#"{"bad": <invalid value: could not serialize to value: can only flatten structs and maps (got a tuple struct)>}"#
     );
 }
 


### PR DESCRIPTION
The latest serde release changes some internals (https://github.com/serde-rs/serde/pull/2786) which makes flatten accidentally work on our value handle in-band signalling.  This works around this by using a different code path in serde.

Refs #222

(Also fix some old typos that now fail CI)
