### PR TITLE
cabi: Add getter for error debug info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to MiniJinja are documented here.
 ## 2.10.0
 
 - Fix incorrect permissions when `--output` is used in the CLI.  #772
+- Added `mj_err_get_debug_info` to the C-ABI.  #775
 
 ## 2.9.0
 

--- a/minijinja-cabi/include/minijinja.h
+++ b/minijinja-cabi/include/minijinja.h
@@ -208,6 +208,11 @@ void mj_env_set_undefined_behavior(struct mj_env *env,
 MINIJINJA_API void mj_err_clear(void);
 
 /*
+ Returns the error's debug info if there is an error.
+ */
+MINIJINJA_API char *mj_err_get_debug_info(void);
+
+/*
  Returns the error's description if there is an error.
  */
 MINIJINJA_API char *mj_err_get_detail(void);


### PR DESCRIPTION
A simple getter, not sure if it would be preferable to separate the source debug info or not

Context: https://github.com/mitsuhiko/minijinja/discussions/748#discussioncomment-12440741