### PR TITLE
cabi: return an empty string when no debug info

### DIFF
--- a/minijinja-cabi/src/error.rs
+++ b/minijinja-cabi/src/error.rs
@@ -60,14 +60,19 @@ pub unsafe extern "C" fn mj_err_get_debug_info() -> *mut c_char {
                 .and_then(|x| {
                     let mut info = String::new();
                     if x.name().is_some() {
-                        writeln!(info, "{}", x.display_debug_info()).unwrap();
+                        let err_info = x.display_debug_info().to_string();
+                        if !err_info.is_empty() {
+                            writeln!(info, "{err_info}").unwrap();
+                        }
                     }
                     let mut source_opt = x.source();
                     while let Some(source) = source_opt {
-                        writeln!(info, "\ncaused by: {source}").unwrap();
                         if let Some(source) = source.downcast_ref::<Error>() {
                             if source.name().is_some() {
-                                writeln!(info, "{}", source.display_debug_info()).unwrap();
+                                let src_info = x.display_debug_info().to_string();
+                                if !src_info.is_empty() {
+                                    writeln!(info, "\ncaused by: {source}\n{src_info}").unwrap();
+                                }
                             }
                         }
                         source_opt = source.source();


### PR DESCRIPTION
Follow up #775. When debug is disabled, a `\n` newline character is still returned due to the use of `writeln!()`. 

Not sure if it is the best approach to check is debug info are set or not.