### PR TITLE
Fix undefineds in some places not reporting proper errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to MiniJinja are documented here.
 - Fixed an issue that caused loop aliasing not to be supported for
   recursive loops.  #678
 - CLI moved from `serde_yml` to `serde_yaml`.  #684
+- Improved undefined error reporting.  Undefined values will now in most
+  cases point to exactly where the error happened.  #686
 
 ## 2.6.0
 

--- a/minijinja/src/compiler/ast.rs
+++ b/minijinja/src/compiler/ast.rs
@@ -186,6 +186,24 @@ impl Expr<'_> {
             Expr::Filter(_) => "filter expression",
         }
     }
+
+    pub fn span(&self) -> Span {
+        match self {
+            Expr::Var(s) => s.span(),
+            Expr::Const(s) => s.span(),
+            Expr::Slice(s) => s.span(),
+            Expr::UnaryOp(s) => s.span(),
+            Expr::BinOp(s) => s.span(),
+            Expr::IfExpr(s) => s.span(),
+            Expr::Filter(s) => s.span(),
+            Expr::Test(s) => s.span(),
+            Expr::GetAttr(s) => s.span(),
+            Expr::GetItem(s) => s.span(),
+            Expr::Call(s) => s.span(),
+            Expr::List(s) => s.span(),
+            Expr::Map(s) => s.span(),
+        }
+    }
 }
 
 /// Root template node.

--- a/minijinja/tests/inputs/err_strict_undefined_for.txt
+++ b/minijinja/tests/inputs/err_strict_undefined_for.txt
@@ -1,0 +1,5 @@
+{"$settings": {"undefined": "strict"}}
+---
+{% for item in undefined_value %}
+    ...
+{% endfor %}

--- a/minijinja/tests/inputs/err_strict_undefined_for_filter.txt
+++ b/minijinja/tests/inputs/err_strict_undefined_for_filter.txt
@@ -1,0 +1,5 @@
+{"$settings": {"undefined": "strict"}}
+---
+{% for item in [undefined_value] if item %}
+    ...
+{% endfor %}

--- a/minijinja/tests/inputs/err_strict_undefined_if.txt
+++ b/minijinja/tests/inputs/err_strict_undefined_if.txt
@@ -1,0 +1,5 @@
+{"$settings": {"undefined": "strict"}}
+---
+{% if undefined_value %}
+    ...
+{% endif %}

--- a/minijinja/tests/inputs/err_strict_undefined_print.txt
+++ b/minijinja/tests/inputs/err_strict_undefined_print.txt
@@ -1,0 +1,3 @@
+{"$settings": {"undefined": "strict"}}
+---
+{{ undefined_value }}

--- a/minijinja/tests/snapshots/test_templates__vm@err_strict_undefined_for.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@err_strict_undefined_for.txt.snap
@@ -1,0 +1,25 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{% for item in undefined_value %}\n    ...\n{% endfor %}"
+info:
+  $settings:
+    undefined: strict
+input_file: minijinja/tests/inputs/err_strict_undefined_for.txt
+---
+!!!ERROR!!!
+
+Error {
+    kind: UndefinedError,
+    name: "err_strict_undefined_for.txt",
+    line: 1,
+}
+
+undefined value (in err_strict_undefined_for.txt:1)
+------------------------ err_strict_undefined_for.txt -------------------------
+   1 > {% for item in undefined_value %}
+     i                ^^^^^^^^^^^^^^^ undefined value
+   2 |     ...
+   3 | {% endfor %}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+No referenced variables
+-------------------------------------------------------------------------------

--- a/minijinja/tests/snapshots/test_templates__vm@err_strict_undefined_for_filter.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@err_strict_undefined_for_filter.txt.snap
@@ -1,0 +1,27 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{% for item in [undefined_value] if item %}\n    ...\n{% endfor %}"
+info:
+  $settings:
+    undefined: strict
+input_file: minijinja/tests/inputs/err_strict_undefined_for_filter.txt
+---
+!!!ERROR!!!
+
+Error {
+    kind: UndefinedError,
+    name: "err_strict_undefined_for_filter.txt",
+    line: 1,
+}
+
+undefined value (in err_strict_undefined_for_filter.txt:1)
+--------------------- err_strict_undefined_for_filter.txt ---------------------
+   1 > {% for item in [undefined_value] if item %}
+     i                                     ^^^^ undefined value
+   2 |     ...
+   3 | {% endfor %}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Referenced variables: {
+    item: undefined,
+}
+-------------------------------------------------------------------------------

--- a/minijinja/tests/snapshots/test_templates__vm@err_strict_undefined_if.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@err_strict_undefined_if.txt.snap
@@ -1,0 +1,25 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{% if undefined_value %}\n    ...\n{% endif %}"
+info:
+  $settings:
+    undefined: strict
+input_file: minijinja/tests/inputs/err_strict_undefined_if.txt
+---
+!!!ERROR!!!
+
+Error {
+    kind: UndefinedError,
+    name: "err_strict_undefined_if.txt",
+    line: 1,
+}
+
+undefined value (in err_strict_undefined_if.txt:1)
+------------------------- err_strict_undefined_if.txt -------------------------
+   1 > {% if undefined_value %}
+     i       ^^^^^^^^^^^^^^^ undefined value
+   2 |     ...
+   3 | {% endif %}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+No referenced variables
+-------------------------------------------------------------------------------

--- a/minijinja/tests/snapshots/test_templates__vm@err_strict_undefined_print.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@err_strict_undefined_print.txt.snap
@@ -1,0 +1,23 @@
+---
+source: minijinja/tests/test_templates.rs
+description: "{{ undefined_value }}"
+info:
+  $settings:
+    undefined: strict
+input_file: minijinja/tests/inputs/err_strict_undefined_print.txt
+---
+!!!ERROR!!!
+
+Error {
+    kind: UndefinedError,
+    name: "err_strict_undefined_print.txt",
+    line: 1,
+}
+
+undefined value (in err_strict_undefined_print.txt:1)
+----------------------- err_strict_undefined_print.txt ------------------------
+   1 > {{ undefined_value }}
+     i    ^^^^^^^^^^^^^^^ undefined value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+No referenced variables
+-------------------------------------------------------------------------------

--- a/minijinja/tests/snapshots/test_templates__vm@loop-recursion-error.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@loop-recursion-error.txt.snap
@@ -20,6 +20,7 @@ Error {
 invalid operation: recursion limit exceeded (in loop-recursion-error.txt:1)
 -------------------------- loop-recursion-error.txt ---------------------------
    1 > {% for item in seq recursive %}
+     i                ^^^ invalid operation
    2 |   {{ loop(seq) }}
    3 | {% endfor %}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/minijinja/tests/snapshots/test_templates__vm@loop_over_non_iterable.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@loop_over_non_iterable.txt.snap
@@ -17,9 +17,9 @@ Error {
 invalid operation: number is not iterable (in loop_over_non_iterable.txt:1)
 ------------------------- loop_over_non_iterable.txt --------------------------
    1 > [{% for item in seq %}{% endfor %}]
+     i                 ^^^ invalid operation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Referenced variables: {
     seq: 42,
 }
 -------------------------------------------------------------------------------
-

--- a/minijinja/tests/test_templates.rs
+++ b/minijinja/tests/test_templates.rs
@@ -11,10 +11,43 @@ use std::sync::Arc;
 use std::{env, fs};
 
 use insta::assert_snapshot;
+use minijinja::syntax::SyntaxConfig;
 use minijinja::value::{Enumerator, Object, ObjectRepr, Rest, Value};
-use minijinja::{context, render, Environment, Error, ErrorKind, State};
+use minijinja::{context, render, Environment, Error, ErrorKind, State, UndefinedBehavior};
 
+use serde::Deserialize;
 use similar_asserts::assert_eq;
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct TestSettings {
+    keep_trailing_newline: bool,
+    lstrip_blocks: bool,
+    trim_blocks: bool,
+    markers: Option<[String; 6]>,
+    line_statement_prefix: Option<String>,
+    line_comment_prefix: Option<String>,
+    undefined: Option<String>,
+}
+
+impl TestSettings {
+    pub fn into_syntax(self) -> SyntaxConfig {
+        let mut builder = SyntaxConfig::builder();
+        if let Some(ref markers) = self.markers {
+            builder
+                .block_delimiters(markers[0].to_string(), markers[1].to_string())
+                .variable_delimiters(markers[2].to_string(), markers[3].to_string())
+                .comment_delimiters(markers[4].to_string(), markers[5].to_string());
+        }
+        if let Some(prefix) = self.line_statement_prefix {
+            builder.line_statement_prefix(prefix);
+        }
+        if let Some(prefix) = self.line_comment_prefix {
+            builder.line_comment_prefix(prefix);
+        }
+        builder.build().unwrap()
+    }
+}
 
 #[test]
 fn test_vm() {
@@ -40,6 +73,22 @@ fn test_vm() {
             Value::from(args.0)
         });
         let ctx: Value = serde_json::from_str(iter.next().unwrap()).unwrap();
+        let settings =
+            if let Some(settings) = ctx.get_attr("$settings").ok().filter(|x| !x.is_undefined()) {
+                TestSettings::deserialize(settings).unwrap()
+            } else {
+                TestSettings::default()
+            };
+        env.set_undefined_behavior(match settings.undefined.as_deref() {
+            Some("strict") => UndefinedBehavior::Strict,
+            Some("lenient") | None => UndefinedBehavior::Lenient,
+            Some("chainable") => UndefinedBehavior::Chainable,
+            Some(other) => panic!("unknown undefined behavior '{}'", other),
+        });
+        env.set_keep_trailing_newline(settings.keep_trailing_newline);
+        env.set_trim_blocks(settings.trim_blocks);
+        env.set_lstrip_blocks(settings.lstrip_blocks);
+        env.set_syntax(settings.into_syntax());
 
         for (path, source) in &refs {
             let ref_filename = path.file_name().unwrap().to_str().unwrap();

--- a/minijinja/tests/test_templates.rs
+++ b/minijinja/tests/test_templates.rs
@@ -3,6 +3,7 @@
     feature = "macros",
     feature = "builtins",
     feature = "adjacent_loop_items",
+    feature = "custom_syntax",
     feature = "deserialization"
 ))]
 use std::collections::BTreeMap;


### PR DESCRIPTION
MiniJinja did not report proper information about what is undefined

## Before

```
undefined value (in err_strict_undefined_if.txt:1)
------------------------- err_strict_undefined_if.txt -------------------------
   1 > {% if undefined_value %}
   2 |     ...
   3 | {% endif %}
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
No referenced variables
-------------------------------------------------------------------------------
```

## After

```
undefined value (in err_strict_undefined_if.txt:1)
------------------------- err_strict_undefined_if.txt -------------------------
   1 > {% if undefined_value %}
     i       ^^^^^^^^^^^^^^^ undefined value
   2 |     ...
   3 | {% endif %}
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
No referenced variables
-------------------------------------------------------------------------------
```
