### PR TITLE
fix: reset loop locals between iterations

### DIFF
--- a/minijinja-cli/src/repl.rs
+++ b/minijinja-cli/src/repl.rs
@@ -74,11 +74,7 @@ enum Command<'a> {
 }
 
 fn parse_command(line: &str) -> Option<Command<'_>> {
-    let line = if let Some(rest) = line.strip_prefix('.') {
-        rest.trim()
-    } else {
-        return None;
-    };
+    let line = line.strip_prefix('.')?.trim();
     match line {
         "exit" | "quit" => return Some(Command::Quit),
         "help" => return Some(Command::Help),

--- a/minijinja-go/minijinja_test.go
+++ b/minijinja-go/minijinja_test.go
@@ -149,6 +149,23 @@ func TestForLoop(t *testing.T) {
 	}
 }
 
+func TestLoopLocalsDoNotPersistBetweenIterations(t *testing.T) {
+	env := NewEnvironment()
+	tmpl, err := env.TemplateFromString("{% for x in [1, 2] %}{% if loop.first %}{% set y = x %}{% endif %}[{{ y }}]{% endfor %}")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	result, err := tmpl.Render(nil)
+	if err != nil {
+		t.Fatalf("render error: %v", err)
+	}
+
+	if result != "[1][]" {
+		t.Errorf("expected '[1][]', got %q", result)
+	}
+}
+
 func TestForLoopWithIndex(t *testing.T) {
 	env := NewEnvironment()
 	tmpl, err := env.TemplateFromString("{% for item in items %}{{ loop.index }}:{{ item }} {% endfor %}")

--- a/minijinja-go/state.go
+++ b/minijinja-go/state.go
@@ -1121,6 +1121,11 @@ func (s *State) pushScope() {
 	s.scopes = append(s.scopes, make(map[string]value.Value))
 }
 
+// resetScope clears the current scope.
+func (s *State) resetScope() {
+	clear(s.scopes[len(s.scopes)-1])
+}
+
 // popScope removes the current scope.
 func (s *State) popScope() {
 	if len(s.scopes) > 1 {
@@ -1371,6 +1376,7 @@ func (s *State) evalForLoopPull(loop *parser.ForLoop, pull value.PullIterator) e
 		if !ok {
 			break
 		}
+		s.resetScope()
 		if err := s.unpackLoopTarget(loop.Target, item); err != nil {
 			return err
 		}
@@ -1495,6 +1501,7 @@ func (s *State) evalForLoopItems(loop *parser.ForLoop, items []value.Value) erro
 			s.out = builder
 
 			for i := range nestedItems {
+				s.resetScope()
 				if err := s.unpackLoopTarget(loop.Target, nestedItems[i]); err != nil {
 					s.out = oldOut
 					return "", err
@@ -1534,6 +1541,7 @@ func (s *State) evalForLoopItems(loop *parser.ForLoop, items []value.Value) erro
 	}
 
 	for i := range items {
+		s.resetScope()
 		if err := s.unpackLoopTarget(loop.Target, items[i]); err != nil {
 			return err
 		}

--- a/minijinja/src/vm/context.rs
+++ b/minijinja/src/vm/context.rs
@@ -330,6 +330,19 @@ impl<'env> Context<'env> {
             .next()
     }
 
+    pub fn next_loop_item(&mut self) -> Option<Value> {
+        let frame = self
+            .stack
+            .iter_mut()
+            .rev()
+            .find(|x| x.current_loop.is_some())?;
+        let item = frame.current_loop.as_mut()?.next();
+        if item.is_some() {
+            frame.locals.clear();
+        }
+        item
+    }
+
     /// The real depth of the context.
     pub fn depth(&self) -> usize {
         self.outer_stack_depth + self.stack.len()

--- a/minijinja/src/vm/mod.rs
+++ b/minijinja/src/vm/mod.rs
@@ -557,7 +557,7 @@ impl<'env> Vm<'env> {
                     ctx_ok!(self.push_loop(state, a, *flags, pc, next_loop_recursion_jump.take()));
                 }
                 Instruction::Iterate(jump_target) => {
-                    match state.ctx.current_loop().unwrap().next() {
+                    match state.ctx.next_loop_item() {
                         Some(item) => stack.push(assert_valid!(item)),
                         None => {
                             pc = *jump_target;

--- a/minijinja/tests/test_templates.rs
+++ b/minijinja/tests/test_templates.rs
@@ -722,6 +722,14 @@ fn test_render_and_return_state() {
 }
 
 #[test]
+fn test_loop_locals_do_not_persist_between_iterations() {
+    assert_eq!(
+        render!("{% for x in [1, 2] %}{% if loop.first %}{% set y = x %}{% endif %}[{{ y }}]{% endfor %}"),
+        "[1][]"
+    );
+}
+
+#[test]
 fn test_render_captured() {
     let env = Environment::new();
     let rendered = env


### PR DESCRIPTION
Fixes #910 for glm5.2 chat template.

Clear loop-frame locals before each iteration so conditional assignments do not leak into the next item. The fix and focused regression coverage apply to both the Rust and Go implementations.

Also updates the CLI REPL parser to satisfy the `question_mark` lint newly enabled by the latest Clippy used in CI.

Tested with `cargo test -p minijinja --all-features`, `cargo test -p minijinja-cli`, `go test ./...`, rustfmt, and the workspace clippy target.

AI disclosure: The original Rust loop fix was prepared with light Codex assistance, directed and reviewed by the contributor before marking the PR ready. The maintainer follow-up added Go parity and addressed the unrelated new Clippy lint failure; both were reviewed and tested before merge.
