### PR TITLE
fix small typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ you must disclose this in the pull request and the extent to which it was.  When
 you use AI for PR descriptions you also must disclose that.
 
 It is rude not to disclose AI usage to the reviewer and it makes it hard to
-understand how much scrutiy needs to be placed on the contribution.
+understand how much scrutiny needs to be placed on the contribution.
 
 I am a strong supporter and users of AI, however I also recognize the challenges
 that lack of disclosure presents on Open Source projects.  Please be respectful


### PR DESCRIPTION
This PR fixes a tiny typo in the contributing guide.

Thanks for `mininjinja` (and all the other stuff!)