### PR TITLE
Fix a big in reverse slicing and add a test

### DIFF
--- a/minijinja/src/compiler/codegen.rs
+++ b/minijinja/src/compiler/codegen.rs
@@ -615,7 +615,7 @@ impl<'source> CodeGenerator<'source> {
                 if let Some(ref start) = s.start {
                     self.compile_expr(start);
                 } else {
-                    self.add(Instruction::LoadConst(Value::from(0)));
+                    self.add(Instruction::LoadConst(Value::from(())));
                 }
                 if let Some(ref stop) = s.stop {
                     self.compile_expr(stop);
@@ -625,7 +625,7 @@ impl<'source> CodeGenerator<'source> {
                 if let Some(ref step) = s.step {
                     self.compile_expr(step);
                 } else {
-                    self.add(Instruction::LoadConst(Value::from(1)));
+                    self.add(Instruction::LoadConst(Value::from(())));
                 }
                 self.add(Instruction::Slice);
                 self.pop_span();

--- a/minijinja/tests/inputs/slicing.txt
+++ b/minijinja/tests/inputs/slicing.txt
@@ -17,3 +17,9 @@
 {{ intrange[2:10:2] }}
 {{ intrange[2:10][0] }}
 {{ intrange[2:10][2:][0] }}
+{{ intrange[::-1] }}
+{{ intrange[::-2] }}
+{{ intrange[4:2:-1] }}
+{{ intrange[4:2:-2] }}
+{{ intrange[-5::-1] }}
+{{ intrange[-5:2:-1] }}

--- a/minijinja/tests/snapshots/test_templates__vm@slicing.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@slicing.txt.snap
@@ -1,6 +1,6 @@
 ---
 source: minijinja/tests/test_templates.rs
-description: "{{ hello[:] }}\n{{ hello[1:] }}\n{{ hello[1:-1] }}\n{{ hello[::2] }}\n{{ hello[2:10] }}\n{{ hello[2:10:2] }}\n{{ intrange[:] }}\n{{ intrange[1:] }}\n{{ intrange[1:-1] }}\n{{ intrange[::2] }}\n{{ intrange[2:10] }}\n{{ intrange[2:10:2] }}\n{{ intrange[2:10][0] }}\n{{ intrange[2:10][2:][0] }}"
+description: "{{ hello[:] }}\n{{ hello[1:] }}\n{{ hello[1:-1] }}\n{{ hello[::2] }}\n{{ hello[2:10] }}\n{{ hello[2:10:2] }}\n{{ intrange[:] }}\n{{ intrange[1:] }}\n{{ intrange[1:-1] }}\n{{ intrange[::2] }}\n{{ intrange[2:10] }}\n{{ intrange[2:10:2] }}\n{{ intrange[2:10][0] }}\n{{ intrange[2:10][2:][0] }}\n{{ intrange[::-1] }}\n{{ intrange[::-2] }}\n{{ intrange[4:2:-1] }}\n{{ intrange[4:2:-2] }}\n{{ intrange[-5::-1] }}\n{{ intrange[-5:2:-1] }}"
 info:
   hello: Hällo Wörld
   intrange:
@@ -30,3 +30,9 @@ loWr
 [2, 4, 6, 8]
 2
 4
+[9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+[9, 7, 5, 3, 1]
+[4, 3]
+[4]
+[5, 4, 3, 2, 1, 0]
+[5, 4, 3]


### PR DESCRIPTION
This fixes an issue introduced by the last change where the bytecode did not pass `None` as intended.  It also avoids `successors` which does not have a length hint.