### PR TITLE
Check that types passed to `ViaDeserialize` implement `Serialize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to MiniJinja are documented here.
   to be checked for truthiness.  Additionally an if expression without
   an else block will always produce a silent undefined object that
   never errors for compatibility with Jinja2.  #687
+- Make the trait bounds of `ViaDeserialize` stricter.  Now the type
+  can only be constructed if the type implements `DeserializeOwned`.
+  This is not a new requirement for passing the function to
+  `add_function` but bad code will now error earlier for better
+  error reporting.  #689
 
 ## 2.7.0
 

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -2,6 +2,7 @@ use minijinja::{context, Environment};
 
 fn main() {
     let mut env = Environment::new();
+
     env.add_template("hello.txt", "Hello {{ name }}!").unwrap();
     let template = env.get_template("hello.txt").unwrap();
     println!("{}", template.render(context!(name => "John")).unwrap());

--- a/minijinja/src/value/deserialize.rs
+++ b/minijinja/src/value/deserialize.rs
@@ -2,8 +2,8 @@ use std::ops::{Deref, DerefMut};
 
 use serde::de::value::{MapDeserializer, SeqDeserializer};
 use serde::de::{
-    self, Deserialize, DeserializeSeed, Deserializer, EnumAccess, IntoDeserializer, MapAccess,
-    SeqAccess, Unexpected, VariantAccess, Visitor,
+    self, Deserialize, DeserializeOwned, DeserializeSeed, Deserializer, EnumAccess,
+    IntoDeserializer, MapAccess, SeqAccess, Unexpected, VariantAccess, Visitor,
 };
 use serde::forward_to_deserialize_any;
 
@@ -110,9 +110,9 @@ impl<'de> Visitor<'de> for ValueVisitor {
 /// env.add_filter("dirname", dirname);
 /// ```
 #[cfg_attr(docsrs, doc(cfg(feature = "deserialization")))]
-pub struct ViaDeserialize<T: for<'de> serde::Deserialize<'de>>(pub T);
+pub struct ViaDeserialize<T: DeserializeOwned>(pub T);
 
-impl<'a, T: for<'de> Deserialize<'de>> ArgType<'a> for ViaDeserialize<T> {
+impl<'a, T: DeserializeOwned> ArgType<'a> for ViaDeserialize<T> {
     type Output = Self;
 
     fn from_value(value: Option<&'a Value>) -> Result<Self, Error> {
@@ -131,7 +131,7 @@ impl<'a, T: for<'de> Deserialize<'de>> ArgType<'a> for ViaDeserialize<T> {
     }
 }
 
-impl<T: for<'de> Deserialize<'de>> Deref for ViaDeserialize<T> {
+impl<T: DeserializeOwned> Deref for ViaDeserialize<T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -139,7 +139,7 @@ impl<T: for<'de> Deserialize<'de>> Deref for ViaDeserialize<T> {
     }
 }
 
-impl<T: for<'de> Deserialize<'de>> DerefMut for ViaDeserialize<T> {
+impl<T: DeserializeOwned> DerefMut for ViaDeserialize<T> {
     fn deref_mut(&mut self) -> &mut T {
         &mut self.0
     }

--- a/minijinja/src/value/deserialize.rs
+++ b/minijinja/src/value/deserialize.rs
@@ -110,9 +110,9 @@ impl<'de> Visitor<'de> for ValueVisitor {
 /// env.add_filter("dirname", dirname);
 /// ```
 #[cfg_attr(docsrs, doc(cfg(feature = "deserialization")))]
-pub struct ViaDeserialize<T>(pub T);
+pub struct ViaDeserialize<T: for<'de> serde::Deserialize<'de>>(pub T);
 
-impl<'a, T: Deserialize<'a>> ArgType<'a> for ViaDeserialize<T> {
+impl<'a, T: for<'de> Deserialize<'de>> ArgType<'a> for ViaDeserialize<T> {
     type Output = Self;
 
     fn from_value(value: Option<&'a Value>) -> Result<Self, Error> {
@@ -131,7 +131,7 @@ impl<'a, T: Deserialize<'a>> ArgType<'a> for ViaDeserialize<T> {
     }
 }
 
-impl<T> Deref for ViaDeserialize<T> {
+impl<T: for<'de> Deserialize<'de>> Deref for ViaDeserialize<T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -139,7 +139,7 @@ impl<T> Deref for ViaDeserialize<T> {
     }
 }
 
-impl<T> DerefMut for ViaDeserialize<T> {
+impl<T: for<'de> Deserialize<'de>> DerefMut for ViaDeserialize<T> {
     fn deref_mut(&mut self) -> &mut T {
         &mut self.0
     }


### PR DESCRIPTION
This provides much better feedback to users who are trying to use a type that does not implement `Deserialize` with `ViaDeserialize`. Previously, the error would appear when trying to use a function or type that itself uses `ViaDeserialize`, e.g. when calling `Environment::add_function` on a function with a parameter using `ViaDeserialize` on a type that does not implement `Deserialize`. For example:

```
error[E0277]: the trait bound `for<'a, 'b, 'c> fn(ViaDeserialize<&'a Page<'b>>, ViaDeserialize<&'c data::config::Config>) -> std::string::String {url_for}: Function<_, _>` is not satisfied
   --> src/templates/functions.rs:66:32
    |
66  |    env.add_function("url_for", url_for);
    |        ------------            ^^^^^^^ the trait `Function<_, _>` is not implemented for fn item `fn(ViaDeserialize<&Page<'b>>, ViaDeserialize<&Config>) -> String {url_for}`
    |        |
    |        required by a bound introduced by this call
    |
note: required by a bound in `Environment::<'source>::add_function`
   --> /Users/chris/.cargo/registry/src/index.crates.io-6f17d22bba15001f/minijinja-2.5.0/src/environment.rs:740:12
    |
736 |     pub fn add_function<N, F, Rv, Args>(&mut self, name: N, f: F)
    |            ------------ required by a bound in this associated function
...
740 |         F: functions::Function<Rv, Args>
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Environment::<'source>::add_function`

```

With this change in place, the error appears at the site where the user tries to use the type incorrectly. For example:

```
error[E0277]: the trait bound `for<'de> NoDeserialize: Deserialize<'de>` is not satisfied
   --> minijinja/tests/test_value.rs:607:18
    |
607 |     let invalid: ViaDeserialize<NoDeserialize>;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'de> Deserialize<'de>` is not implemented for `NoDeserialize`
    |
    = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `NoDeserialize` type
    = note: for types from other crates check whether the crate offers a `serde` feature flag
    = help: the following other types implement trait `Deserialize<'de>`:
              &'a Path
              &'a [u8]
              &'a str
              ()
              (T,)
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
            and 152 others
note: required by a bound in `ViaDeserialize`
   --> /Users/chris/dev/mitsuhiko/minijinja/minijinja/src/value/deserialize.rs:113:30
    |
113 | pub struct ViaDeserialize<T: for<'de> serde::Deserialize<'de>>(pub T);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ViaDeserialize`
```

This is still far from the best possible error message, but it has two major advantages over the previous situation:

1. It is local, that is, the error message appears at the point the user makes the mistake.
2. It is actually clear what the issue is: the type in question does not implement `Deserialize`.

Unfortunately, this does require introducing a higher-ranked trait bound on the type parameter `T` for `ViaDeserialize`, and propagating it to the impls for `ArgType`, `Deref`, and `DerefMut`. What is more, there is today no *great* way to test this: the tests we would need to write are tests that output compiler errors.

This is not, as far as I can tell, a breaking change: no type which worked with `ViaDeserialize` before should work today, and vice versa; the only effect *should* be changing where the error appears.

---

On testing: the existing test infrastructure does not (as far as I could tell) give us a good way to test that this does in fact have the desired effect. The best bet for testing it is probably something like https://github.com/dtolnay/trybuild – with which I am not directly familiar, but it’s well-maintained and the high-level design makes sense to me. In the interval, I am creating a follow-on PR opened against *this* PR (chriskrycho/minijinja#1, because GitHub still doesn’t support any kind of PR stacking), that shows the failure with the new type constraints.