### PR TITLE
Allow objects to influence how they are compared

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "rust-analyzer.cargo.allFeatures": true,
     "rust-analyzer.checkOnSave.command": "clippy",
-    "python.formatting.provider": "black"
+    "python.formatting.provider": "black",
+    "python.REPL.enableREPLSmartSend": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to MiniJinja are documented here.
   `Environnent.undeclared_variables_in_str` to Python binding.  #699
 - Enable `loop_controls` for Python in-line with the CLI.  #704
 - Fixed a panic when comparing plain objects.  #705
+- Added `Object::custom_cmp` to allow objects to influence how they
+  compare against themselves.  This also fixes Python objects in the
+  Python binding not to compare correctly.  #707
 
 ## 2.8.0
 

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -253,7 +253,7 @@ pub trait Object: fmt::Debug + Send + Sync {
     /// anything else.  Objects of different types are given an absolute
     /// ordering outside the scope of this method.
     ///
-    /// The expectation is that an implementer downcasts the other [`DynObject`]
+    /// The requirement is that an implementer downcasts the other [`DynObject`]
     /// to itself, and it that cannot be accomplished `None` must be returned.
     ///
     /// ```rust

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -1,4 +1,6 @@
+use std::any::Any;
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::hash::Hash;
@@ -241,6 +243,35 @@ pub trait Object: fmt::Debug + Send + Sync {
         }
 
         Err(Error::from(ErrorKind::UnknownMethod))
+    }
+
+    /// Custom comparison of this object against another object of the same type.
+    ///
+    /// This must return either `None` or `Some(Ordering)`.  When implemented this
+    /// must guarantee a total ordering as otherwise sort functions will crash.
+    /// This will only compare against other objects of the same type, not
+    /// anything else.  Objects of different types are given an absolute
+    /// ordering outside the scope of this method.
+    ///
+    /// The expectation is that an implementer downcasts the other [`DynObject`]
+    /// to itself, and it that cannot be accomplished `None` must be returned.
+    ///
+    /// ```rust
+    /// # use std::sync::Arc;
+    /// # use std::cmp::Ordering;
+    /// # use minijinja::value::{DynObject, Object};
+    /// # #[derive(Debug)]
+    /// # struct Thing { num: u32 };
+    /// impl Object for Thing {
+    ///     fn custom_cmp(self: &Arc<Self>, other: &DynObject) -> Option<Ordering> {
+    ///         let other = other.downcast_ref::<Self>()?;
+    ///         Some(self.num.cmp(&other.num))
+    ///     }
+    /// }
+    /// ```
+    fn custom_cmp(self: &Arc<Self>, other: &DynObject) -> Option<Ordering> {
+        let _ = other;
+        None
     }
 
     /// Formats the object for stringification.
@@ -610,6 +641,8 @@ type_erase! {
             args: &[Value]
         ) -> Result<Value, Error>;
 
+        fn custom_cmp(&self, other: &DynObject) -> Option<Ordering>;
+
         fn render(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
 
         impl fmt::Debug {
@@ -627,6 +660,11 @@ impl DynObject {
     /// Checks if this dyn object is the same as another.
     pub(crate) fn is_same_object(&self, other: &DynObject) -> bool {
         self.ptr == other.ptr && self.vtable == other.vtable
+    }
+
+    /// Checks if the two dyn objects are of the same tyep.
+    pub(crate) fn is_same_object_type(&self, other: &DynObject) -> bool {
+        self.type_id() == other.type_id()
     }
 }
 

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -662,7 +662,7 @@ impl DynObject {
         self.ptr == other.ptr && self.vtable == other.vtable
     }
 
-    /// Checks if the two dyn objects are of the same tyep.
+    /// Checks if the two dyn objects are of the same type.
     pub(crate) fn is_same_object_type(&self, other: &DynObject) -> bool {
         self.type_id() == other.type_id()
     }


### PR DESCRIPTION
This adds a new `Object::custom_cmp` method to allow limited custom comparisons.  This will allow python objects to be compared against matching types.  This will *not* allow comparisons between objects of different types.  It also requires total order so the python bindings will panic if a sort is attempted of sequences that do not allow total order.

Refs #703