### PR TITLE
Reduce the size of tokens and ast nodes

### DIFF
--- a/minijinja/src/compiler/ast.rs
+++ b/minijinja/src/compiler/ast.rs
@@ -14,22 +14,20 @@ use crate::value::{value_map_with_capacity, Value};
 /// to become too large.
 #[cfg_attr(feature = "unstable_machinery_serde", derive(serde::Serialize))]
 pub struct Spanned<T> {
-    node: Box<T>,
-    span: Span,
+    inner: Box<(T, Span)>,
 }
 
 impl<T> Spanned<T> {
     /// Creates a new spanned node.
     pub fn new(node: T, span: Span) -> Spanned<T> {
         Spanned {
-            node: Box::new(node),
-            span,
+            inner: Box::new((node, span)),
         }
     }
 
     /// Accesses the span.
     pub fn span(&self) -> Span {
-        self.span
+        self.inner.1
     }
 }
 
@@ -37,15 +35,15 @@ impl<T> Deref for Spanned<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.node
+        &self.inner.0
     }
 }
 
 #[cfg(feature = "internal_debug")]
 impl<T: fmt::Debug> fmt::Debug for Spanned<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        ok!(fmt::Debug::fmt(&self.node, f));
-        write!(f, "{:?}", self.span)
+        ok!(fmt::Debug::fmt(&self.inner.0, f));
+        write!(f, "{:?}", self.inner.0)
     }
 }
 

--- a/minijinja/src/compiler/ast.rs
+++ b/minijinja/src/compiler/ast.rs
@@ -43,7 +43,7 @@ impl<T> Deref for Spanned<T> {
 impl<T: fmt::Debug> fmt::Debug for Spanned<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         ok!(fmt::Debug::fmt(&self.inner.0, f));
-        write!(f, "{:?}", self.inner.0)
+        write!(f, "{:?}", self.inner.1)
     }
 }
 

--- a/minijinja/src/compiler/lexer.rs
+++ b/minijinja/src/compiler/lexer.rs
@@ -487,7 +487,7 @@ impl<'s> Tokenizer<'s> {
                 Ok(Token::Int(int))
             } else {
                 u128::from_str_radix(&num, radix)
-                    .map(Token::Int128)
+                    .map(|x| Token::Int128(Box::new(x)))
                     .map_err(|_| self.syntax_error("invalid integer (too large)"))
             }),
             self.span(old_loc),
@@ -534,7 +534,7 @@ impl<'s> Tokenizer<'s> {
         let s = self.advance(str_len + 2);
         Ok(if has_escapes {
             (
-                Token::String(ok!(unescape(&s[1..s.len() - 1]))),
+                Token::String(ok!(unescape(&s[1..s.len() - 1])).into_boxed_str()),
                 self.span(old_loc),
             )
         } else {

--- a/minijinja/src/compiler/parser.rs
+++ b/minijinja/src/compiler/parser.rs
@@ -649,7 +649,7 @@ impl<'a> Parser<'a> {
             Token::Str(_) | Token::String(_) => {
                 let mut buf = match token {
                     Token::Str(s) => s.to_owned(),
-                    Token::String(s) => s,
+                    Token::String(s) => s.into_string(),
                     _ => unreachable!(),
                 };
                 loop {
@@ -663,7 +663,7 @@ impl<'a> Parser<'a> {
                 Ok(const_val!(buf))
             }
             Token::Int(val) => Ok(const_val!(val)),
-            Token::Int128(val) => Ok(const_val!(val)),
+            Token::Int128(val) => Ok(const_val!(*val)),
             Token::Float(val) => Ok(const_val!(val)),
             Token::ParenOpen => self.parse_tuple_or_expression(span),
             Token::BracketOpen => self.parse_list_expr(span),

--- a/minijinja/src/compiler/tokens.rs
+++ b/minijinja/src/compiler/tokens.rs
@@ -23,11 +23,11 @@ pub enum Token<'a> {
     /// A borrowed string.
     Str(&'a str),
     /// An allocated string.
-    String(String),
+    String(Box<str>),
     /// An integer (limited to i64)
     Int(u64),
     /// A large integer
-    Int128(u128),
+    Int128(Box<u128>),
     /// A float
     Float(f64),
     /// A plus (`+`) operator.

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -360,7 +360,8 @@ pub(crate) enum StringType {
 ///
 /// This is used for `i128`/`u128` in the value repr to avoid
 /// the excessive 16 byte alignment.
-#[derive(Copy)]
+#[derive(Copy, Debug)]
+#[cfg_attr(feature = "unstable_machinery_serde", derive(serde::Serialize))]
 #[repr(packed)]
 pub(crate) struct Packed<T: Copy>(pub T);
 

--- a/minijinja/src/vm/context.rs
+++ b/minijinja/src/vm/context.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 
-#[cfg(any(feature = "macros", feature = "multi_template"))]
+#[cfg(feature = "macros")]
 use std::sync::Arc;
 
 use crate::environment::Environment;

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::mem;
 
-#[cfg(any(feature = "macros", feature = "multi_template"))]
+#[cfg(feature = "macros")]
 use std::sync::Arc;
 
 use crate::compiler::instructions::{


### PR DESCRIPTION
This improves the speed of parsing by about 12%.