### PR TITLE
fix: mixed up example names, "object-using-async" and "function-using-async"

### DIFF
--- a/examples/function-using-async/Cargo.toml
+++ b/examples/function-using-async/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "object-using-async"
+name = "function-using-async"
 version = "0.1.0"
 edition = "2021"
 publish = false

--- a/examples/object-using-async/Cargo.toml
+++ b/examples/object-using-async/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "function-using-async"
+name = "object-using-async"
 version = "0.1.0"
 edition = "2021"
 publish = false


### PR DESCRIPTION
I was trying to run the examples and was confused after modifying the function-using-async and not seeing my changes.
The problem was the Cargo.toml of both examples have the wrong "name" (or the folders have the wrong name).