### PR TITLE
Fix the function reference in the src/tests docs

### DIFF
--- a/minijinja/src/tests.rs
+++ b/minijinja/src/tests.rs
@@ -2,8 +2,8 @@
 //!
 //! Test functions in MiniJinja are like [`filters`](crate::filters) but a
 //! different syntax is used to invoke them and they have to return boolean
-//! values.  For instance the expression `{% if foo is defined %}` invokes the
-//! [`is_defined`] test to check if the value is indeed an odd number.
+//! values.  For instance the expression `{% if foo is odd %}` invokes the
+//! [`is_odd`] test to check if the value is indeed an odd number.
 //!
 //! MiniJinja comes with some built-in test functions that are listed below. To
 //! create a custom test write a function that takes at least a value argument


### PR DESCRIPTION
The documentation for the tests module referenced `is_defined`, but explained it as "check if the value is indeed an odd number". Corrected the example to use `is odd`, and the function name to `is_odd`.

Could have corrected the wording too, but the next example shows even/odd, so correcting the test and the function name felt more appropriate.