### PR TITLE
Use smaller integers for spans and addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ All notable changes to MiniJinja are documented here.
   handle escapes.  #728
 - Implemented constant folding in the code generator.  #731
 - Improved error reporting for bad loop recursion calls.  #734
+- The engine now uses smaller integers to represent columns, line numbers
+  and addresses.  This cuts down on the memory usage needed for debug
+  information.  #735
 
 ## 2.8.0
 

--- a/minijinja/src/compiler/codegen.rs
+++ b/minijinja/src/compiler/codegen.rs
@@ -35,14 +35,14 @@ fn get_local_id<'source>(ids: &mut BTreeMap<&'source str, LocalId>, name: &'sour
 /// jump targets.
 enum PendingBlock {
     Branch {
-        jump_instr: usize,
+        jump_instr: u32,
     },
     Loop {
-        iter_instr: usize,
-        jump_instrs: Vec<usize>,
+        iter_instr: u32,
+        jump_instrs: Vec<u32>,
     },
     ScBool {
-        jump_instrs: Vec<usize>,
+        jump_instrs: Vec<u32>,
     },
 }
 
@@ -51,7 +51,7 @@ pub struct CodeGenerator<'source> {
     instructions: Instructions<'source>,
     blocks: BTreeMap<&'source str, Instructions<'source>>,
     pending_block: Vec<PendingBlock>,
-    current_line: u32,
+    current_line: u16,
     span_stack: Vec<Span>,
     filter_local_ids: BTreeMap<&'source str, LocalId>,
     test_local_ids: BTreeMap<&'source str, LocalId>,
@@ -74,7 +74,7 @@ impl<'source> CodeGenerator<'source> {
     }
 
     /// Sets the current location's line.
-    pub fn set_line(&mut self, lineno: u32) {
+    pub fn set_line(&mut self, lineno: u16) {
         self.current_line = lineno;
     }
 
@@ -95,7 +95,7 @@ impl<'source> CodeGenerator<'source> {
     }
 
     /// Add a simple instruction with the current location.
-    pub fn add(&mut self, instr: Instruction<'source>) -> usize {
+    pub fn add(&mut self, instr: Instruction<'source>) -> u32 {
         if let Some(span) = self.span_stack.last() {
             if span.start_line == self.current_line {
                 return self.instructions.add_with_span(instr, *span);
@@ -105,13 +105,13 @@ impl<'source> CodeGenerator<'source> {
     }
 
     /// Add a simple instruction with other location.
-    pub fn add_with_span(&mut self, instr: Instruction<'source>, span: Span) -> usize {
+    pub fn add_with_span(&mut self, instr: Instruction<'source>, span: Span) -> u32 {
         self.instructions.add_with_span(instr, span)
     }
 
     /// Returns the next instruction index.
-    pub fn next_instruction(&self) -> usize {
-        self.instructions.len()
+    pub fn next_instruction(&self) -> u32 {
+        self.instructions.len() as u32
     }
 
     /// Creates a sub generator.
@@ -233,7 +233,7 @@ impl<'source> CodeGenerator<'source> {
         }
     }
 
-    fn end_condition(&mut self, new_jump_instr: usize) {
+    fn end_condition(&mut self, new_jump_instr: u32) {
         match self.pending_block.pop() {
             Some(PendingBlock::Branch { jump_instr }) => {
                 match self.instructions.get_mut(jump_instr) {

--- a/minijinja/src/compiler/lexer.rs
+++ b/minijinja/src/compiler/lexer.rs
@@ -19,8 +19,8 @@ pub struct Tokenizer<'s> {
     stack: Vec<LexerState>,
     source: &'s str,
     filename: &'s str,
-    current_line: u32,
-    current_col: u32,
+    current_line: u16,
+    current_col: u16,
     current_offset: usize,
     trim_leading_whitespace: bool,
     pending_start_marker: Option<(StartMarker, usize)>,
@@ -387,7 +387,7 @@ impl<'s> Tokenizer<'s> {
     }
 
     #[inline]
-    fn loc(&self) -> (u32, u32, u32) {
+    fn loc(&self) -> (u16, u16, u32) {
         (
             self.current_line,
             self.current_col,
@@ -396,7 +396,7 @@ impl<'s> Tokenizer<'s> {
     }
 
     #[inline]
-    fn span(&self, (start_line, start_col, start_offset): (u32, u32, u32)) -> Span {
+    fn span(&self, (start_line, start_col, start_offset): (u16, u16, u32)) -> Span {
         Span {
             start_line,
             start_col,

--- a/minijinja/src/compiler/tokens.rs
+++ b/minijinja/src/compiler/tokens.rs
@@ -127,11 +127,11 @@ impl fmt::Display for Token<'_> {
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "unstable_machinery_serde", derive(serde::Serialize))]
 pub struct Span {
-    pub start_line: u32,
-    pub start_col: u32,
+    pub start_line: u16,
+    pub start_col: u16,
     pub start_offset: u32,
-    pub end_line: u32,
-    pub end_col: u32,
+    pub end_line: u16,
+    pub end_col: u16,
     pub end_offset: u32,
 }
 

--- a/minijinja/src/vm/loop_object.rs
+++ b/minijinja/src/vm/loop_object.rs
@@ -12,7 +12,7 @@ pub(crate) struct LoopState {
     // if we're popping the frame, do we want to jump somewhere?  The
     // first item is the target jump instruction, the second argument
     // tells us if we need to end capturing.
-    pub(crate) current_recursion_jump: Option<(usize, bool)>,
+    pub(crate) current_recursion_jump: Option<(u32, bool)>,
     pub(crate) object: Arc<Loop>,
 
     // Depending on if adjacent_loop_items is enabled or not, the iterator
@@ -27,8 +27,8 @@ impl LoopState {
         iter: ValueIter,
         depth: usize,
         with_loop_var: bool,
-        recurse_jump_target: Option<usize>,
-        current_recursion_jump: Option<(usize, bool)>,
+        recurse_jump_target: Option<u32>,
+        current_recursion_jump: Option<(u32, bool)>,
     ) -> LoopState {
         // for an iterator where the lower and upper bound are matching we can
         // consider them to have ExactSizeIterator semantics.  We do however not
@@ -114,7 +114,7 @@ pub(crate) struct Loop {
     pub idx: AtomicUsize,
     pub depth: usize,
     pub last_changed_value: Mutex<Option<Vec<Value>>>,
-    pub recurse_jump_target: Option<usize>,
+    pub recurse_jump_target: Option<u32>,
     #[cfg(feature = "adjacent_loop_items")]
     iter: Mutex<AdjacentLoopItemIterWrapper>,
 }

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -157,7 +157,7 @@ impl<'env> Vm<'env> {
         state: &mut State<'_, 'env>,
         out: &mut Output,
         stack: Stack,
-        pc: usize,
+        pc: u32,
     ) -> Result<Option<Value>, Error> {
         #[cfg(feature = "stacker")]
         {
@@ -177,7 +177,7 @@ impl<'env> Vm<'env> {
         state: &mut State<'_, 'env>,
         out: &mut Output,
         mut stack: Stack,
-        mut pc: usize,
+        mut pc: u32,
     ) -> Result<Option<Value>, Error> {
         let initial_auto_escape = state.auto_escape;
         let undefined_behavior = state.undefined_behavior();
@@ -947,8 +947,8 @@ impl<'env> Vm<'env> {
         state: &mut State<'_, 'env>,
         iterable: Value,
         flags: u8,
-        pc: usize,
-        current_recursion_jump: Option<(usize, bool)>,
+        pc: u32,
+        current_recursion_jump: Option<(u32, bool)>,
     ) -> Result<(), Error> {
         let iter = ok!(state
             .undefined_behavior()
@@ -1018,7 +1018,7 @@ impl<'env> Vm<'env> {
         &self,
         stack: &mut Stack,
         state: &mut State,
-        offset: usize,
+        offset: u32,
         name: &str,
         flags: u8,
     ) {
@@ -1041,7 +1041,7 @@ impl<'env> Vm<'env> {
 
 #[inline(never)]
 #[cold]
-fn process_err(err: &mut Error, pc: usize, state: &State) {
+fn process_err(err: &mut Error, pc: u32, state: &State) {
     // only attach line information if the error does not have line info yet.
     if err.line().is_none() {
         if let Some(span) = state.instructions.get_span(pc) {

--- a/minijinja/src/vm/state.rs
+++ b/minijinja/src/vm/state.rs
@@ -52,7 +52,7 @@ pub struct State<'template, 'env> {
     #[cfg(feature = "macros")]
     pub(crate) id: isize,
     #[cfg(feature = "macros")]
-    pub(crate) macros: std::sync::Arc<Vec<(&'template Instructions<'env>, usize)>>,
+    pub(crate) macros: std::sync::Arc<Vec<(&'template Instructions<'env>, u32)>>,
     #[cfg(feature = "macros")]
     pub(crate) closure_tracker: std::sync::Arc<crate::vm::closure_object::ClosureTracker>,
     #[cfg(feature = "fuel")]
@@ -398,7 +398,7 @@ impl<'template, 'env> State<'template, 'env> {
     #[cfg(feature = "debug")]
     pub(crate) fn make_debug_info(
         &self,
-        pc: usize,
+        pc: u32,
         instructions: &Instructions<'_>,
     ) -> crate::debug::DebugInfo {
         crate::debug::DebugInfo {


### PR DESCRIPTION
This now uses `u16` for column and line numbers which should be enough for any real world template and uses `u32` for addresses on all architectures.