### PR TITLE
docs: point to add_template_owned regardless if the feature is enable…

### DIFF
--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -138,14 +138,13 @@ impl<'source> Environment<'source> {
     /// let mut env = Environment::new();
     /// env.add_template("index.html", "Hello {{ name }}!").unwrap();
     /// ```
+    /// This method fails if the template has a syntax error.
     ///
     /// Note that there are situations where the interface of this method is
     /// too restrictive as you need to hold on to the strings for the lifetime
-    /// of the environment.  This methodl fails if the template has a syntax error.
-    #[cfg_attr(
-        feature = "loader",
-        doc = "To address this restriction use [`add_template_owned`](Self::add_template_owned)."
-    )]
+    /// of the environment. To avoid this restriction use
+    /// [`add_template_owned`](Self::add_template_owned), which is available
+    /// when the `loader` feature is enabled.
     pub fn add_template(&mut self, name: &'source str, source: &'source str) -> Result<(), Error> {
         self.templates.insert(name, source)
     }


### PR DESCRIPTION
This will allow users of the library to discover `add_template_owned` and the `loader` feature if they are viewing the documentation via rust-analyzer in their IDE. Also fixes a typo "methodl" -> "method"