### PR TITLE
Fix caller being marked as undeclared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to MiniJinja are documented here.
   open parentheses, braces or brackets.  #723
 - Added `State::known_variables` to return a list of known variables
   and `Environment::globals`.  #724
+- Fixed an issue with undeclared variables not handling `caller`.  #725
 
 ## 2.8.0
 

--- a/minijinja/tests/test_templates.rs
+++ b/minijinja/tests/test_templates.rs
@@ -491,19 +491,23 @@ fn test_undeclared_variables() {
     let mut env = Environment::new();
     env.add_template(
         "demo",
-        "{% set x = foo %}{{ x }}{{ bar.baz }}{{ bar.blub }}",
+        "{% set x = foo %}{{ x }}{{ bar.baz }}{{ bar.blub }}
+        {% macro blah() %}{{ macro_x }}{{ caller() }}{% endmacro %}",
     )
     .unwrap();
     let tmpl = env.get_template("demo").unwrap();
     let undeclared = tmpl.undeclared_variables(false);
     assert_eq!(
         undeclared,
-        ["foo", "bar"].into_iter().map(|x| x.to_string()).collect()
+        ["foo", "bar", "macro_x"]
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect()
     );
     let undeclared = tmpl.undeclared_variables(true);
     assert_eq!(
         undeclared,
-        ["foo", "bar.baz", "bar.blub"]
+        ["foo", "bar.baz", "bar.blub", "macro_x"]
             .into_iter()
             .map(|x| x.to_string())
             .collect()


### PR DESCRIPTION
`caller` was not handled correctly for undeclared variable finding.

Refs #715