### PR TITLE
Add support for new escape sequences and Python compatible rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,6 +2449,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pycompat-rendering"
+version = "0.1.0"
+dependencies = [
+ "minijinja",
+]
+
+[[package]]
 name = "pyo3"
 version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/pycompat-rendering/Cargo.toml
+++ b/examples/pycompat-rendering/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "pycompat-rendering"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+minijinja = { path = "../../minijinja" }

--- a/examples/pycompat-rendering/README.md
+++ b/examples/pycompat-rendering/README.md
@@ -1,0 +1,37 @@
+# Python-Compatible Rendering Example
+
+This example demonstrates MiniJinja's Python-compatible rendering mode.
+
+## Background
+
+By default, MiniJinja renders values in its own style:
+- Booleans: `true`/`false`
+- None: `none`
+- Strings: Rust-style escaping and quoting
+
+When Python compatibility is needed (e.g., for SQL templating where precise output matters), you can enable PyCompat mode to match Python Jinja2's output:
+- Booleans: `True`/`False`
+- None: `None`
+- Strings: Python-style escaping and quoting
+
+## Usage
+
+```rust
+use minijinja::Environment;
+
+let mut env = Environment::new();
+
+// Enable Python-compatible rendering
+env.set_pycompat_rendering(true);
+
+// Now templates will render values like Python Jinja2
+let tmpl = env.template_from_str("{{ [true, false, none, 'hello'] }}")?;
+let result = tmpl.render(minijinja::context!{})?;
+// Output: [True, False, None, 'hello']
+```
+
+## Running this Example
+
+```bash
+cargo run --example pycompat-rendering
+```

--- a/examples/pycompat-rendering/src/main.rs
+++ b/examples/pycompat-rendering/src/main.rs
@@ -1,0 +1,72 @@
+use minijinja::{context, Environment};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== MiniJinja Rendering Comparison ===");
+
+    // Create environments for both modes to avoid borrowing issues
+    let mut env_default = Environment::new();
+    let mut env_pycompat = Environment::new();
+
+    // Add the same template to both environments
+    let template_str = r#"{{ [true, false, none, 'foo', "bar'baz", '\x13'] }}"#;
+    env_default.add_template("demo", template_str)?;
+    env_pycompat.add_template("demo", template_str)?;
+
+    // Configure rendering modes
+    env_default.set_pycompat_rendering(false);
+    env_pycompat.set_pycompat_rendering(true);
+
+    // Test rendering
+    let result_default = env_default.get_template("demo")?.render(context! {})?;
+    let result_pycompat = env_pycompat.get_template("demo")?.render(context! {})?;
+
+    println!("Default rendering: {}", result_default);
+    println!("PyCompat rendering: {}", result_pycompat);
+
+    println!("\n=== Individual Value Comparison ===");
+
+    // Test individual values
+    env_default.add_template("bool_true", "{{ true }}")?;
+    env_default.add_template("bool_false", "{{ false }}")?;
+    env_default.add_template("none_val", "{{ none }}")?;
+
+    env_pycompat.add_template("bool_true", "{{ true }}")?;
+    env_pycompat.add_template("bool_false", "{{ false }}")?;
+    env_pycompat.add_template("none_val", "{{ none }}")?;
+
+    println!("Default mode:");
+    println!(
+        "  true -> {}",
+        env_default.get_template("bool_true")?.render(context! {})?
+    );
+    println!(
+        "  false -> {}",
+        env_default
+            .get_template("bool_false")?
+            .render(context! {})?
+    );
+    println!(
+        "  none -> {}",
+        env_default.get_template("none_val")?.render(context! {})?
+    );
+
+    println!("PyCompat mode:");
+    println!(
+        "  true -> {}",
+        env_pycompat
+            .get_template("bool_true")?
+            .render(context! {})?
+    );
+    println!(
+        "  false -> {}",
+        env_pycompat
+            .get_template("bool_false")?
+            .render(context! {})?
+    );
+    println!(
+        "  none -> {}",
+        env_pycompat.get_template("none_val")?.render(context! {})?
+    );
+
+    Ok(())
+}

--- a/minijinja/src/environment.rs
+++ b/minijinja/src/environment.rs
@@ -59,6 +59,7 @@ pub struct Environment<'source> {
     #[cfg(feature = "fuel")]
     fuel: Option<u64>,
     recursion_limit: usize,
+    pycompat_rendering: bool,
 }
 
 impl Default for Environment<'_> {
@@ -111,6 +112,7 @@ impl<'source> Environment<'source> {
             #[cfg(feature = "fuel")]
             fuel: None,
             recursion_limit: MAX_RECURSION,
+            pycompat_rendering: false,
         }
     }
 
@@ -133,6 +135,7 @@ impl<'source> Environment<'source> {
             #[cfg(feature = "fuel")]
             fuel: None,
             recursion_limit: MAX_RECURSION,
+            pycompat_rendering: false,
         }
     }
 
@@ -574,6 +577,24 @@ impl<'source> Environment<'source> {
     #[cfg(feature = "debug")]
     pub fn debug(&self) -> bool {
         self.debug
+    }
+
+    /// Enables or disables Python-compatible rendering mode.
+    ///
+    /// When enabled, certain value types will be rendered to match Python Jinja2's output:
+    /// - `true`/`false` will be rendered as `True`/`False`
+    /// - `none` will be rendered as `None`
+    /// - String escaping and quoting will match Python's style
+    ///
+    /// This is useful when you need template output that's compatible with Python Jinja2.
+    /// By default this is disabled.
+    pub fn set_pycompat_rendering(&mut self, enabled: bool) {
+        self.pycompat_rendering = enabled;
+    }
+
+    /// Returns whether Python-compatible rendering mode is enabled.
+    pub fn pycompat_rendering(&self) -> bool {
+        self.pycompat_rendering
     }
 
     /// Sets the optional fuel of the engine.

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -318,7 +318,7 @@ impl Unescaper {
         for _ in 0..2 {
             let next_char = chars.as_str().chars().next();
             if let Some(c) = next_char {
-                if c >= '0' && c <= '7' {
+                if ('0'..='7').contains(&c) {
                     octal_str.push(c);
                     chars.next(); // consume the character
                 } else {

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -277,6 +277,14 @@ impl Unescaper {
                             let val = ok!(self.parse_u16(&mut char_iter));
                             ok!(self.push_u16(val));
                         }
+                        'x' => {
+                            let val = ok!(self.parse_hex_byte(&mut char_iter));
+                            ok!(self.push_char(val as char));
+                        }
+                        '0'..='7' => {
+                            let val = ok!(self.parse_octal_byte(d, &mut char_iter));
+                            ok!(self.push_char(val as char));
+                        }
                         _ => return Err(ErrorKind::BadEscape.into()),
                     },
                 }
@@ -295,6 +303,33 @@ impl Unescaper {
     fn parse_u16(&self, chars: &mut Chars) -> Result<u16, Error> {
         let hexnum = chars.chain(repeat('\0')).take(4).collect::<String>();
         u16::from_str_radix(&hexnum, 16).map_err(|_| ErrorKind::BadEscape.into())
+    }
+
+    fn parse_hex_byte(&self, chars: &mut Chars) -> Result<u8, Error> {
+        let hexnum = chars.chain(repeat('\0')).take(2).collect::<String>();
+        u8::from_str_radix(&hexnum, 16).map_err(|_| ErrorKind::BadEscape.into())
+    }
+
+    fn parse_octal_byte(&self, first_digit: char, chars: &mut Chars) -> Result<u8, Error> {
+        let mut octal_str = String::new();
+        octal_str.push(first_digit);
+
+        // Collect up to 2 more octal digits (0-7)
+        for _ in 0..2 {
+            let next_char = chars.as_str().chars().next();
+            if let Some(c) = next_char {
+                if c >= '0' && c <= '7' {
+                    octal_str.push(c);
+                    chars.next(); // consume the character
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        u8::from_str_radix(&octal_str, 8).map_err(|_| ErrorKind::BadEscape.into())
     }
 
     fn push_u16(&mut self, c: u16) -> Result<(), Error> {
@@ -450,6 +485,26 @@ mod tests {
         assert_eq!(unescape(r"\t\b\f\r\n\\\/").unwrap(), "\t\x08\x0c\r\n\\/");
         assert_eq!(unescape("foobarbaz").unwrap(), "foobarbaz");
         assert_eq!(unescape(r"\ud83d\udca9").unwrap(), "💩");
+
+        // Test new escape sequences
+        assert_eq!(unescape(r"\0").unwrap(), "\0");
+        assert_eq!(unescape(r"foo\0bar").unwrap(), "foo\0bar");
+        assert_eq!(unescape(r"\x00").unwrap(), "\0");
+        assert_eq!(unescape(r"\x42").unwrap(), "B");
+        assert_eq!(unescape(r"\xab").unwrap(), "\u{ab}");
+        assert_eq!(unescape(r"foo\x42bar").unwrap(), "fooBbar");
+        assert_eq!(unescape(r"\x0a").unwrap(), "\n");
+        assert_eq!(unescape(r"\x0d").unwrap(), "\r");
+
+        // Test octal escape sequences
+        assert_eq!(unescape(r"\0").unwrap(), "\0"); // octal 0 = null
+        assert_eq!(unescape(r"\1").unwrap(), "\x01"); // octal 1 = SOH
+        assert_eq!(unescape(r"\12").unwrap(), "\n"); // octal 12 = 10 decimal = LF
+        assert_eq!(unescape(r"\123").unwrap(), "S"); // octal 123 = 83 decimal = 'S'
+        assert_eq!(unescape(r"\141").unwrap(), "a"); // octal 141 = 97 decimal = 'a'
+        assert_eq!(unescape(r"\177").unwrap(), "\x7f"); // octal 177 = 127 decimal = DEL
+        assert_eq!(unescape(r"foo\123bar").unwrap(), "fooSbar"); // 'S' in the middle
+        assert_eq!(unescape(r"\101\102\103").unwrap(), "ABC"); // octal for A, B, C
     }
 
     #[test]

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -91,6 +91,7 @@ impl<'env> Vm<'env> {
         out: &mut Output,
         auto_escape: AutoEscape,
     ) -> Result<(Option<Value>, State<'template, 'env>), Error> {
+        let _pycompat_guard = crate::value::mark_pycompat_rendering(self.env.pycompat_rendering());
         let mut state = State::new(
             Context::new_with_frame(self.env, ok!(Frame::new_checked(root))),
             auto_escape,

--- a/minijinja/tests/test_pycompat_rendering.rs
+++ b/minijinja/tests/test_pycompat_rendering.rs
@@ -1,0 +1,158 @@
+use minijinja::{context, Environment};
+
+#[test]
+fn test_pycompat_rendering_boolean_values() {
+    let mut env = Environment::new();
+
+    env.add_template("bool_true", "{{ true }}").unwrap();
+    env.add_template("bool_false", "{{ false }}").unwrap();
+
+    // Test default rendering
+    env.set_pycompat_rendering(false);
+    let true_default = env
+        .get_template("bool_true")
+        .unwrap()
+        .render(context! {})
+        .unwrap();
+    let false_default = env
+        .get_template("bool_false")
+        .unwrap()
+        .render(context! {})
+        .unwrap();
+
+    assert_eq!(true_default, "true");
+    assert_eq!(false_default, "false");
+
+    // Test pycompat rendering
+    env.set_pycompat_rendering(true);
+    let true_pycompat = env
+        .get_template("bool_true")
+        .unwrap()
+        .render(context! {})
+        .unwrap();
+    let false_pycompat = env
+        .get_template("bool_false")
+        .unwrap()
+        .render(context! {})
+        .unwrap();
+
+    assert_eq!(true_pycompat, "True");
+    assert_eq!(false_pycompat, "False");
+}
+
+#[test]
+fn test_pycompat_rendering_none_value() {
+    let mut env = Environment::new();
+
+    env.add_template("none_val", "{{ none }}").unwrap();
+
+    // Test default rendering
+    env.set_pycompat_rendering(false);
+    let none_default = env
+        .get_template("none_val")
+        .unwrap()
+        .render(context! {})
+        .unwrap();
+
+    assert_eq!(none_default, "none");
+
+    // Test pycompat rendering
+    env.set_pycompat_rendering(true);
+    let none_pycompat = env
+        .get_template("none_val")
+        .unwrap()
+        .render(context! {})
+        .unwrap();
+
+    assert_eq!(none_pycompat, "None");
+}
+
+#[test]
+fn test_pycompat_rendering_array() {
+    let mut env = Environment::new();
+
+    env.add_template("array", "{{ [true, false, none] }}")
+        .unwrap();
+
+    // Test default rendering
+    env.set_pycompat_rendering(false);
+    let array_default = env
+        .get_template("array")
+        .unwrap()
+        .render(context! {})
+        .unwrap();
+
+    assert_eq!(array_default, "[true, false, none]");
+
+    // Test pycompat rendering
+    env.set_pycompat_rendering(true);
+    let array_pycompat = env
+        .get_template("array")
+        .unwrap()
+        .render(context! {})
+        .unwrap();
+
+    assert_eq!(array_pycompat, "[True, False, None]");
+}
+
+#[test]
+fn test_pycompat_rendering_complex_case() {
+    let mut env = Environment::new();
+
+    // Test the specific case from the issue: {{ [true, false, none, 'foo', "bar'baz", '\x13'] }}
+    env.add_template("complex", "{{ [true, false, none, 'foo'] }}")
+        .unwrap();
+
+    // Test default rendering
+    env.set_pycompat_rendering(false);
+    let _complex_default = env
+        .get_template("complex")
+        .unwrap()
+        .render(context! {})
+        .unwrap();
+
+    // Test pycompat rendering
+    env.set_pycompat_rendering(true);
+    let complex_pycompat = env
+        .get_template("complex")
+        .unwrap()
+        .render(context! {})
+        .unwrap();
+
+    // Check that pycompat has Python-style values
+    assert!(complex_pycompat.contains("True"));
+    assert!(complex_pycompat.contains("False"));
+    assert!(complex_pycompat.contains("None"));
+    assert!(complex_pycompat.contains("'foo'"));
+}
+
+#[test]
+fn test_pycompat_rendering_exact_github_case() {
+    let mut env = Environment::new();
+
+    // Test the exact case from the GitHub issue
+    env.add_template(
+        "github_case",
+        r#"{{ [true, false, none, 'foo', "bar'baz", '\x13'] }}"#,
+    )
+    .unwrap();
+
+    // Test pycompat rendering
+    env.set_pycompat_rendering(true);
+    let result = env
+        .get_template("github_case")
+        .unwrap()
+        .render(context! {})
+        .unwrap();
+
+    println!("GitHub case result: {}", result);
+
+    // Check that pycompat has Python-style values
+    assert!(result.contains("True"));
+    assert!(result.contains("False"));
+    assert!(result.contains("None"));
+    assert!(result.contains("'foo'"));
+    // Check for proper string quoting and escaping
+    assert!(result.contains("\"bar'baz\"") || result.contains("'bar\\'baz'"));
+    assert!(result.contains("'\\x13'"));
+}


### PR DESCRIPTION
Implements \xNN (hexadecimal) and \NNN (octal) escape sequences to match Jinja2 compatibility. The \0 sequence is now handled as part of the octal system for consistency.

This was made with Claude Code for this video: https://www.youtube.com/watch?v=sQYXZCUvpIc

Fixes #803

Fixes #785

🤖 Generated with [Claude Code](https://claude.ai/code)