### PR TITLE
Add tuple support to template engine

### DIFF
--- a/minijinja/src/compiler/codegen.rs
+++ b/minijinja/src/compiler/codegen.rs
@@ -714,6 +714,13 @@ impl<'source> CodeGenerator<'source> {
                 }
                 self.add(Instruction::BuildList(Some(l.items.len())));
             }
+            ast::Expr::Tuple(t) => {
+                self.set_line_from_span(t.span());
+                for item in &t.items {
+                    self.compile_expr(item);
+                }
+                self.add(Instruction::BuildTuple(Some(t.items.len())));
+            }
             ast::Expr::Map(m) => {
                 self.set_line_from_span(m.span());
                 assert_eq!(m.keys.len(), m.values.len());

--- a/minijinja/src/compiler/instructions.rs
+++ b/minijinja/src/compiler/instructions.rs
@@ -66,6 +66,9 @@ pub enum Instruction<'source> {
     /// Builds a list of the last n pairs on the stack.
     BuildList(Option<usize>),
 
+    /// Builds a tuple of the last n pairs on the stack.
+    BuildTuple(Option<usize>),
+
     /// Unpacks a list into N stack items.
     UnpackList(usize),
 

--- a/minijinja/src/compiler/meta.rs
+++ b/minijinja/src/compiler/meta.rs
@@ -186,6 +186,7 @@ fn tracker_visit_expr<'a>(expr: &ast::Expr<'a>, state: &mut AssignmentTracker<'a
                 .for_each(|x| tracker_visit_callarg(x, state));
         }
         ast::Expr::List(expr) => expr.items.iter().for_each(|x| tracker_visit_expr(x, state)),
+        ast::Expr::Tuple(expr) => expr.items.iter().for_each(|x| tracker_visit_expr(x, state)),
         ast::Expr::Map(expr) => expr.keys.iter().zip(expr.values.iter()).for_each(|(k, v)| {
             tracker_visit_expr(k, state);
             tracker_visit_expr(v, state);
@@ -197,6 +198,7 @@ fn track_assign<'a>(expr: &ast::Expr<'a>, state: &mut AssignmentTracker<'a>) {
     match expr {
         ast::Expr::Var(var) => state.assign(var.id),
         ast::Expr::List(list) => list.items.iter().for_each(|x| track_assign(x, state)),
+        ast::Expr::Tuple(tuple) => tuple.items.iter().for_each(|x| track_assign(x, state)),
         _ => {}
     }
 }

--- a/minijinja/src/compiler/parser.rs
+++ b/minijinja/src/compiler/parser.rs
@@ -716,11 +716,10 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_tuple_or_expression(&mut self, span: Span) -> Result<ast::Expr<'a>, Error> {
-        // MiniJinja does not really have tuples, but it treats the tuple
-        // syntax the same as lists.
+        // Parse tuple expressions as actual tuples now
         if skip_token!(self, Token::ParenClose) {
-            return Ok(ast::Expr::List(Spanned::new(
-                ast::List { items: vec![] },
+            return Ok(ast::Expr::Tuple(Spanned::new(
+                ast::Tuple { items: vec![] },
                 self.stream.expand_span(span),
             )));
         }
@@ -737,8 +736,8 @@ impl<'a> Parser<'a> {
                 }
                 items.push(ok!(self.parse_expr()));
             }
-            expr = ast::Expr::List(Spanned::new(
-                ast::List { items },
+            expr = ast::Expr::Tuple(Spanned::new(
+                ast::Tuple { items },
                 self.stream.expand_span(span),
             ));
         } else {

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -216,7 +216,9 @@ use crate::value::ops::as_f64;
 use crate::value::serialize::transform;
 use crate::vm::State;
 
-pub use crate::value::argtypes::{from_args, ArgType, FunctionArgs, FunctionResult, Kwargs, Rest};
+pub use crate::value::argtypes::{
+    from_args, ArgType, FunctionArgs, FunctionResult, Kwargs, Rest, Tuple,
+};
 pub use crate::value::merge_object::merge_maps;
 pub use crate::value::object::{DynObject, Enumerator, Object, ObjectExt, ObjectRepr};
 

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -403,6 +403,16 @@ impl<'env> Vm<'env> {
                     v.reverse();
                     stack.push(Value::from_object(v))
                 }
+                Instruction::BuildTuple(n) => {
+                    use crate::value::Tuple;
+                    let count = n.unwrap_or_else(|| stack.pop().try_into().unwrap());
+                    let mut v = Vec::with_capacity(untrusted_size_hint(count));
+                    for _ in 0..count {
+                        v.push(stack.pop());
+                    }
+                    v.reverse();
+                    stack.push(Value::from_object(Tuple::from(v)))
+                }
                 Instruction::UnpackList(count) => {
                     ctx_ok!(self.unpack_list(&mut stack, *count));
                 }

--- a/minijinja/tests/snapshots/test_parser__parser@set.txt.snap
+++ b/minijinja/tests/snapshots/test_parser__parser@set.txt.snap
@@ -28,7 +28,7 @@ Ok(
                         } @ 2:11-2:12,
                     ],
                 } @ 2:8-2:12,
-                expr: List {
+                expr: Tuple {
                     items: [
                         Const {
                             value: 1,

--- a/minijinja/tests/snapshots/test_parser__parser@tuples.txt.snap
+++ b/minijinja/tests/snapshots/test_parser__parser@tuples.txt.snap
@@ -25,7 +25,7 @@ Ok(
                 raw: "\n",
             } @ 1:15-2:0,
             EmitExpr {
-                expr: List {
+                expr: Tuple {
                     items: [
                         Const {
                             value: 1,
@@ -43,7 +43,7 @@ Ok(
                 raw: "\n",
             } @ 2:15-3:0,
             EmitExpr {
-                expr: List {
+                expr: Tuple {
                     items: [
                         Const {
                             value: 1,
@@ -55,7 +55,7 @@ Ok(
                 raw: "\n",
             } @ 3:10-4:0,
             EmitExpr {
-                expr: List {
+                expr: Tuple {
                     items: [],
                 } @ 4:3-4:5,
             } @ 4:0-4:5,


### PR DESCRIPTION
This adds experimental tuple support to MiniJinja.  It's a backwards incompatible change.

- Added proper tuple literal support to the template engine
- Tuples now render with Python-style formatting: `(item1, item2, ...)` 
- Single-item tuples display with trailing comma: `(item,)`
- Tuples are functionally equivalent to lists but have distinct visual representation

Refs #785