### PR TITLE
Add support for multiple data files to the CLI

### DIFF
--- a/minijinja-cli/src/cli.rs
+++ b/minijinja-cli/src/cli.rs
@@ -10,6 +10,7 @@ use clap::ArgMatches;
 use minijinja::machinery::{
     get_compiled_template, parse, tokenize, Instructions, WhitespaceConfig,
 };
+use minijinja::value::merge_maps;
 use minijinja::{context, Environment, Error as MError, ErrorKind, Value};
 use serde::Deserialize;
 
@@ -396,22 +397,15 @@ pub fn execute() -> Result<i32, Error> {
 
     let (base_ctx, stdin_used) = if let Some(data_files) = matches.get_many::<PathBuf>("data_file")
     {
-        let mut old_ctx = None;
+        let mut contexts = Vec::with_capacity(data_files.len());
         let mut stdin_used = false;
+        let select = matches.get_one::<String>("select").map(|x| x.as_str());
         for data_file in data_files {
-            let (new_ctx, stdin_used_here) = load_data(
-                config.format(),
-                data_file,
-                matches.get_one::<String>("select").map(|x| x.as_str()),
-            )?;
+            let (new_ctx, stdin_used_here) = load_data(config.format(), data_file, select)?;
+            contexts.push(new_ctx);
             stdin_used = stdin_used || stdin_used_here;
-            old_ctx = if let Some(old_ctx) = old_ctx.take() {
-                Some(context!(..new_ctx, ..old_ctx))
-            } else {
-                Some(Value::from(new_ctx))
-            };
         }
-        (old_ctx.unwrap_or_default(), false)
+        (merge_maps(contexts), false)
     } else {
         (Default::default(), false)
     };

--- a/minijinja-cli/src/command.rs
+++ b/minijinja-cli/src/command.rs
@@ -337,14 +337,15 @@ pub(super) fn make_command() -> Command {
                     to allow a data file to be supplied.")
                 .default_value("-")
                 .default_value_if("template", ArgPredicate::IsPresent, None),
-            arg!(data_file: [DATA_FILE] "Path to the data file")
+            arg!(data_file: [DATA_FILE]... "Path to one or more data files used as template context")
                 .long_help("\
                     Path to the data file in the given format.\n\n\
                     \
                     The data file is used to supply the context (variables) to the template. \
                     Various file formats are supported.  When data is read from stdin (by using '-' \
                     as file name), --format must be specified as auto detection is based on \
-                    file extensions.")
+                    file extensions.  Multiple files can be provided which are merged.  Later \
+                    files override files passed before.")
                 .value_parser(value_parser!(PathBuf)),
             #[cfg(feature = "completions")]
             arg!(--"generate-completion" <SH> "Generate a completion script for the given shell")

--- a/minijinja-cli/tests/snapshots/test_basic__long_help.snap
+++ b/minijinja-cli/tests/snapshots/test_basic__long_help.snap
@@ -36,7 +36,7 @@ Examples:
 
     minijinja-cli --expr "1 + 1"
 
-Usage: minijinja-cli [OPTIONS] [TEMPLATE_FILE] [DATA_FILE]
+Usage: minijinja-cli [OPTIONS] [TEMPLATE_FILE] [DATA_FILE]...
 
 Arguments:
   [TEMPLATE_FILE]
@@ -49,12 +49,13 @@ Arguments:
           
           [default: -]
 
-  [DATA_FILE]
+  [DATA_FILE]...
           Path to the data file in the given format.
           
           The data file is used to supply the context (variables) to the template. Various file
           formats are supported.  When data is read from stdin (by using '-' as file name), --format
-          must be specified as auto detection is based on file extensions.
+          must be specified as auto detection is based on file extensions.  Multiple files can be
+          provided which are merged.  Later files override files passed before.
 
 Options:
       --config-file <PATH>

--- a/minijinja-cli/tests/snapshots/test_basic__short_help.snap
+++ b/minijinja-cli/tests/snapshots/test_basic__short_help.snap
@@ -12,11 +12,11 @@ minijinja-cli is a command line tool to render or evaluate jinja2 templates.
 
 Pass a template and optionally a file with template variables to render it to stdout.
 
-Usage: minijinja-cli [OPTIONS] [TEMPLATE_FILE] [DATA_FILE]
+Usage: minijinja-cli [OPTIONS] [TEMPLATE_FILE] [DATA_FILE]...
 
 Arguments:
   [TEMPLATE_FILE]  Path to the input template [default: -]
-  [DATA_FILE]      Path to the data file
+  [DATA_FILE]...   Path to one or more data files used as template context
 
 Options:
       --config-file <PATH>          Alternative path to the config file.

--- a/minijinja-cli/tests/test_basic.rs
+++ b/minijinja-cli/tests/test_basic.rs
@@ -177,6 +177,55 @@ d:
 }
 
 #[test]
+#[cfg(feature = "yaml")]
+fn test_multiple_data_files() {
+    let json_input =
+        file_with_contents_and_ext(r#"{"name": "World", "greeting": "Hello"}"#, ".json");
+    let yaml_input = file_with_contents_and_ext(r#"greeting: Hi"#, ".yaml");
+    let tmpl = file_with_contents(r#"{{ greeting }} {{ name }}!"#);
+
+    assert_cmd_snapshot!(
+        cli()
+            .arg(tmpl.path())
+            .arg(json_input.path())
+            .arg(yaml_input.path()),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Hi World!
+
+    ----- stderr -----
+    "###);
+}
+
+#[test]
+#[cfg(feature = "yaml")]
+fn test_select_from_toplevel() {
+    let json_input = file_with_contents_and_ext(
+        r#"{"base": {"name": "World", "greeting": "Hello"}}"#,
+        ".json",
+    );
+    let yaml_input = file_with_contents_and_ext(r#"base: {greeting: Hi}"#, ".yaml");
+    let tmpl = file_with_contents(r#"{{ greeting }} {{ name }}!"#);
+
+    assert_cmd_snapshot!(
+        cli()
+            .arg("--select=base")
+            .arg(tmpl.path())
+            .arg(json_input.path())
+            .arg(yaml_input.path()),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Hi World!
+
+    ----- stderr -----
+    "###);
+}
+
+#[test]
 #[cfg(feature = "toml")]
 fn test_toml() {
     let input = file_with_contents_and_ext("[section]\nfoo = \"bar\"", ".toml");

--- a/minijinja/src/macros.rs
+++ b/minijinja/src/macros.rs
@@ -146,7 +146,7 @@ macro_rules! context {
             ctx
         } else {
             $crate::value::merge_maps(
-                std::iter::once(ctx).chain(merge_ctx.into_iter()))
+                merge_ctx.into_iter().rev().chain(::std::iter::once(ctx)))
         }
     }};
     (
@@ -156,7 +156,7 @@ macro_rules! context {
             $(
                 $crate::value::Value::from($ctx),
             )*
-        ])
+        ].into_iter().rev())
     }};
 }
 


### PR DESCRIPTION
Fixes #744 

This also changes the order of `merge_maps` to be what one would actually expect.  Since that function was just added it should be fine to change it here.