### PR TITLE
Add support for optional default value in pycompat dict.get method

### DIFF
--- a/minijinja-contrib/src/pycompat.rs
+++ b/minijinja-contrib/src/pycompat.rs
@@ -307,10 +307,10 @@ fn map_methods(value: &Value, method: &str, args: &[Value]) -> Result<Value, Err
             }))
         }
         "get" => {
-            let (key,): (&Value,) = from_args(args)?;
+            let (key, default): (&Value, Option<Value>) = from_args(args)?;
             Ok(match obj.get_value(key) {
                 Some(value) => value,
-                None => Value::from(()),
+                None => default.unwrap_or_else(|| Value::from(())),
             })
         }
         _ => Err(Error::from(ErrorKind::UnknownMethod)),

--- a/minijinja-contrib/tests/pycompat.rs
+++ b/minijinja-contrib/tests/pycompat.rs
@@ -77,6 +77,8 @@ fn test_dict_methods() {
     assert!(eval_expr("{'x': 42}.items()|list == [('x', 42)]").is_true());
     assert!(eval_expr("{'x': 42}.get('x') == 42").is_true());
     assert!(eval_expr("{'x': 42}.get('y') is none").is_true());
+    assert!(eval_expr("{'x': 42}.get('x', 47) == 42").is_true());
+    assert!(eval_expr("{'x': 42}.get('y', 47) == 47").is_true());
 }
 
 #[test]


### PR DESCRIPTION
This adds support for the optional default argument to dict.get in the pycompat module. 

[python reference](https://docs.python.org/3/library/stdtypes.html#dict.get)

- `dict.get(key)` returns `None` when the key is missing (unchanged). 
- `dict.get(key, default_value)` returns the provided default value when the key is missing (new). 