### PR TITLE
fix(minijinja-py): Add missing mapping for SemiStrict undefined behavior

### DIFF
--- a/minijinja-py/src/environment.rs
+++ b/minijinja-py/src/environment.rs
@@ -181,6 +181,7 @@ impl Environment {
             "strict" => UndefinedBehavior::Strict,
             "lenient" => UndefinedBehavior::Lenient,
             "chainable" => UndefinedBehavior::Chainable,
+            "semi_strict" => UndefinedBehavior::SemiStrict,
             _ => {
                 return Err(PyRuntimeError::new_err(
                     "invalid value for undefined behavior",
@@ -198,6 +199,7 @@ impl Environment {
             UndefinedBehavior::Lenient => "lenient",
             UndefinedBehavior::Chainable => "chainable",
             UndefinedBehavior::Strict => "strict",
+            UndefinedBehavior::SemiStrict => "semi_strict",
             _ => {
                 return Err(PyRuntimeError::new_err(
                     "invalid value for undefined behavior",


### PR DESCRIPTION
Using `semi_strict` results in RuntimeError about invalid value for undefined behavior.