### PR TITLE
Remove redundant built-in filter function insertion

### DIFF
--- a/minijinja/src/defaults.rs
+++ b/minijinja/src/defaults.rs
@@ -99,7 +99,6 @@ pub(crate) fn get_builtin_filters() -> BTreeMap<Cow<'static, str>, Value> {
         rv.insert("min".into(), Value::from_function(filters::min));
         rv.insert("max".into(), Value::from_function(filters::max));
         rv.insert("sort".into(), Value::from_function(filters::sort));
-        rv.insert("d".into(), Value::from_function(filters::default));
         rv.insert("list".into(), Value::from_function(filters::list));
         rv.insert("string".into(), Value::from_function(filters::string));
         rv.insert("bool".into(), Value::from_function(filters::bool));


### PR DESCRIPTION
The removed line was identical with an earlier one, line 91.

I spotted this while reading parts of the source code and thought I'd quickly whip up a pull request to improve this. I hope I didn't miss anything and it was duplicated for a reason.

In any case, thanks for this wonderful and helpful crate. 🫶 