### PR TITLE
Add an as_bytes function for the C-ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to MiniJinja are documented here.
   merge feature, and fixed enumeration behavior when non-map objects
   are attempted to be merged.  #745
 - Added `mj_value_new_bytes` to the C-ABI.  #749
+- Added `mj_value_as_bytes` to the C-ABI to borrow from strings or
+  byte values.  #750
 
 ## 2.8.0
 

--- a/minijinja-cabi/example/hello.c
+++ b/minijinja-cabi/example/hello.c
@@ -1,6 +1,7 @@
 #include <minijinja.h>
 #include <stdio.h>
 #include <assert.h>
+#include <string.h>
 
 int main()
 {
@@ -59,6 +60,14 @@ seq: {{ seq }}");
     fprintf(stderr, "1 + 2 = %s\n", ervs);
     mj_str_free(ervs);
     mj_value_decref(&erv);
+
+    // you can borrow utf-8 from strings, if they are strings.
+    mj_value bv = mj_value_new_string("Hello");
+    uintptr_t bvlen;
+    const char *bvstr = mj_value_as_bytes(bv, &bvlen);
+    assert(bvlen == 5);
+    assert(memcmp(bvstr, "Hello", 5) == 0);
+    mj_value_decref(&bv);
 
     mj_env_free(env);
 

--- a/minijinja-cabi/include/minijinja.h
+++ b/minijinja-cabi/include/minijinja.h
@@ -253,6 +253,11 @@ MINIJINJA_API void mj_syntax_config_default(struct mj_syntax_config *syntax);
 MINIJINJA_API bool mj_value_append(struct mj_value *slf, struct mj_value value);
 
 /*
+ If the value is a string or bytes, returns it the pointer
+ */
+MINIJINJA_API const char *mj_value_as_bytes(struct mj_value value, uintptr_t *len_out);
+
+/*
  Extracts a float from the value
  */
 MINIJINJA_API double mj_value_as_f64(struct mj_value value);

--- a/minijinja-cabi/src/utils.rs
+++ b/minijinja-cabi/src/utils.rs
@@ -21,6 +21,12 @@ impl<T> AbiResult for *mut T {
     }
 }
 
+impl<T> AbiResult for *const T {
+    fn err_value() -> Self {
+        ptr::null()
+    }
+}
+
 impl AbiResult for u64 {
     fn err_value() -> Self {
         0


### PR DESCRIPTION
Adds a convenience method to borrow bytes from strings or bytes values.

Refs #749