### PR TITLE
Prototype to add `ToSource` trait to write out AST as Jinja

### DIFF
--- a/minijinja/src/compiler/mod.rs
+++ b/minijinja/src/compiler/mod.rs
@@ -6,4 +6,5 @@ pub mod instructions;
 pub mod lexer;
 pub mod meta;
 pub mod parser;
+pub mod to_source;
 pub mod tokens;

--- a/minijinja/src/compiler/to_source.rs
+++ b/minijinja/src/compiler/to_source.rs
@@ -1,0 +1,134 @@
+use std::fmt::Write;
+
+use crate::compiler::ast::CallArg;
+
+use super::ast::{BinOpKind, Expr, Stmt, Template};
+
+pub trait ToSource {
+    fn to_source(&self, f: &mut String, indent: usize) -> std::fmt::Result;
+}
+
+impl<'a> ToSource for Stmt<'a> {
+    fn to_source(&self, f: &mut String, indent: usize) -> std::fmt::Result {
+        match self {
+            Stmt::Template(t) => t.to_source(f, indent),
+            Stmt::EmitExpr(e) => {
+                write!(f, "{{{{ ")?;
+                e.expr.to_source(f, 0)?;
+                write!(f, " }}}}")
+            }
+            Stmt::EmitRaw(r) => write!(f, "{}", r.raw),
+            Stmt::ForLoop(fl) => {
+                write!(f, "{:indent$}{{% for ", "", indent = 0)?;
+                fl.target.to_source(f, 0)?;
+                write!(f, " in ")?;
+                fl.iter.to_source(f, 0)?;
+                if let Some(filter) = &fl.filter_expr {
+                    write!(f, " if ")?;
+                    filter.to_source(f, 0)?;
+                }
+                writeln!(f, " %}}")?;
+
+                for stmt in &fl.body {
+                    stmt.to_source(f, indent + 2)?;
+                    writeln!(f)?;
+                }
+
+                if !fl.else_body.is_empty() {
+                    writeln!(f, "{:indent$}{{% else %}}", "", indent = 0)?;
+                    for stmt in &fl.else_body {
+                        stmt.to_source(f, indent + 2)?;
+                        writeln!(f)?;
+                    }
+                }
+
+                write!(f, "{:indent$}{{% endfor %}}", "", indent = 0)
+            }
+            // Add other statement types...
+            _ => Ok(()),
+        }
+    }
+}
+
+impl<'a> ToSource for Expr<'a> {
+    fn to_source(&self, f: &mut String, _indent: usize) -> std::fmt::Result {
+        match self {
+            Expr::Var(v) => write!(f, "{}", v.id),
+            Expr::Const(c) => write!(f, "{}", c.value),
+            Expr::BinOp(b) => {
+                b.left.to_source(f, 0)?;
+                write!(
+                    f,
+                    " {} ",
+                    match b.op {
+                        BinOpKind::Add => "+",
+                        BinOpKind::Sub => "-",
+                        BinOpKind::Mul => "*",
+                        BinOpKind::Div => "/",
+                        BinOpKind::Eq => "==",
+                        BinOpKind::Ne => "!=",
+                        BinOpKind::Lt => "<",
+                        BinOpKind::Lte => "<=",
+                        BinOpKind::Gt => ">",
+                        BinOpKind::Gte => ">=",
+                        BinOpKind::ScAnd => "and",
+                        BinOpKind::ScOr => "or",
+                        BinOpKind::FloorDiv => "//",
+                        BinOpKind::Rem => "%",
+                        BinOpKind::Pow => "**",
+                        BinOpKind::Concat => "~",
+                        BinOpKind::In => "in",
+                    }
+                )?;
+                b.right.to_source(f, 0)
+            }
+            Expr::Call(c) => {
+                c.expr.to_source(f, 0)?;
+                write!(f, "(")?;
+                for (i, arg) in c.args.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    match arg {
+                        CallArg::Pos(e) => e.to_source(f, 0)?,
+                        CallArg::Kwarg(name, e) => {
+                            write!(f, "{}=", name)?;
+                            e.to_source(f, 0)?;
+                        }
+                        // Handle other arg types...
+                        _ => {}
+                    }
+                }
+                write!(f, ")")
+            }
+            Expr::IfExpr(if_expr) => {
+                // Write the true expression
+                if_expr.true_expr.to_source(f, 0)?;
+
+                // Write the if condition
+                write!(f, " if ")?;
+                if_expr.test_expr.to_source(f, 0)?;
+
+                // Write the else expression if it exists
+                if let Some(false_expr) = &if_expr.false_expr {
+                    write!(f, " else ")?;
+                    false_expr.to_source(f, 0)?;
+                }
+
+                Ok(())
+            }
+            // Add other expression types...
+            _ => Ok(()),
+        }
+    }
+}
+
+impl<'a> ToSource for Template<'a> {
+    fn to_source(&self, f: &mut String, indent: usize) -> std::fmt::Result {
+        for stmt in &self.children {
+            stmt.to_source(f, indent)?;
+            writeln!(f)?;
+        }
+        Ok(())
+    }
+}

--- a/minijinja/src/lib.rs
+++ b/minijinja/src/lib.rs
@@ -277,6 +277,7 @@ pub mod machinery {
     pub use crate::compiler::instructions::{Instruction, Instructions};
     pub use crate::compiler::lexer::{tokenize, Tokenizer, WhitespaceConfig};
     pub use crate::compiler::parser::{parse, parse_expr};
+    pub use crate::compiler::to_source::ToSource;
     pub use crate::compiler::tokens::{Span, Token};
     pub use crate::template::{CompiledTemplate, TemplateConfig};
     pub use crate::vm::Vm;

--- a/minijinja/tests/test_ast.rs
+++ b/minijinja/tests/test_ast.rs
@@ -1,0 +1,22 @@
+use minijinja::{
+    machinery::{parse, ToSource, WhitespaceConfig},
+    syntax::SyntaxConfig,
+};
+
+#[test]
+fn test_to_source() {
+    let template = "{{ 'bar' if foobar else 'baz' }}";
+
+    let ast = parse(
+        template,
+        "fn.tmpl",
+        SyntaxConfig::default(),
+        WhitespaceConfig::default(),
+    )
+    .unwrap();
+
+    let mut source = String::new();
+    ast.to_source(&mut source, 0).unwrap();
+
+    insta::assert_snapshot!(source);
+}


### PR DESCRIPTION
I am wondering if this would be of interest as an addition. I could imagine this being useful for our usecase in conda recipes in the future (alongside the AST editing) for automated upgrades of the Jinja used.

This adds a trait that would emit back out Jinja code.

Still needs:

- [ ] adhere to SyntaxConfig / WhitespaceConfig
- [ ] implement the rest of the expressions
- [ ] Add a number of roundtrip tests
  - [ ] Current test is actually invalid because it doesn't re-add `".."` to the string constants