### PR TITLE
feat: `MediumStrict` undefined behavior that disallows emitting undefined

### DIFF
--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -796,7 +796,12 @@ impl<'source> Environment<'source> {
         state: &State,
         out: &mut Output,
     ) -> Result<(), Error> {
-        if value.is_undefined() && matches!(self.undefined_behavior, UndefinedBehavior::Strict) {
+        if value.is_undefined()
+            && matches!(
+                self.undefined_behavior,
+                UndefinedBehavior::Strict | UndefinedBehavior::MediumStrict
+            )
+        {
             Err(Error::from(ErrorKind::UndefinedError))
         } else {
             (self.formatter)(out, state, value)

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -124,6 +124,13 @@ pub enum UndefinedBehavior {
     /// * **iteration:** allowed (returns empty array)
     /// * **attribute access of undefined values:** allowed (returns [`undefined`](Value::UNDEFINED))
     Chainable,
+
+    /// Medium strict:
+    /// * **printing:** fails
+    /// * **iteration:** allowed (returns empty array)
+    /// * **testing** returns false
+    /// * **attribute access of undefined values:** fails
+    MediumStrict,
     /// Complains very quickly about undefined values.
     ///
     /// * **printing:** fails
@@ -144,8 +151,11 @@ impl UndefinedBehavior {
         match (self, parent_was_undefined) {
             (UndefinedBehavior::Lenient, false)
             | (UndefinedBehavior::Strict, false)
+            | (UndefinedBehavior::MediumStrict, false)
             | (UndefinedBehavior::Chainable, _) => Ok(Value::UNDEFINED),
-            (UndefinedBehavior::Lenient, true) | (UndefinedBehavior::Strict, true) => {
+            (UndefinedBehavior::Lenient, true)
+            | (UndefinedBehavior::Strict, true)
+            | (UndefinedBehavior::MediumStrict, true) => {
                 Err(Error::from(ErrorKind::UndefinedError))
             }
         }
@@ -176,7 +186,11 @@ impl UndefinedBehavior {
     /// Are we strict on iteration?
     #[inline]
     pub(crate) fn assert_iterable(self, value: &Value) -> Result<(), Error> {
-        if matches!(self, UndefinedBehavior::Strict) && value.is_undefined() {
+        if matches!(
+            self,
+            UndefinedBehavior::Strict | UndefinedBehavior::MediumStrict
+        ) && value.is_undefined()
+        {
             Err(Error::from(ErrorKind::UndefinedError))
         } else {
             Ok(())

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -318,7 +318,13 @@ impl<'env> Vm<'env> {
                     ok!(out.write_str(val).map_err(Error::from));
                 }
                 Instruction::Emit => {
-                    ctx_ok!(self.env.format(&stack.pop(), state, out));
+                    let value = &stack.pop();
+                    if value.is_undefined()
+                        && matches!(undefined_behavior, UndefinedBehavior::MediumStrict)
+                    {
+                        bail!(Error::from(ErrorKind::UndefinedError));
+                    }
+                    ctx_ok!(self.env.format(value, state, out));
                 }
                 Instruction::StoreLocal(name) => {
                     state.ctx.store(name, stack.pop());

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -318,13 +318,7 @@ impl<'env> Vm<'env> {
                     ok!(out.write_str(val).map_err(Error::from));
                 }
                 Instruction::Emit => {
-                    let value = &stack.pop();
-                    if value.is_undefined()
-                        && matches!(undefined_behavior, UndefinedBehavior::MediumStrict)
-                    {
-                        bail!(Error::from(ErrorKind::UndefinedError));
-                    }
-                    ctx_ok!(self.env.format(value, state, out));
+                    ctx_ok!(self.env.format(&stack.pop(), state, out));
                 }
                 Instruction::StoreLocal(name) => {
                     state.ctx.store(name, stack.pop());
@@ -371,7 +365,12 @@ impl<'env> Vm<'env> {
                     let stop = stack.pop();
                     b = stack.pop();
                     a = stack.pop();
-                    if a.is_undefined() && matches!(undefined_behavior, UndefinedBehavior::Strict) {
+                    if a.is_undefined()
+                        && matches!(
+                            undefined_behavior,
+                            UndefinedBehavior::Strict | UndefinedBehavior::MediumStrict
+                        )
+                    {
                         bail!(Error::from(ErrorKind::UndefinedError));
                     }
                     stack.push(ctx_ok!(ops::slice(a, b, stop, step)));

--- a/minijinja/tests/test_undefined.rs
+++ b/minijinja/tests/test_undefined.rs
@@ -1,9 +1,21 @@
 #![cfg(feature = "builtins")]
 use std::collections::HashMap;
 
-use minijinja::{context, render, Environment, ErrorKind, State, UndefinedBehavior};
+use minijinja::{context, render, Environment, ErrorKind, State, UndefinedBehavior, Value};
 
 use similar_asserts::assert_eq;
+
+macro_rules! assert_undefined_error {
+    ($env:expr, $template:expr) => {
+        assert_undefined_error!($env, $template, ())
+    };
+    ($env:expr, $template:expr, $context:expr) => {
+        assert_eq!(
+            $env.render_str($template, $context).unwrap_err().kind(),
+            ErrorKind::UndefinedError
+        );
+    };
+}
 
 #[test]
 fn test_lenient_undefined() {
@@ -97,6 +109,23 @@ fn test_strict_undefined() {
             .kind(),
         ErrorKind::UndefinedError
     );
+
+    assert_eq!(render!(in env, "{{ undefined | default(42) }}"), "42");
+    assert_eq!(render!(in env, "{{ 'foobar' if not undefined }}"), "foobar");
+
+    let context = context! { undefvar => Value::UNDEFINED };
+    assert_eq!(
+        render!(in env, "{{ undefvar | default(42)  }}", context),
+        "42"
+    );
+
+    assert_undefined_error!(env, "{{ 'foobar' if undefvar else 'baz'  }}", &context);
+
+    // TODO is this inconsistent with the test above?
+    assert_eq!(
+        render!(in env, "{{ 'foobar' if not undefvar }}", context),
+        "foobar"
+    );
 }
 
 #[test]
@@ -125,4 +154,85 @@ fn test_chainable_undefined() {
     assert_eq!(render!(in env, "{{ undefined|list }}"), "[]");
     assert_eq!(render!(in env, "<{{ undefined|test }}>"), "<>");
     assert_eq!(render!(in env, "{{ 42 in undefined }}"), "false");
+}
+
+#[test]
+fn test_medium_strict_undefined() {
+    let mut env = Environment::new();
+    env.set_undefined_behavior(UndefinedBehavior::MediumStrict);
+
+    assert_eq!(
+        env.render_str("{{ true.missing_attribute }}", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::UndefinedError
+    );
+    assert_eq!(
+        env.render_str("{{ undefined.missing_attribute }}", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::UndefinedError
+    );
+    assert_eq!(
+        env.render_str("<{% for x in undefined %}...{% endfor %}>", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::UndefinedError
+    );
+    assert_eq!(
+        env.render_str("{{ 'foo' is in(undefined) }}", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::UndefinedError
+    );
+    assert_eq!(
+        env.render_str("<{{ undefined }}>", ()).unwrap_err().kind(),
+        ErrorKind::UndefinedError
+    );
+    assert_eq!(render!(in env, "{{ undefined is undefined }}"), "true");
+    assert_eq!(
+        render!(in env, "{{ x.foo is undefined }}", x => HashMap::<String, String>::new()),
+        "true"
+    );
+    // TODO figure out why this passes
+    // assert_eq!(
+    //     env.render_str(
+    //         "{% if x.foo %}...{% endif %}",
+    //         context! { x => HashMap::<String, String>::new() }
+    //     )
+    //     .unwrap_err()
+    //     .kind(),
+    //     ErrorKind::UndefinedError
+    // );
+    assert_eq!(
+        env.render_str("{{ undefined|list }}", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::InvalidOperation
+    );
+    assert_eq!(
+        env.render_str("{{ 42 in undefined }}", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::UndefinedError
+    );
+
+    assert_eq!(render!(in env, "{{ undefined | default(42) }}"), "42");
+    assert_eq!(render!(in env, "{{ 'foobar' if not undefined }}"), "foobar");
+
+    let context = context! { undefvar => Value::UNDEFINED };
+    assert_eq!(
+        render!(in env, "{{ undefvar | default(42)  }}", context),
+        "42"
+    );
+
+    // This is the main change with respect to the strict behavior
+    assert_eq!(
+        render!(in env, "{{ 'foobar' if undefvar else 'baz'  }}", context),
+        "baz"
+    );
+    assert_eq!(
+        render!(in env, "{{ 'foobar' if not undefvar  }}", context),
+        "foobar"
+    );
 }


### PR DESCRIPTION
A prototype implementation for #680 

This follows strict undefined rules for iterating and attribute access, but allows testing against undefined. It disallows emitting undefined values.