### PR TITLE
Fix `not undefined` with strict undefined behavior

### DIFF
--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -432,7 +432,7 @@ impl<'env> Vm<'env> {
                 Instruction::Lte => op_binop!(<=),
                 Instruction::Not => {
                     a = stack.pop();
-                    stack.push(Value::from(!a.is_true()));
+                    stack.push(Value::from(!ctx_ok!(undefined_behavior.is_true(&a))));
                 }
                 Instruction::StringConcat => {
                     a = stack.pop();

--- a/minijinja/tests/test_undefined.rs
+++ b/minijinja/tests/test_undefined.rs
@@ -28,6 +28,7 @@ fn test_lenient_undefined() {
     );
     assert_eq!(render!(in env, "{{ 'foo' is in(undefined) }}"), "false");
     assert_eq!(render!(in env, "<{{ undefined }}>"), "<>");
+    assert_eq!(render!(in env, "{{ not undefined }}"), "true");
     assert_eq!(render!(in env, "{{ undefined is undefined }}"), "true");
     assert_eq!(
         render!(in env, "{{ x.foo is undefined }}", x => HashMap::<String, String>::new()),
@@ -72,6 +73,7 @@ fn test_semi_strict_undefined() {
         env.render_str("<{{ undefined }}>", ()).unwrap_err().kind(),
         ErrorKind::UndefinedError
     );
+    assert_eq!(render!(in env, "{{ not undefined }}"), "true");
     assert_eq!(render!(in env, "{{ undefined is undefined }}"), "true");
     assert_eq!(render!(in env, "<{{ 42 if false }}>"), "<>");
     assert_eq!(
@@ -139,6 +141,12 @@ fn test_strict_undefined() {
         env.render_str("<{{ undefined }}>", ()).unwrap_err().kind(),
         ErrorKind::UndefinedError
     );
+    assert_eq!(
+        env.render_str("<{{ not undefined }}>", ())
+            .unwrap_err()
+            .kind(),
+        ErrorKind::UndefinedError
+    );
     assert_eq!(render!(in env, "{{ undefined is undefined }}"), "true");
     assert_eq!(env.render_str("<{{ 42 if false }}>", ()).unwrap(), "<>");
     assert_eq!(
@@ -190,6 +198,7 @@ fn test_chainable_undefined() {
     );
     assert_eq!(render!(in env, "{{ 'foo' is in(undefined) }}"), "false");
     assert_eq!(render!(in env, "<{{ undefined }}>"), "<>");
+    assert_eq!(render!(in env, "{{ not undefined }}"), "true");
     assert_eq!(render!(in env, "{{ undefined is undefined }}"), "true");
     assert_eq!(render!(in env, "{{ undefined|list }}"), "[]");
     assert_eq!(render!(in env, "<{{ undefined|test }}>"), "<>");


### PR DESCRIPTION
When using `UndefinedBehavior::Strict`, the expression `not undefined` should produce `UndefinedError` instead of `true` in order to match Jinja2.