### PR TITLE
Make context! preserve key order with preserve_order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to MiniJinja are documented here.
 
 ## Unreleased
 
+* Fixed `context!` sorting its keys when the `preserve_order` feature is enabled.  #920
+
 ## 2.23.0
 
 * Fixed Unicode identifiers in templates rendered through the Python bindings.

--- a/minijinja/src/macros.rs
+++ b/minijinja/src/macros.rs
@@ -25,21 +25,26 @@ macro_rules! some {
 pub mod __context {
     use crate::value::Value;
     use crate::Environment;
-    use std::collections::BTreeMap;
     use std::rc::Rc;
 
+    #[cfg(not(feature = "preserve_order"))]
+    pub type ContextMap = std::collections::BTreeMap<&'static str, Value>;
+
+    #[cfg(feature = "preserve_order")]
+    pub type ContextMap = indexmap::IndexMap<&'static str, Value>;
+
     #[inline(always)]
-    pub fn make() -> BTreeMap<&'static str, Value> {
-        BTreeMap::default()
+    pub fn make() -> ContextMap {
+        ContextMap::default()
     }
 
     #[inline(always)]
-    pub fn add(ctx: &mut BTreeMap<&'static str, Value>, key: &'static str, value: Value) {
+    pub fn add(ctx: &mut ContextMap, key: &'static str, value: Value) {
         ctx.insert(key, value);
     }
 
     #[inline(always)]
-    pub fn build(ctx: BTreeMap<&'static str, Value>) -> Value {
+    pub fn build(ctx: ContextMap) -> Value {
         Value::from_object(ctx)
     }
 

--- a/minijinja/src/value/object.rs
+++ b/minijinja/src/value/object.rs
@@ -1170,6 +1170,7 @@ mod preserve_order_impls {
     use indexmap::IndexMap;
 
     impl_value_map!(IndexMap, mapped_rev_key_value_enumerator);
+    impl_str_map!(IndexMap, mapped_rev_key_value_enumerator);
 }
 
 impl<T, const N: usize> Object for [T; N]

--- a/minijinja/tests/test_macros.rs
+++ b/minijinja/tests/test_macros.rs
@@ -248,3 +248,18 @@ fn test_unenclosed_resolve() {
         .unwrap();
     assert_snapshot!(rv, @"render global|ctx global|");
 }
+
+#[test]
+#[cfg(feature = "preserve_order")]
+fn test_context_preserves_order() {
+    let ctx = context! { zebra => 1, apple => 2 };
+    assert_snapshot!(format!("{ctx:?}"), @r#"{"zebra": 1, "apple": 2}"#);
+    assert_snapshot!(
+        ctx.try_iter()
+            .unwrap()
+            .map(|k| k.to_string())
+            .collect::<Vec<_>>()
+            .join(","),
+        @"zebra,apple"
+    );
+}


### PR DESCRIPTION
Fixes #920.

`__context::make()` in `minijinja/src/macros.rs` built the context in a `std::collections::BTreeMap` unconditionally, so `context!` came out with sorted keys even with `preserve_order` enabled, disagreeing with `Value::from_serialize` in the same build.

Changes:

- `__context` now uses a feature-gated `ContextMap` alias: `BTreeMap<&'static str, Value>` by default, `indexmap::IndexMap<&'static str, Value>` under `preserve_order`.
- Added `impl_str_map!(IndexMap, ...)` alongside the existing `impl_value_map!(IndexMap, ...)` in `value/object.rs`, so `IndexMap` with string keys gets the same `Object`/`From<...>` impls `BTreeMap` and `HashMap` already have. No behavior change without the feature.
- Regression test in `tests/test_macros.rs` behind `#[cfg(feature = "preserve_order")]`, plus a CHANGELOG entry.

Scope note: `context!{ a => 1, ..other }` goes through `MergeDict`, whose `enumerate` collects keys into a `BTreeSet` and therefore still sorts under `preserve_order`. That is a separate code path with its own ordering question (which source's order wins), so I left it alone rather than bundle a design decision into this fix. Happy to follow up if you want it changed.

Verification (all from this branch):

```
$ cargo fmt --all --check                # clean
$ cargo test -p minijinja                # all suites pass
$ cargo test -p minijinja --all-features # all suites pass, incl. new test
$ cargo clippy -p minijinja --all-targets --all-features -- -D warnings
```

Clippy reports one `needless_borrow` at `minijinja/tests/test_macros.rs:113` (`m.call(&state, args!(42))`). I confirmed against a `git stash` baseline that it is pre-existing on `main` and untouched by this change, so I left it as-is.

## AI disclosure

Per CONTRIBUTING.md: this contribution was made with AI assistance. The diagnosis, the code change, the test, and this PR description were all produced by an AI agent (Claude) and reviewed by me before submitting. The verification commands above were actually executed, not assumed.
