### PR TITLE
Improve performance of iteration over map items

### DIFF
--- a/benchmarks/benches/templates.rs
+++ b/benchmarks/benches/templates.rs
@@ -1,5 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use minijinja::machinery::parse;
+use minijinja::value::Value;
 use minijinja::{context, Environment, State};
 
 fn do_parse() {
@@ -37,6 +38,20 @@ fn do_render(env: &Environment) {
     .unwrap();
 }
 
+fn bench_loop_map_items(c: &mut Criterion) {
+    let env = create_real_env();
+    let tmpl = env.get_template("map_items.jinja").unwrap();
+    let ctx = context! {
+        employees => (0..10000).map(|i| (i, format!("Person{i}"))).collect::<Value>(),
+    };
+    c.bench_function("loop_map_items", |b| {
+        b.iter(|| {
+            tmpl.render_captured_to(ctx.clone(), std::io::sink())
+                .unwrap()
+        });
+    });
+}
+
 fn create_real_env() -> Environment<'static> {
     let mut env = Environment::new();
     env.add_template("footer.html", include_str!("../inputs/footer.html"))
@@ -46,6 +61,8 @@ fn create_real_env() -> Environment<'static> {
         include_str!("../inputs/all_elements.html"),
     )
     .unwrap();
+    env.add_template("map_items.jinja", include_str!("../inputs/map_items.jinja"))
+        .unwrap();
     env.add_filter("asset_url", |_: &State, value: String| Ok(value));
     env.add_function("current_year", |_: &State| Ok(2022));
     env
@@ -58,6 +75,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let env = create_real_env();
         b.iter(|| do_render(&env));
     });
+    bench_loop_map_items(c);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benchmarks/inputs/map_items.jinja
+++ b/benchmarks/inputs/map_items.jinja
@@ -1,0 +1,5 @@
+ID,NAME
+
+{% for id, name in employees | items %}
+{{id}},{{name}}
+{% endfor %}

--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -341,18 +341,19 @@ mod builtins {
         let by_value = matches!(ok!(kwargs.get("by")), Some("value"));
         let case_sensitive = ok!(kwargs.get::<Option<bool>>("case_sensitive")).unwrap_or(false);
         let reverse = ok!(kwargs.get::<Option<bool>>("reverse")).unwrap_or(false);
-        let mut rv: Vec<_> = ok!(v.try_iter())
-            .map(|key| (key.clone(), v.get_item(&key).unwrap_or(Value::UNDEFINED)))
-            .collect();
+        let mut rv: Vec<_> = if let Some(iter) = v.as_object().and_then(|v| v.try_iter_pairs()) {
+            iter.collect()
+        } else {
+            ok!(v.try_iter())
+                .map(|key| (key.clone(), v.get_item(&key).unwrap_or(Value::UNDEFINED)))
+                .collect()
+        };
         safe_sort(&mut rv, |a, b| {
             let (a, b) = if by_value { (&a.1, &b.1) } else { (&a.0, &b.0) };
             cmp_helper(a, b, case_sensitive, reverse)
         })?;
         kwargs.assert_all_used()?;
-        Ok(rv
-            .into_iter()
-            .map(|(k, v)| Value::from(vec![k, v]))
-            .collect())
+        Ok(rv.into_iter().map(|(k, v)| Value::from([k, v])).collect())
     }
 
     /// Returns an iterable of pairs (items) from a mapping.
@@ -377,7 +378,7 @@ mod builtins {
         if v.kind() == ValueKind::Map {
             Ok(Value::make_object_iterable(v.clone(), |v| {
                 match v.as_object().and_then(|v| v.try_iter_pairs()) {
-                    Some(iter) => Box::new(iter.map(|(key, value)| Value::from(vec![key, value]))),
+                    Some(iter) => Box::new(iter.map(|(key, value)| Value::from([key, value]))),
                     None => Box::new(
                         // this really should not happen unless the object changes it's shape
                         // after the initial check

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -1443,7 +1443,7 @@ impl Value {
                     let mut v = if let ObjectRepr::Map = o.repr() {
                         iter.map(|(k, _)| k).collect::<Vec<_>>()
                     } else {
-                        iter.map(|(k, v)| vec![k, v].into()).collect::<Vec<_>>()
+                        iter.map(|(k, v)| [k, v].into()).collect::<Vec<_>>()
                     };
                     v.reverse();
                     Some(Value::make_object_iterable(v, move |v| {
@@ -1476,7 +1476,7 @@ impl Value {
                                 Box::new(iter.map(|(k, _)| k))
                                     as Box<dyn Iterator<Item = Value> + Send + Sync>
                             } else {
-                                Box::new(iter.map(|(k, v)| vec![k, v].into()))
+                                Box::new(iter.map(|(k, v)| [k, v].into()))
                                     as Box<dyn Iterator<Item = Value> + Send + Sync>
                             }
                         } else {

--- a/minijinja/src/value/mod.rs
+++ b/minijinja/src/value/mod.rs
@@ -1439,12 +1439,46 @@ impl Value {
                         Box::new(v.iter().cloned())
                     }))
                 }
+                Enumerator::KeyValueIter(iter) => {
+                    let mut v = if let ObjectRepr::Map = o.repr() {
+                        iter.map(|(k, _)| k).collect::<Vec<_>>()
+                    } else {
+                        iter.map(|(k, v)| vec![k, v].into()).collect::<Vec<_>>()
+                    };
+                    v.reverse();
+                    Some(Value::make_object_iterable(v, move |v| {
+                        Box::new(v.iter().cloned())
+                    }))
+                }
                 Enumerator::RevIter(rev_iter) => {
                     let for_restart = self.clone();
                     let iter = Mutex::new(Some(rev_iter));
                     Some(Value::make_iterable(move || {
                         if let Some(iter) = iter.lock().unwrap().take() {
                             Box::new(iter) as Box<dyn Iterator<Item = Value> + Send + Sync>
+                        } else {
+                            match for_restart.reverse().and_then(|x| x.try_iter()) {
+                                Ok(iterable) => Box::new(iterable)
+                                    as Box<dyn Iterator<Item = Value> + Send + Sync>,
+                                Err(err) => Box::new(Some(Value::from(err)).into_iter())
+                                    as Box<dyn Iterator<Item = Value> + Send + Sync>,
+                            }
+                        }
+                    }))
+                }
+                Enumerator::RevKeyValueIter(rev_iter) => {
+                    let for_restart = self.clone();
+                    let iter = Mutex::new(Some(rev_iter));
+                    let repr = o.repr();
+                    Some(Value::make_iterable(move || {
+                        if let Some(iter) = iter.lock().unwrap().take() {
+                            if let ObjectRepr::Map = repr {
+                                Box::new(iter.map(|(k, _)| k))
+                                    as Box<dyn Iterator<Item = Value> + Send + Sync>
+                            } else {
+                                Box::new(iter.map(|(k, v)| vec![k, v].into()))
+                                    as Box<dyn Iterator<Item = Value> + Send + Sync>
+                            }
                         } else {
                             match for_restart.reverse().and_then(|x| x.try_iter()) {
                                 Ok(iterable) => Box::new(iterable)

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -346,7 +346,7 @@ macro_rules! impl_object_helpers {
                     if let ObjectRepr::Map = self.repr() {
                         Some(Box::new(iter.map(|(key, _)| key)))
                     } else {
-                        Some(Box::new(iter.map(|(key, val)| vec![key, val].into())))
+                        Some(Box::new(iter.map(|(key, val)| [key, val].into())))
                     }
                 }
                 Enumerator::RevIter(iter) => Some(Box::new(iter)),
@@ -354,7 +354,7 @@ macro_rules! impl_object_helpers {
                     if let ObjectRepr::Map = self.repr() {
                         Some(Box::new(iter.map(|(key, _)| key)))
                     } else {
-                        Some(Box::new(iter.map(|(key, val)| vec![key, val].into())))
+                        Some(Box::new(iter.map(|(key, val)| [key, val].into())))
                     }
                 }
                 Enumerator::Str(s) => Some(Box::new(s.iter().copied().map(Value::from))),
@@ -1173,4 +1173,31 @@ mod preserve_order_impls {
     use indexmap::IndexMap;
 
     impl_value_map!(IndexMap, mapped_rev_key_value_enumerator);
+}
+
+impl<T, const N: usize> Object for [T; N]
+where
+    T: Into<Value> + Clone + Send + Sync + fmt::Debug + 'static,
+{
+    fn repr(self: &Arc<Self>) -> ObjectRepr {
+        ObjectRepr::Seq
+    }
+
+    #[inline(always)]
+    fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
+        self.get(some!(key.as_usize())).cloned().map(|v| v.into())
+    }
+
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
+        Enumerator::Seq(N)
+    }
+}
+
+impl<T, const N : usize> From<[T; N]> for Value
+where
+    T: Into<Value> + Clone + Send + Sync + fmt::Debug + 'static,
+{
+    fn from(value: [T; N]) -> Self {
+        Value::from_object(value)
+    }
 }

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -342,7 +342,21 @@ macro_rules! impl_object_helpers {
                     })))
                 }
                 Enumerator::Iter(iter) => Some(iter),
+                Enumerator::KeyValueIter(iter) => {
+                    if let ObjectRepr::Map = self.repr() {
+                        Some(Box::new(iter.map(|(key, _)| key)))
+                    } else {
+                        Some(Box::new(iter.map(|(key, val)| vec![key, val].into())))
+                    }
+                }
                 Enumerator::RevIter(iter) => Some(Box::new(iter)),
+                Enumerator::RevKeyValueIter(iter) => {
+                    if let ObjectRepr::Map = self.repr() {
+                        Some(Box::new(iter.map(|(key, _)| key)))
+                    } else {
+                        Some(Box::new(iter.map(|(key, val)| vec![key, val].into())))
+                    }
+                }
                 Enumerator::Str(s) => Some(Box::new(s.iter().copied().map(Value::from))),
                 Enumerator::Values(v) => Some(Box::new(v.into_iter())),
             }
@@ -352,18 +366,25 @@ macro_rules! impl_object_helpers {
         $vis fn try_iter_pairs(
             self: $self_ty,
         ) -> Option<Box<dyn Iterator<Item = (Value, Value)> + Send + Sync>> {
-            let iter = some!(self.try_iter());
-            let repr = self.repr();
-            let self_clone = self.clone();
-            Some(Box::new(iter.enumerate().map(move |(idx, item)| {
-                match repr {
-                    ObjectRepr::Map => {
-                        let value = self_clone.get_value(&item);
-                        (item, value.unwrap_or_default())
+            if let ObjectRepr::Map = self.repr() {
+                match self.enumerate() {
+                    Enumerator::KeyValueIter(iter) => Some(iter),
+                    Enumerator::RevKeyValueIter(iter) => Some(Box::new(iter)),
+                    _ => {
+                        let iter = some!(self.try_iter());
+                        let self_clone = self.clone();
+                        Some(Box::new(iter.map(move |key| {
+                            let value = self_clone.get_value(&key).unwrap_or_default();
+                            (key, value)
+                        })))
                     }
-                    _ => (Value::from(idx), item)
                 }
-            })))
+            } else {
+                let iter = some!(self.try_iter());
+                Some(Box::new(iter.enumerate().map(move |(idx, item)| {
+                    (Value::from(idx), item)
+                })))
+            }
         }
     };
 }
@@ -376,6 +397,46 @@ pub trait ObjectExt: Object + Send + Sync + 'static {
     /// to return an [`Iterator`].  This iterator is then wrapped in an
     /// [`Enumerator::Iter`].  This allows one to create an iterator that borrows
     /// out of the object.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use std::collections::HashSet;
+    /// use std::sync::Arc;
+    /// use minijinja::value::{Value, Object, ObjectRepr, ObjectExt, Enumerator};
+    ///
+    /// #[derive(Debug)]
+    /// struct CustomSet(HashSet<usize>);
+    ///
+    /// impl Object for CustomSet {
+    ///     fn repr(self: &Arc<Self>) -> ObjectRepr {
+    ///         ObjectRepr::Iterable
+    ///     }
+    ///
+    ///     fn enumerate(self: &Arc<Self>) -> Enumerator {
+    ///         self.mapped_enumerator(|this| {
+    ///             Box::new(this.0.iter().copied().map(Value::from))
+    ///         })
+    ///     }
+    /// }
+    /// ```
+    fn mapped_enumerator<F>(self: &Arc<Self>, maker: F) -> Enumerator
+    where
+        F: for<'a> FnOnce(&'a Self) -> Box<dyn Iterator<Item = Value> + Send + Sync + 'a>
+            + Send
+            + Sync
+            + 'static,
+        Self: Sized,
+    {
+        mapped_enumerator(self, maker)
+    }
+
+    /// Creates a new key-value pair enumerator that projects into the given object.
+    ///
+    /// It takes a method that is passed a reference to `self` and is expected to
+    /// return an [`Iterator`].  This iterator is then wrapped in an
+    /// [`Enumerator::KeyValueIter`].  This allows one to create an iterator that
+    /// borrows out of the object.
     ///
     /// # Example
     ///
@@ -393,21 +454,46 @@ pub trait ObjectExt: Object + Send + Sync + 'static {
     ///     }
     ///
     ///     fn enumerate(self: &Arc<Self>) -> Enumerator {
-    ///         self.mapped_enumerator(|this| {
-    ///             Box::new(this.0.keys().copied().map(Value::from))
+    ///         self.mapped_key_value_enumerator(|this| {
+    ///             Box::new(this.0.iter().map(|(&k, &v)| (Value::from(k), Value::from(v))))
     ///         })
     ///     }
     /// }
     /// ```
-    fn mapped_enumerator<F>(self: &Arc<Self>, maker: F) -> Enumerator
+    fn mapped_key_value_enumerator<F>(self: &Arc<Self>, maker: F) -> Enumerator
     where
-        F: for<'a> FnOnce(&'a Self) -> Box<dyn Iterator<Item = Value> + Send + Sync + 'a>
+        F: for<'a> FnOnce(&'a Self) -> Box<dyn Iterator<Item = (Value, Value)> + Send + Sync + 'a>
             + Send
             + Sync
             + 'static,
         Self: Sized,
     {
-        mapped_enumerator(self, maker)
+        struct Iter {
+            iter: Box<dyn Iterator<Item = (Value, Value)> + Send + Sync + 'static>,
+            _object: DynObject,
+        }
+
+        impl Iterator for Iter {
+            type Item = (Value, Value);
+
+            fn next(&mut self) -> Option<Self::Item> {
+                self.iter.next()
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.iter.size_hint()
+            }
+        }
+
+        // SAFETY: this is safe because the object is kept alive by the iter
+        let iter = unsafe {
+            std::mem::transmute::<
+                Box<dyn Iterator<Item = _>>,
+                Box<dyn Iterator<Item = _> + Send + Sync>,
+            >(maker(self))
+        };
+        let _object = DynObject::new(self.clone());
+        Enumerator::KeyValueIter(Box::new(Iter { iter, _object }))
     }
 
     /// Creates a new reversible iterator enumeration that projects into the given object.
@@ -420,21 +506,21 @@ pub trait ObjectExt: Object + Send + Sync + 'static {
     /// # Example
     ///
     /// ```
-    /// # use std::collections::HashMap;
+    /// # use std::collections::BTreeSet;
     /// use std::sync::Arc;
     /// use std::ops::Range;
     /// use minijinja::value::{Value, Object, ObjectExt, ObjectRepr, Enumerator};
     ///
     /// #[derive(Debug)]
-    /// struct VecView(Vec<usize>);
+    /// struct OrderedSet(BTreeSet<usize>);
     ///
-    /// impl Object for VecView {
+    /// impl Object for OrderedSet {
     ///     fn repr(self: &Arc<Self>) -> ObjectRepr {
     ///         ObjectRepr::Iterable
     ///     }
     ///
     ///     fn enumerate(self: &Arc<Self>) -> Enumerator {
-    ///         self.mapped_enumerator(|this| {
+    ///         self.mapped_rev_enumerator(|this| {
     ///             Box::new(this.0.iter().cloned().map(Value::from))
     ///         })
     ///     }
@@ -485,6 +571,80 @@ pub trait ObjectExt: Object + Send + Sync + 'static {
         };
         let _object = DynObject::new(self.clone());
         Enumerator::RevIter(Box::new(Iter { iter, _object }))
+    }
+
+    /// Creates reversible key-value pair enumeration that projects into the given object.
+    ///
+    /// It takes a method that is passed a reference to `self` and is expected to
+    /// return a [`DoubleEndedIterator`].  This iterator is then wrapped in an
+    /// [`Enumerator::RevKeyValueIter`].  This allows one to create an iterator that
+    /// borrows out of the object and is reversible.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use std::collections::BTreeMap;
+    /// use std::sync::Arc;
+    /// use minijinja::value::{Value, Object, ObjectExt, Enumerator};
+    ///
+    /// #[derive(Debug)]
+    /// struct CustomMap(BTreeMap<usize, i64>);
+    ///
+    /// impl Object for CustomMap {
+    ///     fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
+    ///         self.0.get(&key.as_usize()?).copied().map(Value::from)
+    ///     }
+    ///
+    ///     fn enumerate(self: &Arc<Self>) -> Enumerator {
+    ///         self.mapped_rev_key_value_enumerator(|this| {
+    ///             Box::new(this.0.iter().map(|(&k, &v)| (Value::from(k), Value::from(v))))
+    ///         })
+    ///     }
+    /// }
+    /// ```
+    fn mapped_rev_key_value_enumerator<F>(self: &Arc<Self>, maker: F) -> Enumerator
+    where
+        F: for<'a> FnOnce(
+                &'a Self,
+            )
+                -> Box<dyn DoubleEndedIterator<Item = (Value, Value)> + Send + Sync + 'a>
+            + Send
+            + Sync
+            + 'static,
+        Self: Sized,
+    {
+        struct Iter {
+            iter: Box<dyn DoubleEndedIterator<Item = (Value, Value)> + Send + Sync + 'static>,
+            _object: DynObject,
+        }
+
+        impl Iterator for Iter {
+            type Item = (Value, Value);
+
+            fn next(&mut self) -> Option<Self::Item> {
+                self.iter.next()
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.iter.size_hint()
+            }
+        }
+
+        impl DoubleEndedIterator for Iter {
+            fn next_back(&mut self) -> Option<Self::Item> {
+                self.iter.next_back()
+            }
+        }
+
+        // SAFETY: this is safe because the `Iter` will keep our object alive.
+        let iter = unsafe {
+            std::mem::transmute::<
+                Box<dyn DoubleEndedIterator<Item = _>>,
+                Box<dyn DoubleEndedIterator<Item = _> + Send + Sync>,
+            >(maker(self))
+        };
+        let _object = DynObject::new(self.clone());
+        Enumerator::RevKeyValueIter(Box::new(Iter { iter, _object }))
     }
 
     impl_object_helpers!(&Arc<Self>);
@@ -556,6 +716,29 @@ pub enum Enumerator {
     /// | yes      | sometimes known |
     Iter(Box<dyn Iterator<Item = Value> + Send + Sync>),
 
+    /// A dynamic iterator over key value pairs.
+    ///
+    /// This enumerator allows efficient iteration over the items of a mapping in the
+    /// contexts where both key and value are required (e.g. `|items` and `|dictsort`
+    /// filters).
+    ///
+    /// Objects with [`ObjectRepr::Map`] are encouraged to return this enumerator if
+    /// their iterator naturally yields (key, value) pairs.  Note that it does NOT
+    /// change the iteration behavior of the map in the templates, which is to
+    /// iterate over keys.  In the context where a value corresponding the key is
+    /// also required, the previous `Iter` option would call [`Object::get_value`],
+    /// which incurs unnecessary cost of the map lookup.  This enumerator avoids the
+    /// cost.
+    ///
+    /// For [`ObjectRepr::Iter`], the iteration behavior is consistent with the
+    /// `Iter` alternative, i.e. the iteration is over the values, which in this case
+    /// is (key, value) pairs.
+    ///
+    /// | Iterable | Length          |
+    /// |----------|-----------------|
+    /// | yes      | sometimes known |
+    KeyValueIter(Box<dyn Iterator<Item = (Value, Value)> + Send + Sync>),
+
     /// Like `Iter` but supports efficient reversing.
     ///
     /// This means that the iterator has to be of type [`DoubleEndedIterator`].
@@ -564,6 +747,16 @@ pub enum Enumerator {
     /// |----------|-----------------|
     /// | yes      | sometimes known |
     RevIter(Box<dyn DoubleEndedIterator<Item = Value> + Send + Sync>),
+
+    /// Like `KeyValueIter` but supports efficient reversing.
+    ///
+    /// Similar to `KeyValueIter`, avoids an extra lookup while iterating over the
+    /// items of a mapping where both key and value are used.
+    ///
+    /// | Iterable | Length          |
+    /// |----------|-----------------|
+    /// | yes      | sometimes known |
+    RevKeyValueIter(Box<dyn DoubleEndedIterator<Item = (Value, Value)> + Send + Sync>),
 
     /// Indicates sequential iteration.
     ///
@@ -712,7 +905,15 @@ impl Enumerator {
                 (a, Some(b)) if a == b => a,
                 _ => return None,
             },
+            Enumerator::KeyValueIter(i) => match i.size_hint() {
+                (a, Some(b)) if a == b => a,
+                _ => return None,
+            },
             Enumerator::RevIter(i) => match i.size_hint() {
+                (a, Some(b)) if a == b => a,
+                _ => return None,
+            },
+            Enumerator::RevKeyValueIter(i) => match i.size_hint() {
                 (a, Some(b)) if a == b => a,
                 _ => return None,
             },
@@ -798,7 +999,12 @@ macro_rules! impl_str_map_helper {
             }
 
             fn enumerate(self: &Arc<Self>) -> Enumerator {
-                self.$enumerator(|this| Box::new(this.keys().map(|x| Value::from(x as &str))))
+                self.$enumerator(|this| {
+                    Box::new(
+                        this.iter()
+                            .map(|(k, v)| (Value::from(k as &str), v.clone().into())),
+                    )
+                })
             }
 
             fn enumerator_len(self: &Arc<Self>) -> Option<usize> {
@@ -831,7 +1037,12 @@ macro_rules! impl_static_str_map_helper {
             }
 
             fn enumerate(self: &Arc<Self>) -> Enumerator {
-                self.$enumerator(|this| Box::new(this.keys().map(|x| Value::from(*x))))
+                self.$enumerator(|this| {
+                    Box::new(
+                        this.iter()
+                            .map(|(k, v)| (Value::from(*k), v.clone().into())),
+                    )
+                })
             }
 
             fn enumerator_len(self: &Arc<Self>) -> Option<usize> {
@@ -918,7 +1129,9 @@ macro_rules! impl_value_map {
             }
 
             fn enumerate(self: &Arc<Self>) -> Enumerator {
-                self.$enumerator(|this| Box::new(this.keys().cloned()))
+                self.$enumerator(|this| {
+                    Box::new(this.iter().map(|(k, v)| (k.clone(), v.clone().into())))
+                })
             }
 
             fn enumerator_len(self: &Arc<Self>) -> Option<usize> {
@@ -938,8 +1151,8 @@ macro_rules! impl_value_map {
 }
 
 impl_value_vec!(Vec);
-impl_value_map!(BTreeMap, mapped_rev_enumerator);
-impl_str_map!(BTreeMap, mapped_rev_enumerator);
+impl_value_map!(BTreeMap, mapped_rev_key_value_enumerator);
+impl_str_map!(BTreeMap, mapped_rev_key_value_enumerator);
 
 #[cfg(feature = "std_collections")]
 mod std_collections_impls {
@@ -949,8 +1162,8 @@ mod std_collections_impls {
     impl_value_iterable!(LinkedList, mapped_rev_enumerator);
     impl_value_iterable!(HashSet, mapped_enumerator);
     impl_value_iterable!(BTreeSet, mapped_rev_enumerator);
-    impl_str_map!(HashMap, mapped_enumerator);
-    impl_value_map!(HashMap, mapped_enumerator);
+    impl_str_map!(HashMap, mapped_key_value_enumerator);
+    impl_value_map!(HashMap, mapped_key_value_enumerator);
     impl_value_vec!(VecDeque);
 }
 
@@ -959,5 +1172,5 @@ mod preserve_order_impls {
     use super::*;
     use indexmap::IndexMap;
 
-    impl_value_map!(IndexMap, mapped_rev_enumerator);
+    impl_value_map!(IndexMap, mapped_rev_key_value_enumerator);
 }

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -1193,7 +1193,7 @@ where
     }
 }
 
-impl<T, const N : usize> From<[T; N]> for Value
+impl<T, const N: usize> From<[T; N]> for Value
 where
     T: Into<Value> + Clone + Send + Sync + fmt::Debug + 'static,
 {


### PR DESCRIPTION
The Enumerator enum underlying the object iteration support in the engine currently
allows only one kind of iterator yielding a single Value as the item. So the map-like
objects currently store an iterator over the keys in the Enumerator. This means, in
contexts where both key and value are required, e.g. items and dictsort filters, the
renderer has to call `get_value` to fetch the value corresponding to the key while
iterating the map. This extra lookup is wasteful, and can be avoided if the
Enumerator can store an iterator of the key value pairs of a map.

Expand the enum with `KeyValueIter` and `RevKeyValueIter` alternatives storing an
iterator over key-value pairs. Update `Object::try_iter` to return an iterator over
the keys for the new enumerators in case the ObjectRepr is Map, to avoid breaking
their iteration behavior in templates. Update `Object::try_iter_pairs` to return the
underlying iterators directly for the new enumerators.

Add two new helper methods in the ObjectExt trait to allow creating new enumerators
projecting into the given object, similar to `mapped_enumerator` method. Update docs
on the existing methods. Fix a wrong example on the `mapped_rev_enumerator` method.

Update Object impl of HashMap, IndexMap, and BTreeMap to use the new enumerators.

Implement Object trait for arrays, and use array instead of vector to store key value pairs
to reduce the number of memory allocations.

Add a benchmark for iterating over a map. Results on MacBook Pro M1:
```
loop_map_items          time:   [2.3926 ms 2.3958 ms 2.3993 ms]
                        change: [-48.584% -48.480% -48.377%] (p = 0.00 < 0.05)
                        Performance has improved.
```

(No AI assistance was used to prepare these changes, everything is hand-crafted).