### PR TITLE
fix: bound the size of string repetition (#924)

### DIFF
--- a/minijinja/src/filters.rs
+++ b/minijinja/src/filters.rs
@@ -1149,7 +1149,7 @@ mod builtins {
         ok!(args.assert_all_used());
         if let Some(indent) = indent {
             let mut out = Vec::<u8>::new();
-            let indentation = " ".repeat(indent);
+            let indentation = ok!(crate::utils::repeat_str(" ", indent));
             let formatter = serde_json::ser::PrettyFormatter::with_indent(indentation.as_bytes());
             let mut s = serde_json::Serializer::with_formatter(&mut out, formatter);
             serde::Serialize::serialize(&value, &mut s)
@@ -1231,7 +1231,7 @@ mod builtins {
         ok!(kwargs.assert_all_used());
 
         let input = strip_trailing_newline(value.as_str());
-        let indent_with = " ".repeat(width);
+        let indent_with = ok!(crate::utils::repeat_str(" ", width));
         let mut output = String::new();
         let mut iterator = input.split('\n');
         if !indent_first_line {

--- a/minijinja/src/utils.rs
+++ b/minijinja/src/utils.rs
@@ -29,6 +29,19 @@ pub(crate) fn untrusted_size_hint(value: usize) -> usize {
     value.min(1024)
 }
 
+/// The largest string a template can ask the engine to build by repetition.
+pub(crate) const MAX_REPEATED_STRING_LEN: usize = 100000;
+
+pub(crate) fn repeat_str(s: &str, n: usize) -> Result<String, Error> {
+    match s.len().checked_mul(n) {
+        Some(len) if len <= MAX_REPEATED_STRING_LEN => Ok(s.repeat(n)),
+        _ => Err(Error::new(
+            ErrorKind::InvalidOperation,
+            "string is too large to repeat",
+        )),
+    }
+}
+
 const SMALL_INT_FORMAT_CACHE_LIMIT: usize = 256;
 
 #[inline(always)]

--- a/minijinja/src/value/ops.rs
+++ b/minijinja/src/value/ops.rs
@@ -324,12 +324,13 @@ pub fn mul(lhs: &Value, rhs: &Value) -> Result<Value, Error> {
         .map(|s| (s, rhs))
         .or_else(|| rhs.as_str().map(|s| (s, lhs)))
     {
-        return Ok(Value::from(s.repeat(ok!(n.as_usize().ok_or_else(|| {
+        let n = ok!(n.as_usize().ok_or_else(|| {
             Error::new(
                 ErrorKind::InvalidOperation,
                 "strings can only be multiplied with integers",
             )
-        })))));
+        }));
+        return crate::utils::repeat_str(s, n).map(Value::from);
     } else if let Some((seq, n)) = lhs
         .as_object()
         .map(|s| (s, rhs))


### PR DESCRIPTION
Fixes #924.

`"x" * n`, `indent(width=n)` and `tojson(indent=n)` passed a count from the
render data straight to `str::repeat`, which reserves the whole result up
front and aborts the process when the allocator refuses.

All three now go through `repeat_str`, which refuses a result larger than the
limit `range` already applies to its item count.
MSG

Credits:
- Found by [Team Atlanta](https://team-atlanta.github.io/).  
- Collected and verified by [OSTIF](https://ostif.org/) using AI with their own harness.  
- Manually verified and reported by [Shielder](https://www.shielder.com/).
