### PR TITLE
Fix python locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to MiniJinja are documented here.
   Python binding not to compare correctly.  #707
 - Fixed a bug where `undeclared_variables` would incorrectly handle
   variables referenced by macros.  #714
+- Fixed a deadlock in the Python binding when multiple threads were
+  rendering from the same environment at once.  #717
 
 ## 2.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,6 @@ name = "minijinja-py"
 version = "2.7.0"
 dependencies = [
  "minijinja",
- "once_cell",
  "pyo3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ strip = true
 [profile.dev.package.insta]
 opt-level = 3
 
-[profile.dev.package.similar]
-opt-level = 3
-
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"

--- a/minijinja-py/Cargo.toml
+++ b/minijinja-py/Cargo.toml
@@ -10,5 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 minijinja = { version = "2.7.0", path = "../minijinja", features = ["loader", "json", "urlencode", "fuel", "preserve_order", "speedups", "custom_syntax", "loop_controls", "internal_safe_search"] }
-once_cell = "1.17.0"
 pyo3 = { version = "0.23.4", features = ["extension-module", "serde", "abi3-py38"] }

--- a/minijinja-py/README.md
+++ b/minijinja-py/README.md
@@ -173,6 +173,13 @@ Here is what this means for some basic types:
   However methods are disambiugated so `foo.items()` works and will correctly call
   the method in all cases.
 
+## Threading
+
+MiniJinja's Python bindin is thread-safe but it uses locks internally on the
+environment.  In particular only one thread can render a template from the same
+environment at the time.  If you want to render templates from multiple threads
+you should be creating a new environment for each thread.
+
 ## Sponsor
 
 If you like the project and find it useful you can [become a

--- a/minijinja-py/src/state.rs
+++ b/minijinja-py/src/state.rs
@@ -19,8 +19,8 @@ pub struct StateRef;
 impl StateRef {
     /// Returns a reference to the environment.
     #[getter]
-    pub fn get_env(&self) -> PyResult<Py<Environment>> {
-        with_environment(Ok)
+    pub fn get_env(&self, py: Python<'_>) -> PyResult<Py<Environment>> {
+        with_environment(py, Ok)
     }
 
     /// Returns the name of the template.


### PR DESCRIPTION
This releases the lock around template rendering to get rid of a deadlock.

It's still a bad idea to render from the same environment from multiple threads as only one template can render at the time in Python due to the internal lock.

Fixes #716