### PR TITLE
clippy:doc_overindented_list_items

### DIFF
--- a/minijinja/src/lib.rs
+++ b/minijinja/src/lib.rs
@@ -178,7 +178,7 @@
 //!   the ability to auto escape via `AutoEscape::Json`.
 //! - `urlencode`: When enabled the `urlencode` filter is added as builtin filter.
 //! - `loop_controls`: enables the `{% break %}` and `{% continue %}` loop control flow
-//!    tags.
+//!   tags.
 //!
 //! Performance and memory related features:
 //!


### PR DESCRIPTION
warning: doc list item overindented
   --> minijinja/src/lib.rs:181:5
    |
181 | //!    tags.
    |     ^^^ help: try using `  ` (2 spaces)
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items
    = note: `#[warn(clippy::doc_overindented_list_items)]` on by default