### PR TITLE
Use deprecated serde_yaml in cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to MiniJinja are documented here.
   it now ensures that the iterator is not running "one item ahead".  #677
 - Fixed an issue that caused loop aliasing not to be supported for
   recursive loops.  #678
+- CLI moved from `serde_yml` to `serde_yaml`.  #684
 
 ## 2.6.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,12 +1713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e281a65eeba3d4503a2839252f86374528f9ceafe6fed97c1d3b52e1fb625c1"
-
-[[package]]
 name = "line-statements"
 version = "0.1.0"
 dependencies = [
@@ -1958,7 +1952,7 @@ dependencies = [
  "serde_json",
  "serde_json5",
  "serde_qs",
- "serde_yml",
+ "serde_yaml",
  "tempfile",
  "toml",
 ]
@@ -2826,20 +2820,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.10"
+name = "serde_yaml"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ce6afeda22f0b55dde2c34897bce76a629587348480384231205c14b59a01f"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "log",
- "memchr",
  "ryu",
  "serde",
- "serde_json",
- "tempfile",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3384,6 +3374,12 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/minijinja-cli/Cargo.toml
+++ b/minijinja-cli/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.65"
 
 [features]
 default = ["toml", "yaml", "querystring", "cbor", "datetime", "json5", "repl", "completions", "unicode", "ini", "contrib", "preserve_order"]
-yaml = ["serde_yml"]
+yaml = ["serde_yaml"]
 querystring = ["serde_qs"]
 cbor = ["ciborium"]
 datetime = ["minijinja-contrib/datetime", "minijinja-contrib/timezone"]
@@ -52,7 +52,7 @@ serde = { version = "1.0.183", features = ["derive", "rc"] }
 serde_json = "1.0.105"
 serde_json5 = { version = "0.1.0", optional = true }
 serde_qs = { version = "0.12.0", optional = true }
-serde_yml = { version = "0.0.10", optional = true }
+serde_yaml = { version = "0.9.34", optional = true }
 tempfile = "3.9.0"
 toml = { version = "0.7.6", optional = true }
 clap_complete = { version = "4", optional = true }

--- a/minijinja-cli/src/cli.rs
+++ b/minijinja-cli/src/cli.rs
@@ -101,9 +101,9 @@ fn load_data(
         #[cfg(feature = "yaml")]
         "yaml" => {
             // for merge keys to work we need to manually call `apply_merge`.
-            // For this reason we need to deserialize into a serde_yml::Value
+            // For this reason we need to deserialize into a serde_yaml::Value
             // before converting it into a final value.
-            let mut v: serde_yml::Value = serde_yml::from_slice(&contents)?;
+            let mut v: serde_yaml::Value = serde_yaml::from_slice(&contents)?;
             v.apply_merge()?;
             Value::from_serialize(v)
         }

--- a/minijinja-cli/src/config.rs
+++ b/minijinja-cli/src/config.rs
@@ -334,7 +334,7 @@ fn interpret_raw_value(s: &str) -> Result<Value, Error> {
     }
     #[cfg(feature = "yaml")]
     mod imp {
-        pub use serde_yml::from_str;
+        pub use serde_yaml::from_str;
         pub const FMT: &str = "JSON";
     }
     imp::from_str::<Value>(s)


### PR DESCRIPTION
This moves minijinja-cli back to the deprecated `serde_yaml`.

Refs https://github.com/BurntSushi/jiff/pull/225