### PR TITLE
Expose wordwrap filter in minijinja-py

### DIFF
--- a/minijinja-py/Cargo.toml
+++ b/minijinja-py/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 minijinja = { version = "2.23.0", path = "../minijinja", features = ["loader", "json", "urlencode", "fuel", "preserve_order", "speedups", "custom_syntax", "loop_controls", "unicode", "internal_safe_search"] }
-minijinja-contrib = { version = "2.23.0", path = "../minijinja-contrib", features = ["pycompat", "html_entities"] }
+minijinja-contrib = { version = "2.23.0", path = "../minijinja-contrib", features = ["pycompat", "html_entities", "wordwrap"] }
 pyo3 = { version = "0.27.0", features = ["extension-module", "serde", "abi3-py38"] }
 
 [build-dependencies]

--- a/minijinja-py/tests/test_basic.py
+++ b/minijinja-py/tests/test_basic.py
@@ -533,6 +533,18 @@ def test_striptags():
     assert env.eval_expr("'<a>&auml;</a>'|striptags") == "ä"
 
 
+def test_wordwrap():
+    env = Environment()
+    # wordwrap is enabled by the `wordwrap` Cargo feature (enabled in
+    # minijinja-py/Cargo.toml).  Default width is 79.
+    assert env.render_str(
+        "{{ text|wordwrap(width=20) }}",
+        text="the quick brown fox jumps over the lazy dog",
+    ) == "the quick brown fox\njumps over the lazy\ndog"
+    # default width is 79 — short text is unchanged
+    assert env.eval_expr("'hello world'|wordwrap") == "hello world"
+
+
 def test_attribute_lookups():
     class X:
         def __getattr__(self, _):


### PR DESCRIPTION
Fixes #885

The `wordwrap` Cargo feature on `minijinja-contrib` was not enabled in
`minijinja-py`'s `Cargo.toml`, so the `wordwrap` filter was unavailable
when using the Python bindings. Enabling the feature causes
`minijinja_contrib::add_to_environment(&mut env)` (called from
`minijinja_py::environment::Environment::new`) to register the filter
automatically — no Rust binding code change is needed beyond adding the
feature flag.

The change:

```diff
-minijinja-contrib = { version = "2.23.0", path = "../minijinja-contrib", features = ["pycompat", "html_entities"] }
+minijinja-contrib = { version = "2.23.0", path = "../minijinja-contrib", features = ["pycompat", "html_entities", "wordwrap"] }
```

Added a regression test (`test_wordwrap`) in
`minijinja-py/tests/test_basic.py` that exercises the filter at
`width=20` and verifies the default width (79) leaves short text
unchanged.

The full test suite (`pytest tests/`) passes (46 tests).

## AI Disclosure

This contribution was prepared with the assistance of Claude (Anthropic).
Claude was used to identify the missing Cargo feature flag from the
issue, write the regression test, and draft this PR description.
All code in the change was reviewed by me before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)