### PR TITLE
fix regression with the next-generation trait solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to MiniJinja are documented here.
 
+## 2.10.2
+
+* Fixed an issue with the function bounds that caused the
+  next-generation trait resolver to fail.  #787
+
 ## 2.10.1
 
 - Re-release of 2.10.0 because of a broken release process.

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -699,9 +699,7 @@ impl<'source> Environment<'source> {
     pub fn add_filter<N, F, Rv, Args>(&mut self, name: N, f: F)
     where
         N: Into<Cow<'source, str>>,
-        // the crazy bounds here exist to enable borrowing in closures
-        F: functions::Function<Rv, Args>
-            + for<'a> functions::Function<Rv, <Args as FunctionArgs<'a>>::Output>,
+        F: functions::Function<Rv, Args>,
         Rv: FunctionResult,
         Args: for<'a> FunctionArgs<'a>,
     {
@@ -721,9 +719,7 @@ impl<'source> Environment<'source> {
     pub fn add_test<N, F, Rv, Args>(&mut self, name: N, f: F)
     where
         N: Into<Cow<'source, str>>,
-        // the crazy bounds here exist to enable borrowing in closures
-        F: functions::Function<Rv, Args>
-            + for<'a> functions::Function<Rv, <Args as FunctionArgs<'a>>::Output>,
+        F: functions::Function<Rv, Args>,
         Rv: FunctionResult,
         Args: for<'a> FunctionArgs<'a>,
     {
@@ -747,9 +743,7 @@ impl<'source> Environment<'source> {
     pub fn add_function<N, F, Rv, Args>(&mut self, name: N, f: F)
     where
         N: Into<Cow<'source, str>>,
-        // the crazy bounds here exist to enable borrowing in closures
-        F: functions::Function<Rv, Args>
-            + for<'a> functions::Function<Rv, <Args as FunctionArgs<'a>>::Output>,
+        F: functions::Function<Rv, Args>,
         Rv: FunctionResult,
         Args: for<'a> FunctionArgs<'a>,
     {

--- a/minijinja/src/functions.rs
+++ b/minijinja/src/functions.rs
@@ -230,6 +230,8 @@ macro_rules! tuple_impls {
             Rv: FunctionResult,
             $($name: for<'a> ArgType<'a>,)*
         {
+            // Need to allow this lint for the one-element tuple case.
+            #[allow(clippy::needless_lifetimes)]
             fn invoke<'a>(&self, args: ($(<$name as ArgType<'a>>::Output,)*), _: SealedMarker) -> Rv {
                 self.invoke_nested(args)
             }

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -1056,9 +1056,7 @@ impl Value {
     /// ```
     pub fn from_function<F, Rv, Args>(f: F) -> Value
     where
-        // the crazy bounds here exist to enable borrowing in closures
-        F: functions::Function<Rv, Args>
-            + for<'a> functions::Function<Rv, <Args as FunctionArgs<'a>>::Output>,
+        F: functions::Function<Rv, Args>,
         Rv: FunctionResult,
         Args: for<'a> FunctionArgs<'a>,
     {


### PR DESCRIPTION
Hi there :wave: unfortunately minijinja currently relies on a type system bug. This code will break with the `-Znext-solver`.

Let's look at the relevant section of the minimization in https://github.com/rust-lang/trait-system-refactor-initiative/issues/195#issuecomment-2851196452 [[godbolt](https://rust.godbolt.org/z/PcoMbjMdh)]:
```rust
trait Arg<'a> {
    type Output;
}

trait Filter<A> {}
impl<A, F: FnMut(A)> Filter<A> for F {}

fn inspect_values<F, A>(_: F)
where
    A: for<'a> Arg<'a>,
    F: for<'a> Filter<<A as Arg<'a>>::Output> + Filter<A>,
{
}

fn generic_caller<F, A>(f: F)
where
    A: for<'a> Arg<'a>,
    F: for<'a> Filter<<A as Arg<'a>>::Output> + Filter<A>,
{
    inspect_values(f)
}
```
The call to `inspect_values` starts out with `A` and `F` being unconstrained inference variables, let's call them `?a` and `?f`. `?f` then gets constrained to the `F` parameter from `generic_caller`. This leaves us with the following trait bounds: 
- `?a: for<'a> Arg<'a>`
- `F: for<'a> Filter<<?a as Arg<'a>>::Output>`
- `F: Filter<?a>`

One of these bounds has to constrain `?a` to the `A` parameter for this to compile. `?a: for<'a> Arg<'a>` certainly cannot do so, so we're left with the `F: Filter` bounds.

---

`F: Filter<?a>` can be proven by either using the `F: for<'a> Filter<<A as Arg<'a>>::Output>` or the `F: Filter<A>` where-bound of `generic_caller`. The first instantiates `?a` with `<<A as Arg<'a>>::Output`, the second with `A`. As both where-bounds are valid, this remains ambiguous.

---

`F: for<'a> Filter<<?a as Arg<'a>>::Output>` can *in theory* also be proven by using both where-bounds of `generic_caller`. The fact that `F: for<'a> Filter<<A as Arg<'a>>::Output>` may apply should be clear, but `F: Filter<A>` is also totally valid. We'd just need to instantiate `?a` with some type `T` for which `<T as Arg<'a>>::Output` normalizes to `A`.

What's even more subtle is that even if we use the `F: for<'a> Filter<<A as Arg<'a>>::Output>` where-bound to to prove `F: for<'a> Filter<<?a as Arg<'a>>::Output>`, this does not necessarily have to constrain `?a` to `A`. It would also be valid to instantiate `?a` with some type `T != A` for which `<T as Arg<'a>>::Output` normalizes to `<A as Arg<'a>>::Output>`.

---

The current type system implementation incorrectly relates associated types structurally, i.e. by simply checking that their generic arguments are equal, if these associated types reference higher ranked regions, the `'a` from `for<'a>`. This can result in a lot of weird errors and questionable inference behavior, see https://github.com/rust-lang/trait-system-refactor-initiative/issues/9 for an example. Trying to support this behavior with the new implementation is pretty much impossible without adding explicit hacks for each individual breakage. 

See https://github.com/rust-lang/trait-system-refactor-initiative/issues/195 and https://github.com/rust-lang/trait-system-refactor-initiative/issues/168 for more details about the breakage.

## What this PR is doing

To avoid the ambiguity errors with `-Znext-solver`, I am moving the duplicate where-bounds into the `Function` impl so that generic functions have a single `F: Function` where-bound which references `A` directly.

I don't believe this to be a breaking change unless people try to use the `Function` trait for functions whose signature is not higher ranked, i.e. `fn(&'a str)` for some early-bound lifetime `'a`. However, given that `fn invoke` is `#[doc(hidden)]` and all uses of the trait inside of `minijinja` already had a higher-ranked bound, this should not be an issue.

If you think this change is acceptable, it would be awesome to also backport this change to older versions as the crater run in https://github.com/rust-lang/rust/pull/133502 discovered quite a few projects which depend on older versions of this crate. 

I am sorry for the inconvenience and please ask any questions if you would like some additional clarification. Thanks :>

