### PR TITLE
Bump textwrap dependency to 0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,7 +2801,7 @@ dependencies = [
  "nix",
  "radix_trie",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
  "utf8parse",
  "windows-sys 0.52.0",
 ]
@@ -3211,13 +3211,13 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3522,6 +3522,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode_categories"

--- a/minijinja-contrib/Cargo.toml
+++ b/minijinja-contrib/Cargo.toml
@@ -28,7 +28,7 @@ unicode_wordwrap = ["wordwrap", "textwrap/unicode-linebreak", "textwrap/unicode-
 [dependencies]
 minijinja = { version = "2.8.0", path = "../minijinja", default-features = false }
 serde = "1.0.164"
-textwrap = { version = "0.16.1", optional = true, default-features = false, features = ["smawk"] }
+textwrap = { version = "0.16.2", optional = true, default-features = false, features = ["smawk"] }
 time = { version = "0.3.35", optional = true, features = ["serde", "formatting", "parsing"] }
 time-tz = { version = "2.0.0", features = ["db"], optional = true }
 unicode_categories = { version = "0.1.1", optional = true }


### PR DESCRIPTION
Has some meaningful fixes that make it more useful.

Replaces #747