### PR TITLE
Enable pycompat and contrib in python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to MiniJinja are documented here.
   compatibility.  #763
 - The `default` filter now accepts a second argument to enable lax
   defaulting.  #764
+- Enable `pycompat` by default for the Python bindings and register
+  the default contrib filters and tests.  #767
 
 ## 2.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,6 +2079,7 @@ name = "minijinja-py"
 version = "2.8.0"
 dependencies = [
  "minijinja",
+ "minijinja-contrib",
  "pyo3",
 ]
 

--- a/minijinja-py/Cargo.toml
+++ b/minijinja-py/Cargo.toml
@@ -10,4 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 minijinja = { version = "2.8.0", path = "../minijinja", features = ["loader", "json", "urlencode", "fuel", "preserve_order", "speedups", "custom_syntax", "loop_controls", "internal_safe_search"] }
+minijinja-contrib = { version = "2.8.0", path = "../minijinja-contrib", features = ["pycompat"] }
 pyo3 = { version = "0.23.4", features = ["extension-module", "serde", "abi3-py38"] }

--- a/minijinja-py/python/minijinja/__init__.py
+++ b/minijinja-py/python/minijinja/__init__.py
@@ -68,6 +68,7 @@ class Environment(_lowlevel.Environment):
         comment_end_string="#}",
         line_statement_prefix=None,
         line_comment_prefix=None,
+        pycompat=True,
     ):
         super().__init__()
         if loader is not None:
@@ -114,6 +115,7 @@ class Environment(_lowlevel.Environment):
         self.comment_end_string = comment_end_string
         self.line_statement_prefix = line_statement_prefix
         self.line_comment_prefix = line_comment_prefix
+        self.pycompat = pycompat
 
     @handle_panic(_lowlevel.Environment.render_str)
     def render_str(self, *args, **kwargs):

--- a/minijinja-py/tests/test_basic.py
+++ b/minijinja-py/tests/test_basic.py
@@ -488,3 +488,13 @@ def test_load_from_path():
     with pytest.raises(TemplateError) as e:
         env.render_template("../test_basic.py")
     assert e.value.kind == "TemplateNotFound"
+
+
+def test_pycompat():
+    env = Environment()
+    assert env.eval_expr("{'x': 42}.get('x')") == 42
+
+    env.pycompat = False
+    with pytest.raises(TemplateError) as e:
+        assert env.eval_expr("{'x': 42}.get('x')")
+    assert "unknown method: map has no method named get" in e.value.message


### PR DESCRIPTION
The python bindings did not enable the `pycompat` mode before.  This was assumed to be okay since most types are just python types.  However this does cause confusing because dictionaries created within the minijinja engine will not have those methods.

This now enables this mode by default which should resolve most of those inconsistencies.  It won't fix everything though since not all methods are a perfect match.

This also enables the contrib module which adds a few methods missing.

Fixes #766 