### PR TITLE
Allow conditional expressions in keyword arguments

### DIFF
--- a/minijinja/src/compiler/parser.rs
+++ b/minijinja/src/compiler/parser.rs
@@ -668,7 +668,7 @@ impl<'a> Parser<'a> {
                                 first_span = Some(var.span());
                             }
                             has_kwargs = true;
-                            args.push(ast::CallArg::Kwarg(var.id, ok!(self.parse_expr_noif())));
+                            args.push(ast::CallArg::Kwarg(var.id, ok!(self.parse_expr())));
                         }
                         _ if has_kwargs => {
                             return Err(syntax_error(Cow::Borrowed(

--- a/minijinja/tests/inputs/namespace.txt
+++ b/minijinja/tests/inputs/namespace.txt
@@ -17,3 +17,6 @@
 ---
 {% set ns = namespace({"found": true}) %}
 {{- ns }}
+---
+{% set ns = namespace(value='yes' if true else 'no') %}
+{{- ns }}

--- a/minijinja/tests/snapshots/test_templates__vm@namespace.txt.snap
+++ b/minijinja/tests/snapshots/test_templates__vm@namespace.txt.snap
@@ -1,6 +1,6 @@
 ---
 source: minijinja/tests/test_templates.rs
-description: "{%- set ns = namespace() %}\n{%- set ns.foo = 0 %}\n{%- for count in range(10) %}\n  {%- set ns.foo = ns.foo + count %}\n{%- endfor %}\n{{- ns }}\n---\n{% set ns.foo = namespace() %}\n{%- set ns.foo.bar = 42 %}\n{{- ns }}\n---\n{% set ns = namespace(found=true) %}\n{{- ns }}\n---\n{% set ns = namespace({\"found\": true}) %}\n{{- ns }}"
+description: "{%- set ns = namespace() %}\n{%- set ns.foo = 0 %}\n{%- for count in range(10) %}\n  {%- set ns.foo = ns.foo + count %}\n{%- endfor %}\n{{- ns }}\n---\n{% set ns.foo = namespace() %}\n{%- set ns.foo.bar = 42 %}\n{{- ns }}\n---\n{% set ns = namespace(found=true) %}\n{{- ns }}\n---\n{% set ns = namespace({\"found\": true}) %}\n{{- ns }}\n---\n{% set ns = namespace(value='yes' if true else 'no') %}\n{{- ns }}"
 info: {}
 input_file: minijinja/tests/inputs/namespace.txt
 ---
@@ -11,4 +11,5 @@ input_file: minijinja/tests/inputs/namespace.txt
 {"found": True}
 ---
 {"found": True}
-
+---
+{"value": "yes"}


### PR DESCRIPTION
Jinja permits conditional expressions as keyword argument values, but MiniJinja currently rejects them unless parenthesized. Parse keyword values as full expressions and cover the valid syntax with a rendering test.

Tested with `cargo test -p minijinja --all-features`.

AI disclosure: OpenAI Codex helped investigate the parser difference, prepare the change and description, and run the tests. The contributor reviewed the result.
