### PR TITLE
Add multiple-key support in the sort filter

### DIFF
--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -740,7 +740,7 @@ mod builtins {
     ///
     /// * `case_sensitive`: set to `true` to make the sorting of strings case sensitive.
     /// * `attribute`: can be set to an attribute or dotted path to sort by that attribute.
-    ///    can be a comma-separated list of attributes forming a composite key like "age, name".
+    ///   can be a comma-separated list of attributes forming a composite key like "age, name".
     /// * `reverse`: set to `true` to sort in reverse.
     ///
     /// ```jinja

--- a/minijinja/tests/test_filters.rs
+++ b/minijinja/tests/test_filters.rs
@@ -231,3 +231,63 @@ fn test_zip_single_iterable() {
     let result = tmpl.render(context!()).unwrap();
     assert_eq!(result, "[[1], [2], [3]]");
 }
+
+#[test]
+fn test_sort_keys() {
+    let env = Environment::new();
+    let tmpl = env
+        .template_from_str(
+            r"{{ [{'a': 1, 'b': 2, 'c': 5}, {'a': 2, 'b': 1, 'c': 6}] | sort(keys=['b', 'a']) }}",
+        )
+        .unwrap();
+    let result = tmpl.render(context!()).unwrap();
+    assert_eq!(
+        result,
+        r#"[{"a": 2, "b": 1, "c": 6}, {"a": 1, "b": 2, "c": 5}]"#
+    );
+}
+
+#[test]
+fn test_sort_keys_reverse() {
+    let env = Environment::new();
+    let ctx = context! {
+        cities => vec![
+            context!(name => "Sydney", country => "Australia"),
+            context!(name => "Sydney", country => "Canada"),
+            context!(name => "Kochi", country => "India"),
+            context!(name => "Kochi", country => "Japan"),
+        ]
+    };
+    let tmpl = env
+        .template_from_str(
+            "{{ cities | sort(keys=['name', 'country'], reverse=true) \
+             | map(attribute='country')}}",
+        )
+        .unwrap();
+    let result = tmpl.render(ctx).unwrap();
+    assert_eq!(result, r#"["Canada", "Australia", "Japan", "India"]"#);
+}
+
+#[test]
+fn test_sort_keys_single() {
+    let env = Environment::new();
+    let tmpl = env
+        .template_from_str(r"{{ [{'a': 1, 'b': 2}, {'a': 2, 'b': 1}] | sort(keys=['b']) }}")
+        .unwrap();
+    let result = tmpl.render(context!()).unwrap();
+    assert_eq!(result, r#"[{"a": 2, "b": 1}, {"a": 1, "b": 2}]"#);
+}
+
+#[test]
+fn test_sort_attribute_and_keys_error() {
+    let env = Environment::new();
+    let tmpl = env
+        .template_from_str(
+            r"{{ [{'a': 1, 'b': 2}, {'a': 2, 'b': 1}] | sort(attribute='a', keys=['b', 'a']) }}",
+        )
+        .unwrap();
+    let err = tmpl.render(context!()).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("cannot use 'attribute' and 'keys' together"));
+}

--- a/minijinja/tests/test_filters.rs
+++ b/minijinja/tests/test_filters.rs
@@ -233,11 +233,11 @@ fn test_zip_single_iterable() {
 }
 
 #[test]
-fn test_sort_keys() {
+fn test_sort_attribute_list() {
     let env = Environment::new();
     let tmpl = env
         .template_from_str(
-            r"{{ [{'a': 1, 'b': 2, 'c': 5}, {'a': 2, 'b': 1, 'c': 6}] | sort(keys=['b', 'a']) }}",
+            r"{{ [{'a': 1, 'b': 2, 'c': 5}, {'a': 2, 'b': 1, 'c': 6}] | sort(attribute='b,a') }}",
         )
         .unwrap();
     let result = tmpl.render(context!()).unwrap();
@@ -248,7 +248,7 @@ fn test_sort_keys() {
 }
 
 #[test]
-fn test_sort_keys_reverse() {
+fn test_sort_attribute_list_reverse() {
     let env = Environment::new();
     let ctx = context! {
         cities => vec![
@@ -260,7 +260,7 @@ fn test_sort_keys_reverse() {
     };
     let tmpl = env
         .template_from_str(
-            "{{ cities | sort(keys=['name', 'country'], reverse=true) \
+            "{{ cities | sort(attribute='name, country', reverse=true) \
              | map(attribute='country')}}",
         )
         .unwrap();
@@ -269,25 +269,11 @@ fn test_sort_keys_reverse() {
 }
 
 #[test]
-fn test_sort_keys_single() {
+fn test_sort_attribute_list_single() {
     let env = Environment::new();
     let tmpl = env
-        .template_from_str(r"{{ [{'a': 1, 'b': 2}, {'a': 2, 'b': 1}] | sort(keys=['b']) }}")
+        .template_from_str(r"{{ [{'a': 1, 'b': 2}, {'a': 2, 'b': 1}] | sort(attribute='b,') }}")
         .unwrap();
     let result = tmpl.render(context!()).unwrap();
     assert_eq!(result, r#"[{"a": 2, "b": 1}, {"a": 1, "b": 2}]"#);
-}
-
-#[test]
-fn test_sort_attribute_and_keys_error() {
-    let env = Environment::new();
-    let tmpl = env
-        .template_from_str(
-            r"{{ [{'a': 1, 'b': 2}, {'a': 2, 'b': 1}] | sort(attribute='a', keys=['b', 'a']) }}",
-        )
-        .unwrap();
-    let err = tmpl.render(context!()).unwrap_err();
-    assert!(err
-        .to_string()
-        .contains("cannot use 'attribute' and 'keys' together"));
 }


### PR DESCRIPTION
Currently, the `sort` filter allows sorting objects using a custom key via the "attribute" keyword argument, which is limited to fetching a single field from the object and using that as the key. Sometimes it is useful to sort objects using multiple keys, or a composite key made of multiple fields of the object. Add a new keyword argument "keys" to support such keys.

Now, you can not only sort cities by their name ...

`{{ cities|sort(attribute="name") }}`

... but also sort cities with the same name by their country:

`{{ cities|sort(keys=["name", "country"]) }}`