### PR TITLE
add `DerefMut` to AST nodes and add rewrite test

### DIFF
--- a/minijinja/src/compiler/ast.rs
+++ b/minijinja/src/compiler/ast.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 #[cfg(feature = "internal_debug")]
 use std::fmt;
@@ -38,6 +38,12 @@ impl<T> Deref for Spanned<T> {
 
     fn deref(&self) -> &Self::Target {
         &self.node
+    }
+}
+
+impl<T> DerefMut for Spanned<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.node
     }
 }
 

--- a/minijinja/tests/snapshots/test_ast__ast.snap
+++ b/minijinja/tests/snapshots/test_ast__ast.snap
@@ -1,0 +1,24 @@
+---
+source: minijinja/tests/test_ast.rs
+expression: ast
+snapshot_kind: text
+---
+Template {
+    children: [
+        EmitExpr {
+            expr: IfExpr {
+                test_expr: Var {
+                    id: "foobar",
+                } @ 1:12-1:18,
+                true_expr: Const {
+                    value: "bar",
+                } @ 1:3-1:8,
+                false_expr: Some(
+                    Const {
+                        value: "baz",
+                    } @ 0:0-0:0,
+                ),
+            } @ 1:0-1:18,
+        } @ 1:0-1:18,
+    ],
+} @ 0:0-1:21

--- a/minijinja/tests/test_ast.rs
+++ b/minijinja/tests/test_ast.rs
@@ -1,0 +1,54 @@
+// Test AST and AST rewriting
+use minijinja::{
+    machinery::{ast::*, parse, Span, WhitespaceConfig},
+    syntax::SyntaxConfig,
+    Value,
+};
+use std::ops::DerefMut;
+
+fn make_span() -> Span {
+    Span {
+        start_line: 0,
+        start_col: 0,
+        start_offset: 0,
+        end_line: 0,
+        end_col: 0,
+        end_offset: 0,
+    }
+}
+
+/// Rewrite the if expression to always have a false body containing "baz"
+fn rewrite_if_expr(expr: &mut IfExpr) {
+    let const_el = Const {
+        value: Value::from_safe_string("baz".to_string()),
+    };
+
+    let false_body = Expr::Const(Spanned::new(const_el, make_span()));
+
+    expr.false_expr = Some(false_body);
+}
+
+#[test]
+fn test_ast() {
+    let template = "{{ 'bar' if foobar }}";
+
+    let mut ast = parse(
+        template,
+        "fn.tmpl",
+        SyntaxConfig::default(),
+        WhitespaceConfig::default(),
+    )
+    .unwrap();
+
+    if let Stmt::Template(ref mut t) = ast {
+        for c in t.children.deref_mut() {
+            if let Stmt::EmitExpr(e) = c {
+                if let Expr::IfExpr(ref mut i) = e.expr {
+                    rewrite_if_expr(i.deref_mut());
+                }
+            }
+        }
+    }
+
+    insta::assert_debug_snapshot!(ast);
+}


### PR DESCRIPTION
I am interested in the ability to modify the AST to be able to use StrictUndefined for our use case (where we would like an EmitExpr on empty else clause to not trigger the undefined behavior). It becomes possible to do so when we add `DerefMut` as a trait to the nodes. 

In another change, I also added `#[derive(Clone)]` to all the nodes so that it would be possible to clone subsets of nodes to rewrite the AST entirely.

Obviously the Span's become invalid through these AST rewrite operations.