### PR TITLE
Add SemiStrict and improve Jinja2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to MiniJinja are documented here.
 
+## 2.8.0
+
+- Added `MostlyStrict` undefined mode that is like strict but allows
+  to be checked for truthiness.  Additionally an if expression without
+  an else block will always produce a silent undefined object that
+  never errors for compatibility with Jinja2.  #687
+
 ## 2.7.0
 
 - Removed string interning.  #675

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to MiniJinja are documented here.
 
 ## 2.8.0
 
-- Added `MostlyStrict` undefined mode that is like strict but allows
+- Added `SemiStrict` undefined mode that is like strict but allows
   to be checked for truthiness.  Additionally an if expression without
   an else block will always produce a silent undefined object that
   never errors for compatibility with Jinja2.  #687

--- a/minijinja/src/compiler/codegen.rs
+++ b/minijinja/src/compiler/codegen.rs
@@ -661,7 +661,8 @@ impl<'source> CodeGenerator<'source> {
                     self.compile_expr(false_expr);
                 } else {
                     // special behavior: missing false block have a silent undefined
-                    // to permit special casing.
+                    // to permit special casing.  This is for compatibility also with
+                    // what Jinja2 does.
                     self.add(Instruction::LoadConst(ValueRepr::SilentUndefined.into()));
                 }
                 self.end_if();

--- a/minijinja/src/compiler/codegen.rs
+++ b/minijinja/src/compiler/codegen.rs
@@ -7,7 +7,7 @@ use crate::compiler::instructions::{
 use crate::compiler::tokens::Span;
 use crate::output::CaptureMode;
 use crate::value::ops::neg;
-use crate::value::{Kwargs, Value, ValueMap};
+use crate::value::{Kwargs, Value, ValueMap, ValueRepr};
 
 #[cfg(test)]
 use similar_asserts::assert_eq;
@@ -651,7 +651,9 @@ impl<'source> CodeGenerator<'source> {
                 if let Some(ref false_expr) = i.false_expr {
                     self.compile_expr(false_expr);
                 } else {
-                    self.add(Instruction::LoadConst(Value::UNDEFINED));
+                    // special behavior: missing false block have a silent undefined
+                    // to permit special casing.
+                    self.add(Instruction::LoadConst(ValueRepr::SilentUndefined.into()));
                 }
                 self.end_if();
             }

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -13,7 +13,7 @@ use crate::expression::Expression;
 use crate::output::Output;
 use crate::template::{CompiledTemplate, CompiledTemplateRef, Template, TemplateConfig};
 use crate::utils::{AutoEscape, BTreeMapKeysDebug, UndefinedBehavior};
-use crate::value::{FunctionArgs, FunctionResult, Value};
+use crate::value::{FunctionArgs, FunctionResult, Value, ValueRepr};
 use crate::vm::State;
 use crate::{defaults, filters, functions, tests};
 
@@ -796,10 +796,12 @@ impl<'source> Environment<'source> {
         state: &State,
         out: &mut Output,
     ) -> Result<(), Error> {
-        if value.is_undefined() && matches!(self.undefined_behavior, UndefinedBehavior::Strict) {
-            Err(Error::from(ErrorKind::UndefinedError))
-        } else {
-            (self.formatter)(out, state, value)
+        match (self.undefined_behavior, &value.0) {
+            (UndefinedBehavior::Strict, &ValueRepr::Undefined | &ValueRepr::SilentUndefined)
+            | (UndefinedBehavior::MostlyStrict, &ValueRepr::Undefined) => {
+                Err(Error::from(ErrorKind::UndefinedError))
+            }
+            _ => (self.formatter)(out, state, value),
         }
     }
 

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -797,10 +797,13 @@ impl<'source> Environment<'source> {
         out: &mut Output,
     ) -> Result<(), Error> {
         match (self.undefined_behavior, &value.0) {
-            (UndefinedBehavior::Strict, &ValueRepr::Undefined | &ValueRepr::SilentUndefined)
-            | (UndefinedBehavior::MostlyStrict, &ValueRepr::Undefined) => {
-                Err(Error::from(ErrorKind::UndefinedError))
-            }
+            // this intentionally does not check for SilentUndefined.  SilentUndefined is
+            // exclusively used in the missing else condition of an if expression to match
+            // Jinja2 behavior.  Those go straight to the formatter.
+            (
+                UndefinedBehavior::Strict | UndefinedBehavior::MostlyStrict,
+                &ValueRepr::Undefined,
+            ) => Err(Error::from(ErrorKind::UndefinedError)),
             _ => (self.formatter)(out, state, value),
         }
     }

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -800,10 +800,9 @@ impl<'source> Environment<'source> {
             // this intentionally does not check for SilentUndefined.  SilentUndefined is
             // exclusively used in the missing else condition of an if expression to match
             // Jinja2 behavior.  Those go straight to the formatter.
-            (
-                UndefinedBehavior::Strict | UndefinedBehavior::MostlyStrict,
-                &ValueRepr::Undefined,
-            ) => Err(Error::from(ErrorKind::UndefinedError)),
+            (UndefinedBehavior::Strict | UndefinedBehavior::SemiStrict, &ValueRepr::Undefined) => {
+                Err(Error::from(ErrorKind::UndefinedError))
+            }
             _ => (self.formatter)(out, state, value),
         }
     }

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -706,7 +706,7 @@ mod builtins {
         let iter = ok!(state.undefined_behavior().try_iter(values));
         for value in iter {
             if value.is_undefined() {
-                ok!(state.undefined_behavior().handle_undefined(&value));
+                ok!(state.undefined_behavior().handle_undefined(false));
                 continue;
             } else if !value.is_number() {
                 return Err(Error::new(

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -636,7 +636,9 @@ mod builtins {
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
     pub fn int(value: &Value) -> Result<Value, Error> {
         match &value.0 {
-            ValueRepr::Undefined | ValueRepr::None => Ok(Value::from(0)),
+            ValueRepr::Undefined | ValueRepr::SilentUndefined | ValueRepr::None => {
+                Ok(Value::from(0))
+            }
             ValueRepr::Bool(x) => Ok(Value::from(*x as u64)),
             ValueRepr::U64(_) | ValueRepr::I64(_) | ValueRepr::U128(_) | ValueRepr::I128(_) => {
                 Ok(value.clone())
@@ -669,7 +671,9 @@ mod builtins {
     #[cfg_attr(docsrs, doc(cfg(feature = "builtins")))]
     pub fn float(value: &Value) -> Result<Value, Error> {
         match &value.0 {
-            ValueRepr::Undefined | ValueRepr::None => Ok(Value::from(0.0)),
+            ValueRepr::Undefined | ValueRepr::SilentUndefined | ValueRepr::None => {
+                Ok(Value::from(0.0))
+            }
             ValueRepr::Bool(x) => Ok(Value::from(*x as u64 as f64)),
             ValueRepr::String(..) | ValueRepr::SmallStr(_) => value
                 .as_str()
@@ -698,7 +702,7 @@ mod builtins {
         let iter = ok!(state.undefined_behavior().try_iter(values));
         for value in iter {
             if value.is_undefined() {
-                ok!(state.undefined_behavior().handle_undefined(false));
+                ok!(state.undefined_behavior().handle_undefined(&value));
                 continue;
             } else if !value.is_number() {
                 return Err(Error::new(
@@ -1186,7 +1190,9 @@ mod builtins {
             Ok(rv)
         } else {
             match &value.0 {
-                ValueRepr::None | ValueRepr::Undefined => Ok("".into()),
+                ValueRepr::None | ValueRepr::Undefined | ValueRepr::SilentUndefined => {
+                    Ok("".into())
+                }
                 ValueRepr::Bytes(b) => Ok(percent_encoding::percent_encode(b, SET).to_string()),
                 ValueRepr::String(..) | ValueRepr::SmallStr(_) => Ok(
                     percent_encoding::utf8_percent_encode(value.as_str().unwrap(), SET).to_string(),

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -336,7 +336,7 @@ mod builtins {
         let mut rv = match value {
             None => ValueMap::default(),
             Some(value) => match value.0 {
-                ValueRepr::Undefined => ValueMap::default(),
+                ValueRepr::Undefined | ValueRepr::SilentUndefined => ValueMap::default(),
                 ValueRepr::Object(obj) if obj.repr() == ObjectRepr::Map => {
                     obj.try_iter_pairs().into_iter().flatten().collect()
                 }

--- a/minijinja/src/syntax.rs
+++ b/minijinja/src/syntax.rs
@@ -180,6 +180,15 @@
 //! {{ title|upper if title }}
 //! ```
 //!
+//! Note that for compatibility with Jinja2, when the `else` block is missing the undefined
+//! value will be marked as "silent".  This means even if strict undefined behavior is
+//! requested, this undefined value will print to an empty string.  This means
+//! that this is always valid:
+//!
+//! ```jinja
+//! {{ value if false }} -> prints an empty string (silent undefined returned from else)
+//! ```
+//!
 //! # Tags
 //!
 //! Tags control logic in templates.  The following tags exist:

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -172,9 +172,6 @@ impl UndefinedBehavior {
             (UndefinedBehavior::Strict, &ValueRepr::Undefined | &ValueRepr::SilentUndefined) => {
                 Err(Error::from(ErrorKind::UndefinedError))
             }
-            (UndefinedBehavior::MostlyStrict, &ValueRepr::Undefined) => {
-                Err(Error::from(ErrorKind::UndefinedError))
-            }
             _ => Ok(value.is_true()),
         }
     }

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -116,6 +116,7 @@ pub enum UndefinedBehavior {
     /// * **printing:** allowed (returns empty string)
     /// * **iteration:** allowed (returns empty array)
     /// * **attribute access of undefined values:** fails
+    /// * **if true:** allowed (is false)
     #[default]
     Lenient,
     /// Like `Lenient`, but also allows chaining of undefined lookups.
@@ -123,6 +124,7 @@ pub enum UndefinedBehavior {
     /// * **printing:** allowed (returns empty string)
     /// * **iteration:** allowed (returns empty array)
     /// * **attribute access of undefined values:** allowed (returns [`undefined`](Value::UNDEFINED))
+    /// * **if true:** allowed (is false)
     Chainable,
     /// Complains very quickly about undefined values but not quite as strictly.
     ///
@@ -134,12 +136,14 @@ pub enum UndefinedBehavior {
     /// * **printing:** fails (most of the time, see disclaimer)
     /// * **iteration:** fails (most of the time, see disclaimer)
     /// * **attribute access of undefined values:** fails
+    /// * **if true:** allowed (is false)
     MostlyStrict,
     /// Complains very quickly about undefined values.
     ///
     /// * **printing:** fails
     /// * **iteration:** fails
     /// * **attribute access of undefined values:** fails
+    /// * **if true:** fails
     Strict,
 }
 

--- a/minijinja/src/value/argtypes.rs
+++ b/minijinja/src/value/argtypes.rs
@@ -937,7 +937,9 @@ impl TryFrom<Value> for Kwargs {
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         match value.0 {
-            ValueRepr::Undefined => Ok(Kwargs::new(Default::default())),
+            ValueRepr::Undefined | ValueRepr::SilentUndefined => {
+                Ok(Kwargs::new(Default::default()))
+            }
             ValueRepr::Object(_) => {
                 Kwargs::extract(&value).ok_or_else(|| Error::from(ErrorKind::InvalidOperation))
             }

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -410,7 +410,10 @@ impl SmallStr {
 
 #[derive(Clone)]
 pub(crate) enum ValueRepr {
+    /// The regular undefined type produced as part of template evaluation
     Undefined,
+    /// A special undefined marker that indicates an always-quiet undefined.
+    /// This is emitted for ternary expressions with missing else blocks.
     SilentUndefined,
     Bool(bool),
     U64(u64),

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -411,6 +411,7 @@ impl SmallStr {
 #[derive(Clone)]
 pub(crate) enum ValueRepr {
     Undefined,
+    SilentUndefined,
     Bool(bool),
     U64(u64),
     I64(i64),
@@ -428,7 +429,7 @@ pub(crate) enum ValueRepr {
 impl fmt::Debug for ValueRepr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            ValueRepr::Undefined => f.write_str("undefined"),
+            ValueRepr::Undefined | ValueRepr::SilentUndefined => f.write_str("undefined"),
             ValueRepr::Bool(ref val) => fmt::Debug::fmt(val, f),
             ValueRepr::U64(ref val) => fmt::Debug::fmt(val, f),
             ValueRepr::I64(ref val) => fmt::Debug::fmt(val, f),
@@ -458,7 +459,7 @@ impl fmt::Debug for ValueRepr {
 impl Hash for Value {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self.0 {
-            ValueRepr::None | ValueRepr::Undefined => 0u8.hash(state),
+            ValueRepr::None | ValueRepr::Undefined | ValueRepr::SilentUndefined => 0u8.hash(state),
             ValueRepr::String(ref s, _) => s.hash(state),
             ValueRepr::SmallStr(ref s) => s.as_str().hash(state),
             ValueRepr::Bool(b) => b.hash(state),
@@ -488,7 +489,10 @@ impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
         match (&self.0, &other.0) {
             (&ValueRepr::None, &ValueRepr::None) => true,
-            (&ValueRepr::Undefined, &ValueRepr::Undefined) => true,
+            (
+                &ValueRepr::Undefined | &ValueRepr::SilentUndefined,
+                &ValueRepr::Undefined | &ValueRepr::SilentUndefined,
+            ) => true,
             (&ValueRepr::String(ref a, _), &ValueRepr::String(ref b, _)) => a == b,
             (&ValueRepr::SmallStr(ref a), &ValueRepr::SmallStr(ref b)) => a.as_str() == b.as_str(),
             (&ValueRepr::Bytes(ref a), &ValueRepr::Bytes(ref b)) => a == b,
@@ -578,7 +582,10 @@ impl Ord for Value {
         }
         match (&self.0, &other.0) {
             (&ValueRepr::None, &ValueRepr::None) => Ordering::Equal,
-            (&ValueRepr::Undefined, &ValueRepr::Undefined) => Ordering::Equal,
+            (
+                &ValueRepr::Undefined | &ValueRepr::SilentUndefined,
+                &ValueRepr::Undefined | &ValueRepr::SilentUndefined,
+            ) => Ordering::Equal,
             (&ValueRepr::String(ref a, _), &ValueRepr::String(ref b, _)) => a.cmp(b),
             (&ValueRepr::SmallStr(ref a), &ValueRepr::SmallStr(ref b)) => {
                 a.as_str().cmp(b.as_str())
@@ -632,7 +639,7 @@ impl fmt::Debug for Value {
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
-            ValueRepr::Undefined => Ok(()),
+            ValueRepr::Undefined | ValueRepr::SilentUndefined => Ok(()),
             ValueRepr::Bool(val) => val.fmt(f),
             ValueRepr::U64(val) => val.fmt(f),
             ValueRepr::I64(val) => val.fmt(f),
@@ -1043,7 +1050,7 @@ impl Value {
     /// perform operations on it.
     pub fn kind(&self) -> ValueKind {
         match self.0 {
-            ValueRepr::Undefined => ValueKind::Undefined,
+            ValueRepr::Undefined | ValueRepr::SilentUndefined => ValueKind::Undefined,
             ValueRepr::Bool(_) => ValueKind::Bool,
             ValueRepr::U64(_) | ValueRepr::I64(_) | ValueRepr::F64(_) => ValueKind::Number,
             ValueRepr::None => ValueKind::None,
@@ -1107,7 +1114,10 @@ impl Value {
             ValueRepr::String(ref x, _) => !x.is_empty(),
             ValueRepr::SmallStr(ref x) => !x.is_empty(),
             ValueRepr::Bytes(ref x) => !x.is_empty(),
-            ValueRepr::None | ValueRepr::Undefined | ValueRepr::Invalid(_) => false,
+            ValueRepr::None
+            | ValueRepr::Undefined
+            | ValueRepr::SilentUndefined
+            | ValueRepr::Invalid(_) => false,
             ValueRepr::Object(ref x) => x.is_true(),
         }
     }
@@ -1119,7 +1129,7 @@ impl Value {
 
     /// Returns `true` if this value is undefined.
     pub fn is_undefined(&self) -> bool {
-        matches!(&self.0, ValueRepr::Undefined)
+        matches!(&self.0, ValueRepr::Undefined | ValueRepr::SilentUndefined)
     }
 
     /// Returns `true` if this value is none.
@@ -1220,7 +1230,9 @@ impl Value {
     /// ```
     pub fn get_attr(&self, key: &str) -> Result<Value, Error> {
         let value = match self.0 {
-            ValueRepr::Undefined => return Err(Error::from(ErrorKind::UndefinedError)),
+            ValueRepr::Undefined | ValueRepr::SilentUndefined => {
+                return Err(Error::from(ErrorKind::UndefinedError))
+            }
             ValueRepr::Object(ref dy) => dy.get_value(&Value::from(key)),
             _ => None,
         };
@@ -1271,7 +1283,7 @@ impl Value {
     /// assert_eq!(value.to_string(), "Foo");
     /// ```
     pub fn get_item(&self, key: &Value) -> Result<Value, Error> {
-        if let ValueRepr::Undefined = self.0 {
+        if let ValueRepr::Undefined | ValueRepr::SilentUndefined = self.0 {
             Err(Error::from(ErrorKind::UndefinedError))
         } else {
             Ok(self.get_item_opt(key).unwrap_or(Value::UNDEFINED))
@@ -1305,7 +1317,9 @@ impl Value {
     /// ```
     pub fn try_iter(&self) -> Result<ValueIter, Error> {
         match self.0 {
-            ValueRepr::None | ValueRepr::Undefined => Some(ValueIterImpl::Empty),
+            ValueRepr::None | ValueRepr::Undefined | ValueRepr::SilentUndefined => {
+                Some(ValueIterImpl::Empty)
+            }
             ValueRepr::String(ref s, _) => {
                 Some(ValueIterImpl::Chars(0, s.chars().count(), Arc::clone(s)))
             }
@@ -1336,7 +1350,9 @@ impl Value {
     ///   reversible itself, it consumes it and then reverses it.
     pub fn reverse(&self) -> Result<Value, Error> {
         match self.0 {
-            ValueRepr::Undefined | ValueRepr::None => Some(self.clone()),
+            ValueRepr::Undefined | ValueRepr::SilentUndefined | ValueRepr::None => {
+                Some(self.clone())
+            }
             ValueRepr::String(ref s, _) => Some(Value::from(s.chars().rev().collect::<String>())),
             ValueRepr::SmallStr(ref s) => {
                 // TODO: add small str optimization here
@@ -1627,9 +1643,10 @@ impl Serialize for Value {
             ValueRepr::U64(u) => serializer.serialize_u64(u),
             ValueRepr::I64(i) => serializer.serialize_i64(i),
             ValueRepr::F64(f) => serializer.serialize_f64(f),
-            ValueRepr::None | ValueRepr::Undefined | ValueRepr::Invalid(_) => {
-                serializer.serialize_unit()
-            }
+            ValueRepr::None
+            | ValueRepr::Undefined
+            | ValueRepr::SilentUndefined
+            | ValueRepr::Invalid(_) => serializer.serialize_unit(),
             ValueRepr::U128(u) => serializer.serialize_u128(u.0),
             ValueRepr::I128(i) => serializer.serialize_i128(i.0),
             ValueRepr::String(ref s, _) => serializer.serialize_str(s),

--- a/minijinja/src/value/ops.rs
+++ b/minijinja/src/value/ops.rs
@@ -134,7 +134,9 @@ pub fn slice(value: Value, start: Value, stop: Value, step: Value) -> Result<Val
                 b.get(start..start + len).unwrap_or_default().to_owned(),
             ))
         }
-        ValueRepr::Undefined | ValueRepr::None => Ok(Value::from(Vec::<Value>::new())),
+        ValueRepr::Undefined | ValueRepr::SilentUndefined | ValueRepr::None => {
+            Ok(Value::from(Vec::<Value>::new()))
+        }
         ValueRepr::Object(obj) if matches!(obj.repr(), ObjectRepr::Seq | ObjectRepr::Iterable) => {
             Ok(Value::make_object_iterable(obj, move |obj| {
                 let len = obj.enumerator_len().unwrap_or_default();

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -337,7 +337,7 @@ impl<'env> Vm<'env> {
                     // special case.
                     stack.push(match a.get_attr_fast(name) {
                         Some(value) => assert_valid!(value),
-                        None => ctx_ok!(undefined_behavior.handle_undefined(&a)),
+                        None => ctx_ok!(undefined_behavior.handle_undefined(a.is_undefined())),
                     });
                 }
                 Instruction::SetAttr(name) => {
@@ -357,7 +357,7 @@ impl<'env> Vm<'env> {
                     b = stack.pop();
                     stack.push(match b.get_item_opt(&a) {
                         Some(value) => assert_valid!(value),
-                        None => ctx_ok!(undefined_behavior.handle_undefined(&b)),
+                        None => ctx_ok!(undefined_behavior.handle_undefined(b.is_undefined())),
                     });
                 }
                 Instruction::Slice => {

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -337,7 +337,7 @@ impl<'env> Vm<'env> {
                     // special case.
                     stack.push(match a.get_attr_fast(name) {
                         Some(value) => assert_valid!(value),
-                        None => ctx_ok!(undefined_behavior.handle_undefined(a.is_undefined())),
+                        None => ctx_ok!(undefined_behavior.handle_undefined(&a)),
                     });
                 }
                 Instruction::SetAttr(name) => {
@@ -357,7 +357,7 @@ impl<'env> Vm<'env> {
                     b = stack.pop();
                     stack.push(match b.get_item_opt(&a) {
                         Some(value) => assert_valid!(value),
-                        None => ctx_ok!(undefined_behavior.handle_undefined(b.is_undefined())),
+                        None => ctx_ok!(undefined_behavior.handle_undefined(&b)),
                     });
                 }
                 Instruction::Slice => {

--- a/minijinja/tests/test_undefined.rs
+++ b/minijinja/tests/test_undefined.rs
@@ -140,10 +140,7 @@ fn test_strict_undefined() {
         ErrorKind::UndefinedError
     );
     assert_eq!(render!(in env, "{{ undefined is undefined }}"), "true");
-    assert_eq!(
-        env.render_str("{{ 42 if false }}", ()).unwrap_err().kind(),
-        ErrorKind::UndefinedError
-    );
+    assert_eq!(env.render_str("<{{ 42 if false }}>", ()).unwrap(), "<>");
     assert_eq!(
         render!(in env, "{{ x.foo is undefined }}", x => HashMap::<String, String>::new()),
         "true"

--- a/minijinja/tests/test_undefined.rs
+++ b/minijinja/tests/test_undefined.rs
@@ -39,9 +39,9 @@ fn test_lenient_undefined() {
 }
 
 #[test]
-fn test_mostly_strict_undefined() {
+fn test_semi_strict_undefined() {
     let mut env = Environment::new();
-    env.set_undefined_behavior(UndefinedBehavior::MostlyStrict);
+    env.set_undefined_behavior(UndefinedBehavior::SemiStrict);
 
     assert_eq!(
         env.render_str("{{ true.missing_attribute }}", ())

--- a/minijinja/tests/test_undefined.rs
+++ b/minijinja/tests/test_undefined.rs
@@ -39,6 +39,69 @@ fn test_lenient_undefined() {
 }
 
 #[test]
+fn test_mostly_strict_undefined() {
+    let mut env = Environment::new();
+    env.set_undefined_behavior(UndefinedBehavior::MostlyStrict);
+
+    assert_eq!(
+        env.render_str("{{ true.missing_attribute }}", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::UndefinedError
+    );
+    assert_eq!(
+        env.render_str("{{ undefined.missing_attribute }}", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::UndefinedError
+    );
+    assert_eq!(
+        env.render_str("<{% for x in undefined %}...{% endfor %}>", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::UndefinedError
+    );
+    assert_eq!(
+        env.render_str("{{ 'foo' is in(undefined) }}", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::UndefinedError
+    );
+    assert_eq!(render!(in env, "<{% if undefined %}42{% endif %}>"), "<>");
+    assert_eq!(
+        env.render_str("<{{ undefined }}>", ()).unwrap_err().kind(),
+        ErrorKind::UndefinedError
+    );
+    assert_eq!(render!(in env, "{{ undefined is undefined }}"), "true");
+    assert_eq!(render!(in env, "<{{ 42 if false }}>"), "<>");
+    assert_eq!(
+        render!(in env, "{{ x.foo is undefined }}", x => HashMap::<String, String>::new()),
+        "true"
+    );
+    assert_eq!(
+        env.render_str(
+            "{% if x.foo %}...{% endif %}",
+            context! { x => HashMap::<String, String>::new() }
+        )
+        .unwrap_err()
+        .kind(),
+        ErrorKind::UndefinedError
+    );
+    assert_eq!(
+        env.render_str("{{ undefined|list }}", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::InvalidOperation
+    );
+    assert_eq!(
+        env.render_str("{{ 42 in undefined }}", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::UndefinedError
+    );
+}
+
+#[test]
 fn test_strict_undefined() {
     let mut env = Environment::new();
     env.set_undefined_behavior(UndefinedBehavior::Strict);
@@ -68,10 +131,20 @@ fn test_strict_undefined() {
         ErrorKind::UndefinedError
     );
     assert_eq!(
+        env.render_str("<{% if undefined %}42{% endif %}>", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::UndefinedError
+    );
+    assert_eq!(
         env.render_str("<{{ undefined }}>", ()).unwrap_err().kind(),
         ErrorKind::UndefinedError
     );
     assert_eq!(render!(in env, "{{ undefined is undefined }}"), "true");
+    assert_eq!(
+        env.render_str("{{ 42 if false }}", ()).unwrap_err().kind(),
+        ErrorKind::UndefinedError
+    );
     assert_eq!(
         render!(in env, "{{ x.foo is undefined }}", x => HashMap::<String, String>::new()),
         "true"

--- a/minijinja/tests/test_undefined.rs
+++ b/minijinja/tests/test_undefined.rs
@@ -80,12 +80,11 @@ fn test_mostly_strict_undefined() {
     );
     assert_eq!(
         env.render_str(
-            "{% if x.foo %}...{% endif %}",
+            "<{% if x.foo %}...{% endif %}>",
             context! { x => HashMap::<String, String>::new() }
         )
-        .unwrap_err()
-        .kind(),
-        ErrorKind::UndefinedError
+        .unwrap(),
+        "<>"
     );
     assert_eq!(
         env.render_str("{{ undefined|list }}", ())


### PR DESCRIPTION
This makes to changes to Jinja2

1. The implicit `else` branch in an if expression will evaluate to a new `SilentUndefined` representation.  This is invisible from the perspective of an engine user.  Jinja2 does something similar where it will always use a default `Undefined` object which does not error on iteration of truthiness checks.
2. Adds a new `SemiStrict` undefined behavior which is like `Strict` but permits boolean evaluations.  Eg: `{% if undefined %}` does not error.

This addresses #680
