### PR TITLE
Fix unknown_method_callback error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to MiniJinja are documented here.
 - Do not panic if too large templates (too many lines or too many
   columns) are loaded.  The error reporting will be wrong in those
   cases but the templates will load.  #742
+- Fixed a bug that caused unknown method callbacks to not get
+  proper error reporting if they cannot find a method.  #743
 
 ## 2.8.0
 

--- a/minijinja/tests/test_environment.rs
+++ b/minijinja/tests/test_environment.rs
@@ -173,6 +173,13 @@ fn test_unknown_method_callback() {
 
     let rv = env.render_str("{{ {'x': 42}.items() }}", ()).unwrap();
     assert_snapshot!(rv, @r###"[["x", 42]]"###);
+
+    let err = env.render_str("{{ [].does_not_exist() }}", ()).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::UnknownMethod);
+    assert_eq!(
+        err.detail(),
+        Some("sequence has no method named does_not_exist")
+    );
 }
 
 #[test]


### PR DESCRIPTION
This fixes a bug that an `unknown_method_callback` would not trigger the default error handling for unknown methods.  Now the error message is properly filled in if that callback returns `UnknownMethod`.